### PR TITLE
Set restriction on selected actions for MountainCar-v0

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -78,6 +78,9 @@ class Env(object):
         done (boolean): whether the episode has ended, in which case further step() calls will return undefined results
         info (dict): contains auxiliary diagnostic information (helpful for debugging, and sometimes learning)
         """
+        if not self.action_space.contains(action):
+            raise error.InvalidAction('Invalid action selected: {}'.format(action))
+
         self.monitor._before_step(action)
         observation, reward, done, info = self._step(action)
         done = self.monitor._after_step(observation, reward, done, info)

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -31,8 +31,6 @@ class MountainCarEnv(gym.Env):
 
     def _step(self, action):
         # action = np.sign((self.state[0]+math.pi/2) * self.state[1])+1
-        if (self.action_space.contains(action) == False):
-            raise ValueError("Invalid action '%s' selected" % action)
 
         position, velocity = self.state
         velocity += (action-1)*0.001 + math.cos(3*position)*(-0.0025)

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -29,11 +29,9 @@ class MountainCarEnv(gym.Env):
         self.action_space = spaces.Discrete(3)
         self.observation_space = spaces.Box(self.low, self.high)
 
-        self.action_set = (0, 1, 2)
-
     def _step(self, action):
         # action = np.sign((self.state[0]+math.pi/2) * self.state[1])+1
-        if (action not in self.action_set):
+        if (self.action_space.contains(action) == False):
             raise ValueError("Invalid action '%s' selected" % action)
 
         position, velocity = self.state

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -29,8 +29,13 @@ class MountainCarEnv(gym.Env):
         self.action_space = spaces.Discrete(3)
         self.observation_space = spaces.Box(self.low, self.high)
 
+        self.action_set = (0, 1, 2)
+
     def _step(self, action):
         # action = np.sign((self.state[0]+math.pi/2) * self.state[1])+1
+        if (action not in self.action_set):
+            raise ValueError("Invalid action '%s' selected" % action)
+
         position, velocity = self.state
         velocity += (action-1)*0.001 + math.cos(3*position)*(-0.0025)
         if (velocity > self.max_speed): velocity = self.max_speed

--- a/gym/error.py
+++ b/gym/error.py
@@ -32,6 +32,12 @@ class ResetNotAllowed(Exception):
     """
     pass
 
+class InvalidAction(Exception):
+    """Raised when the user performs an action not contained within the
+    action space
+    """
+    pass
+
 # API errors
 
 class APIError(Error):


### PR DESCRIPTION
Restricts accepted actions for MountainCar-v0 to be from the set (0, 1, 2) throwing a ValueError if the submitted action is outside of that range