### PR TITLE
update mujoco and bump version

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -111,48 +111,48 @@ register(
 # 2D
 
 register(
-    id='Reacher-v0',
+    id='Reacher-v1',
     entry_point='gym.envs.mujoco:ReacherEnv',
     timestep_limit=50
 )
 
 register(
-    id='InvertedPendulum-v0',
+    id='InvertedPendulum-v1',
     entry_point='gym.envs.mujoco:InvertedPendulumEnv',
 )
 
 register(
-    id='InvertedDoublePendulum-v0',
+    id='InvertedDoublePendulum-v1',
     entry_point='gym.envs.mujoco:InvertedDoublePendulumEnv',
 )
 
 register(
-    id='HalfCheetah-v0',
+    id='HalfCheetah-v1',
     entry_point='gym.envs.mujoco:HalfCheetahEnv',
 )
 
 register(
-    id='Hopper-v0',
+    id='Hopper-v1',
     entry_point='gym.envs.mujoco:HopperEnv',
 )
 
 register(
-    id='Swimmer-v0',
+    id='Swimmer-v1',
     entry_point='gym.envs.mujoco:SwimmerEnv',
 )
 
 register(
-    id='Walker2d-v0',
+    id='Walker2d-v1',
     entry_point='gym.envs.mujoco:Walker2dEnv',
 )
 
 register(
-    id='Ant-v0',
+    id='Ant-v1',
     entry_point='gym.envs.mujoco:AntEnv',
 )
 
 register(
-    id='Humanoid-v0',
+    id='Humanoid-v1',
     entry_point='gym.envs.mujoco:HumanoidEnv',
 )
 

--- a/gym/envs/mujoco/ant.py
+++ b/gym/envs/mujoco/ant.py
@@ -6,7 +6,6 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self):
         mujoco_env.MujocoEnv.__init__(self, 'ant.xml', 5)
         utils.EzPickle.__init__(self)
-        self.finalize()
 
     def _step(self, a):
         xposbefore = self.get_body_com("torso")[0]
@@ -18,7 +17,7 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             np.square(np.clip(self.model.data.cfrc_ext, -1, 1)))
         survive_reward = 1.0
         reward = forward_reward - ctrl_cost - contact_cost + survive_reward
-        state = self._state
+        state = self.state_vector()
         notdone = np.isfinite(state).all() \
             and state[2] >= 0.2 and state[2] <= 1.0
         done = not notdone
@@ -36,10 +35,10 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             np.clip(self.model.data.cfrc_ext, -1, 1).flat,
         ])
 
-    def _reset(self):
-        self.model.data.qpos = self.init_qpos + np.random.uniform(size=(self.model.nq,1),low=-.1,high=.1)
-        self.model.data.qvel = self.init_qvel + np.random.randn(self.model.nv,1)*.1
-        self.reset_viewer_if_necessary()
+    def reset_model(self):
+        qpos = self.init_qpos + np.random.uniform(size=self.model.nq,low=-.1,high=.1)
+        qvel = self.init_qvel + np.random.randn(self.model.nv) * .1
+        self.set_state(qpos, qvel)
         return self._get_obs()
 
     def viewer_setup(self):

--- a/gym/envs/mujoco/half_cheetah.py
+++ b/gym/envs/mujoco/half_cheetah.py
@@ -6,7 +6,6 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self):
         mujoco_env.MujocoEnv.__init__(self, 'half_cheetah.xml', 5)
         utils.EzPickle.__init__(self)
-        self.finalize()
 
     def _step(self, action):
         xposbefore = self.model.data.qpos[0,0]
@@ -25,10 +24,10 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             self.model.data.qvel.flat,
         ])
 
-    def _reset(self):
-        self.model.data.qpos = self.init_qpos + np.random.uniform(size=(self.model.nq,1),low=-.1,high=.1)
-        self.model.data.qvel = self.init_qvel + np.random.randn(self.model.nv,1)*.1
-        self.reset_viewer_if_necessary()        
+    def reset_model(self):
+        qpos = self.init_qpos + np.random.uniform(low=-.1, high=.1, size=self.model.nq)
+        qvel = self.init_qvel + np.random.randn(self.model.nv) * .1
+        self.set_state(qpos, qvel)
         return self._get_obs()
 
     def viewer_setup(self):

