### PR TITLE
add a simple directory of community work in the OpenAI Gym ecosystem

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,25 @@
+# Agents
+
+An "agent" describes the method of running an RL algorithm against an environment in the gym. The agent may contain the algorithm itself or simply provide an integration between an algorithm and the gym environments. Submit another to this list via a pull-request. 
+
+_**NOTICE**: Evaluations submitted to the scoreboard are encouraged to link a writeup (gist) about duplicating the results. These writeups will likely direct you to specific algorithms. This agent listing is not attempting to replace writeups and will likely in time be filled with general purpose agents that will serve as a great starting place for those looking for tooling integrations or general algorithm ideas and attempts._
+
+## RandomAgent
+
+A sample agent located in this repo at `gym/examples/agents/random_agent.py`. This simple agent leverages the environments ability to produce a random valid action and does so for each step.  
+
+## cem.py
+
+A generic Cross-Entropy agent located in this repo at `gym/examples/agents/cem.py`. This agent defaults to 10 iterations of 25 episodes considering the top 20% "elite".
+
+## TabularQAgent
+
+Agent implementing tabular Q-learning located in this repo at `gym/examples/agents/tabular_q_agent.py`. 
+
+## dqn
+
+This is a very basic DQN (with experience replay) implementation, which uses OpenAI's gym environment and Keras/Theano neural networks. [/sherjilozair/dqn](https://github.com/sherjilozair/dqn)
+
+## rllab
+
+a framework for developing and evaluating reinforcement learning algorithms, fully compatible with OpenAI Gym. It includes a wide range of continuous control tasks plus implementations of many algorithms. [/rllab/rllab](https://github.com/rllab/rllab)

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,7 @@
+# Environments
+
+The gym comes prepackaged with many many environments. Its this common api around many environments that makes the gym so great. Here we will list additional environments that do not come prepacked with the gym. Submit another to this list via a pull-request. 
+
+_**NOTICE**: Its possible that in time OpenAI will develop a full fledged repository of suplimental environments. Until this this bit of markdown will suffice._
+
+Coming soon…

--- a/docs/misc.md
+++ b/docs/misc.md
@@ -1,0 +1,7 @@
+# Miscellaneous
+
+Here we have a bunch of tools, libs, apis, tutorials, resources, etc. provided by the community to add value to the gym ecosystem. 
+
+## OpenAIGym.jl
+
+Convenience wrapper of the OpenAI Gym for the Julia language [/tbreloff/OpenAIGym.jl](https://github.com/tbreloff/OpenAIGym.jl)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,0 +1,7 @@
+#Table of Contents
+
+ - [Agents](agents.md) contains a listing of agents compatible with gym environments. Agents facilitate the running of an algorithm against an environment.
+
+ - [Environments](environments.md) lists more environments to run your algorithms against. These do not come prepackaged with the gym. 
+ 
+ - [Miscellaneous](misc.md) is a collection of other value-add tools and utilities. These could be anything from a small convenience lib to a collection of video tutorials or a new language binding. 


### PR DESCRIPTION
i am wondering if this could be the start of a directory of community work. Maybe generic agents, additional environment or other tools. 

By all means please criticize the wording and formatting and patterns. I will gladly oblige i just wanted to see a place were this work could be listed that is easy to find and low effort to maintain. 

people can add items to the directory via simple pull requests.  