--- a/gym/envs/mujoco/hopper.py
+++ b/gym/envs/mujoco/hopper.py
@@ -2,45 +2,39 @@ import numpy as np
 from gym import utils
 from gym.envs.mujoco import mujoco_env
 
-
 class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self):
         mujoco_env.MujocoEnv.__init__(self, 'hopper.xml', 4)
         utils.EzPickle.__init__(self)
-        self.finalize()
 
     def _step(self, a):
-        posbefore = self.model.data.qpos[0, 0]
+        posbefore = self.model.data.qpos[0,0]
         self.do_simulation(a, self.frame_skip)
-        posafter, height, ang = self.model.data.qpos[0:3, 0]
+        posafter,height,ang = self.model.data.qpos[0:3,0]
         alive_bonus = 1.0
         reward = (posafter - posbefore) / self.dt
         reward += alive_bonus
         reward -= 1e-3 * np.square(a).sum()
-        s = self._state
+        s = self.state_vector()
         done = not (np.isfinite(s).all() and (np.abs(s[2:]) < 100).all() and
-                    (height > 0.7) and (abs(ang) < 0.2))
+                    (height > .7) and (abs(ang) < .2))
         ob = self._get_obs()
         return ob, reward, done, {}
 
     def _get_obs(self):
         return np.concatenate([
             self.model.data.qpos.flat[1:],
-            np.clip(self.model.data.qvel.flat, -10, 10)
+            np.clip(self.model.data.qvel.flat,-10,10)
         ])
 
-    def _reset(self):
-        self.model.data.qpos = (self.init_qpos +
-                                np.random.rand(self.model.nq, 1) * 0.01 -
-                                0.005)
-        self.model.data.qvel = (self.init_qvel +
-                                np.random.rand(self.model.nv, 1) * 0.01 -
-                                0.005)
-        self.reset_viewer_if_necessary()
+    def reset_model(self):
+        qpos = self.init_qpos + np.random.uniform(low=-.005, high=.005, size=self.model.nq)
+        qvel = self.init_qvel + np.random.uniform(low=-.005, high=.005, size=self.model.nv)
+        self.set_state(qpos, qvel)
         return self._get_obs()
 
     def viewer_setup(self):
         self.viewer.cam.trackbodyid = 2
         self.viewer.cam.distance = self.model.stat.extent * 0.75
-        self.viewer.cam.lookat[2] += 0.8
+        self.viewer.cam.lookat[2] += .8
         self.viewer.cam.elevation = -20

--- a/gym/envs/mujoco/humanoid.py
+++ b/gym/envs/mujoco/humanoid.py
@@ -8,11 +8,9 @@ def mass_center(model):
     return (np.sum(mass * xpos, 0) / np.sum(mass))[0]
 
 class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
-    def __init__(self, initial_randomness=0.01):
+    def __init__(self):
         mujoco_env.MujocoEnv.__init__(self, 'humanoid.xml', 5)
         utils.EzPickle.__init__(self)
-        self.initial_randomness = initial_randomness
-        self.finalize()
 
     def _get_obs(self):
         data = self.model.data
@@ -38,12 +36,12 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         done = bool((qpos[2] < 1.0) or (qpos[2] > 2.0))
         return self._get_obs(), reward, done, dict(reward_linvel=lin_vel_cost, reward_quadctrl=-quad_ctrl_cost, reward_alive=alive_bonus, reward_impact=-quad_impact_cost)
 
-    # TODO: requires more complicated reset.
-    def _reset(self):
-        self.model.data.qpos = self.init_qpos + (np.random.rand(self.model.nq,1)-0.5)*2*self.initial_randomness
-        self.model.data.qvel = self.init_qvel + (np.random.rand(self.model.nv,1)-0.5)*2*self.initial_randomness
-        self.model.forward()
-        self.reset_viewer_if_necessary()        
+    def reset_model(self):
+        c = 0.01
+        self.set_state(
+            self.init_qpos + np.random.uniform(low=-c, high=c, size=self.model.nq),
+            self.init_qvel + np.random.uniform(low=-c, high=c, size=self.model.nv,)
+        )
         return self._get_obs()
 
     def viewer_setup(self):

--- a/gym/envs/mujoco/inverted_double_pendulum.py
+++ b/gym/envs/mujoco/inverted_double_pendulum.py
@@ -7,7 +7,6 @@ class InvertedDoublePendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self):
         mujoco_env.MujocoEnv.__init__(self, 'inverted_double_pendulum.xml', 5)
         utils.EzPickle.__init__(self)
-        self.finalize()
 
     def _step(self, action):
         self.do_simulation(action, self.frame_skip)
@@ -30,10 +29,11 @@ class InvertedDoublePendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             np.clip(self.model.data.qfrc_constraint, -10, 10)
         ]).ravel()
 
-    def _reset(self):
-        self.model.data.qpos = self.init_qpos + np.random.uniform(size=(self.model.nq,1),low=-.1,high=.1)
-        self.model.data.qvel = self.init_qvel + np.random.randn(self.model.nv,1)*.1
-        self.reset_viewer_if_necessary()
+    def reset_model(self):
+        self.set_state(
+            self.init_qpos + np.random.uniform(low=-.1, high=.1, size=self.model.nq),
+            self.init_qvel + np.random.randn(self.model.nv) * .1
+        )
         return self._get_obs()
 
     def viewer_setup(self):

--- a/gym/envs/mujoco/inverted_pendulum.py
+++ b/gym/envs/mujoco/inverted_pendulum.py
@@ -6,7 +6,6 @@ class InvertedPendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self):
         utils.EzPickle.__init__(self)
         mujoco_env.MujocoEnv.__init__(self, 'inverted_pendulum.xml', 2)
-        self.finalize()
 
     def _step(self, a):
         reward = 1.0
@@ -16,10 +15,9 @@ class InvertedPendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         done = not notdone
         return ob, reward, done, {}
 
-    def _reset(self):
+    def reset_model(self):
         self.model.data.qpos = self.init_qpos + np.random.uniform(size=(self.model.nq,1), low=-0.01, high=0.01)
         self.model.data.qvel = self.init_qvel + np.random.uniform(size=(self.model.nv,1), low=-0.01, high=0.01)
-        self.reset_viewer_if_necessary()        
         return self._get_obs()
 
     def _get_obs(self):

--- a/gym/envs/mujoco/inverted_pendulum.py
+++ b/gym/envs/mujoco/inverted_pendulum.py
@@ -16,8 +16,9 @@ class InvertedPendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         return ob, reward, done, {}
 
     def reset_model(self):
-        self.model.data.qpos = self.init_qpos + np.random.uniform(size=(self.model.nq,1), low=-0.01, high=0.01)
-        self.model.data.qvel = self.init_qvel + np.random.uniform(size=(self.model.nv,1), low=-0.01, high=0.01)
+        qpos = self.init_qpos + np.random.uniform(size=(self.model.nq,1), low=-0.01, high=0.01)
+        qvel = self.init_qvel + np.random.uniform(size=(self.model.nv,1), low=-0.01, high=0.01)
+        self.set_state(qpos, qvel)
         return self._get_obs()
 
     def _get_obs(self):

--- a/gym/envs/mujoco/reacher.py
+++ b/gym/envs/mujoco/reacher.py
@@ -6,7 +6,6 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self):
         utils.EzPickle.__init__(self)
         mujoco_env.MujocoEnv.__init__(self, 'reacher.xml', 2)
-        self.finalize()
 
     def _step(self, a):
         vec = self.get_body_com("fingertip")-self.get_body_com("target")
@@ -21,17 +20,16 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def viewer_setup(self):
         self.viewer.cam.trackbodyid=0
 
-    def _reset(self):
-        qpos = np.random.uniform(low=-0.1, high=0.1, size=(self.model.nq,1)) + self.init_qpos
+    def reset_model(self):
+        qpos = np.random.uniform(low=-0.1, high=0.1, size=self.model.nq) + self.init_qpos
         while True:
-            self.goal = np.random.uniform(low=-.2, high=.2, size=(2,1))
+            self.goal = np.random.uniform(low=-.2, high=.2, size=2)
             if np.linalg.norm(self.goal) < 2: break
         qpos[-2:] = self.goal
         self.model.data.qpos = qpos
-        qvel = self.init_qvel + np.random.rand(self.model.nv,1)*.01-.005
+        qvel = self.init_qvel + np.random.uniform(low=-.005, high=.005, size=self.model.nv)
         qvel[-2:] = 0
-        self.model.data.qvel = qvel
-        self.reset_viewer_if_necessary()
+        self.set_state(qpos, qvel)
         return self._get_obs()
 
     def _get_obs(self):

--- a/gym/envs/mujoco/reacher.py
+++ b/gym/envs/mujoco/reacher.py
@@ -26,7 +26,6 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             self.goal = np.random.uniform(low=-.2, high=.2, size=2)
             if np.linalg.norm(self.goal) < 2: break
         qpos[-2:] = self.goal
-        self.model.data.qpos = qpos
         qvel = self.init_qvel + np.random.uniform(low=-.005, high=.005, size=self.model.nv)
         qvel[-2:] = 0
         self.set_state(qpos, qvel)

--- a/gym/envs/mujoco/swimmer.py
+++ b/gym/envs/mujoco/swimmer.py
@@ -6,15 +6,14 @@ class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self):
         mujoco_env.MujocoEnv.__init__(self, 'swimmer.xml', 4)
         utils.EzPickle.__init__(self)
-        self.ctrl_cost_coeff = 0.0001
-        self.finalize()
 
     def _step(self, a):
+        ctrl_cost_coeff = 0.0001        
         xposbefore = self.model.data.qpos[0,0]
         self.do_simulation(a, self.frame_skip)
         xposafter = self.model.data.qpos[0,0]
         reward_fwd = (xposafter - xposbefore) / self.dt
-        reward_ctrl = - self.ctrl_cost_coeff * np.square(a).sum()
+        reward_ctrl = - ctrl_cost_coeff * np.square(a).sum()
         reward = reward_fwd + reward_ctrl
         ob = self._get_obs()
         return ob, reward, False, dict(reward_fwd = reward_fwd, reward_ctrl=reward_ctrl)
@@ -23,13 +22,11 @@ class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def _get_obs(self):
         qpos = self.model.data.qpos
         qvel = self.model.data.qvel
-        return np.concatenate([
-            qpos.flat[2:],
-            qvel.flat
-        ])
+        return np.concatenate([qpos.flat[2:], qvel.flat])
 
-    def _reset(self):
-        self.model.data.qpos = self.init_qpos + np.random.uniform(size=(self.model.nq,1),low=-.1,high=.1)
-        self.model.data.qvel = self.init_qvel + np.random.uniform(size=(self.model.nv,1),low=-.1,high=.1)
-        self.reset_viewer_if_necessary()
+    def reset_model(self):
+        self.set_state(
+            self.init_qpos + np.random.uniform(low=-.1, high=.1, size=self.model.nq),
+            self.init_qvel + np.random.uniform(low=-.1, high=.1, size=self.model.nv)
+        )
         return self._get_obs()

--- a/gym/envs/mujoco/walker2d.py
+++ b/gym/envs/mujoco/walker2d.py
@@ -2,13 +2,11 @@ import numpy as np
 from gym import utils
 from gym.envs.mujoco import mujoco_env
 
-# copied from hopper
 class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def __init__(self):
         mujoco_env.MujocoEnv.__init__(self, "walker2d.xml", 4)
         utils.EzPickle.__init__(self)
-        self.finalize()
 
     def _step(self, a):
         posbefore = self.model.data.qpos[0,0]
@@ -28,10 +26,11 @@ class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         qvel = self.model.data.qvel
         return np.concatenate([qpos[1:], np.clip(qvel,-10,10)]).ravel()
 
-    def _reset(self):
-        self.model.data.qpos = self.init_qpos + np.random.rand(self.model.nq,1)*.01-.005
-        self.model.data.qvel = self.init_qvel + np.random.rand(self.model.nv,1)*.01-.005
-        self.reset_viewer_if_necessary()        
+    def reset_model(self):
+        self.set_state(
+            self.init_qpos + np.random.uniform(low=-.005, high=.005, size=self.model.nq),
+            self.init_qvel + np.random.uniform(low=-.005, high=.005, size=self.model.nv)            
+        )
         return self._get_obs()
 
     def viewer_setup(self):

--- a/misc/check_envs_for_change.py
+++ b/misc/check_envs_for_change.py
@@ -1,0 +1,37 @@
+ENVS = ["Ant-v0", "HalfCheetah-v0", "Hopper-v0", "Humanoid-v0", "InvertedDoublePendulum-v0", "Reacher-v0", "Swimmer-v0", "Walker2d-v0"]
+OLD_COMMIT = "HEAD"
+
+# ================================================================
+
+import subprocess, gym
+from gym import utils
+from os import path
+
+def cap(cmd):
+    "Call and print command"
+    print utils.colorize(cmd, "green")
+    subprocess.check_call(cmd,shell=True)
+
+# ================================================================
+
+gymroot = path.abspath(path.dirname(path.dirname(gym.__file__)))
+oldgymroot = "/tmp/old-gym"
+comparedir = "/tmp/gym-comparison"
+
+oldgymbase = path.basename(oldgymroot)
+
+print "gym root", gymroot
+thisdir = path.abspath(path.dirname(__file__))
+print "this directory", thisdir
+cap("rm -rf %(oldgymroot)s %(comparedir)s && mkdir %(comparedir)s && cd /tmp && git clone %(gymroot)s %(oldgymbase)s"%locals())
+for env in ENVS:
+    print utils.colorize("*"*50 + "\nENV: %s" % env, "red")
+    writescript = path.join(thisdir, "write_rollout_data.py")
+    outfileA = path.join(comparedir, env) + "-A.npz"
+    cap("python %(writescript)s %(env)s %(outfileA)s"%locals())
+    outfileB = path.join(comparedir, env) + "-B.npz"
+    cap("python %(writescript)s %(env)s %(outfileB)s --gymdir=%(oldgymroot)s"%locals())
+
+    comparescript = path.join(thisdir, "compare_rollout_data.py")
+    cap("python %(comparescript)s %(outfileA)s %(outfileB)s"%locals())
+

--- a/misc/compare_rollout_data.py
+++ b/misc/compare_rollout_data.py
@@ -1,0 +1,26 @@
+import argparse, numpy as np
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file1")
+    parser.add_argument("file2")
+    args = parser.parse_args()
+    file1 = np.load(args.file1)
+    file2 = np.load(args.file2)
+
+    for k in sorted(file1.keys()):
+        arr1 = file1[k]
+        arr2 = file2[k]
+        if arr1.shape == arr2.shape:
+            if np.allclose(file1[k], file2[k]):
+                print "%s: matches!"%k
+                continue
+            else:
+                print "%s: arrays are not equal. Difference = %g"%(k, np.abs(arr1 - arr2).max())
+        else:
+            print "%s: arrays have different shape! %s vs %s"%(k, arr1.shape, arr2.shape)
+        print "first 30 els:\n1. %s\n2. %s"%(arr1.flat[:30], arr2.flat[:30])
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/write_rollout_data.py
+++ b/misc/write_rollout_data.py
@@ -1,0 +1,55 @@
+"""
+This script does a few rollouts with an environment and writes the data to an npz file
+Its purpose is to help with verifying that you haven't functionally changed an environment.
+(If you have, you should bump the version number.)
+"""
+import argparse, numpy as np, collections, sys
+from os import path
+
+
+class RandomAgent(object):
+    def __init__(self, ac_space):
+        self.ac_space = ac_space
+    def act(self, _):
+        return self.ac_space.sample()
+
+def rollout(env, agent, timestep_limit):
+    """
+    Simulate the env and agent for timestep_limit steps
+    """
+    ob = env.reset()
+    data = collections.defaultdict(list)
+    for _ in xrange(timestep_limit):
+        data["observation"].append(ob)
+        action = agent.act(ob)
+        data["action"].append(action)
+        ob,rew,done,_ = env.step(action)
+        data["reward"].append(rew)
+        if done:
+            break
+    return data
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("envid")
+    parser.add_argument("outfile")
+    parser.add_argument("--gymdir")
+
+    args = parser.parse_args()
+    if args.gymdir:
+        sys.path.insert(0, args.gymdir)
+    import gym
+    from gym import utils
+    print utils.colorize("gym directory: %s"%path.dirname(gym.__file__), "yellow")
+    env = gym.make(args.envid)
+    agent = RandomAgent(env.action_space)
+    alldata = {}
+    for i in xrange(2):
+        np.random.seed(i)
+        data = rollout(env, agent, env.spec.timestep_limit)
+        for (k, v) in data.items():
+            alldata["%i-%s"%(i, k)] = v
+    np.savez(args.outfile, **alldata)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- I reorganized things a bit to reduce code duplication, and now qpos/qvel are only set through set_state, which also calls `forward` and `_update_subtree`.
- resetData seems to make a numerical difference. I'm doing the ctypes stuff in mujoco_env for now, but we can later push that code into an update to mujoco-py
- I added some tooling for checking if the environments have changed. See the misc directory. All you have to do is run check_envs_for_change.py and it will compare HEAD against current code

@hojonathanho @dementrock could you sanity check mujoco changes?
