### PR TITLE
Bug regarding variable in video recoder 

### DIFF
--- a/gym/monitoring/video_recorder.py
+++ b/gym/monitoring/video_recorder.py
@@ -282,7 +282,7 @@ class ImageEncoder(object):
         if not isinstance(frame, (np.ndarray, np.generic)):
             raise error.InvalidFrame('Wrong type {} for {} (must be np.ndarray or np.generic)'.format(type(frame), frame))
         if frame.shape != self.frame_shape:
-            raise error.InvalidFrame("Your frame has shape {}, but the VideoRecorder is configured for shape {}.".format(frame_shape, self.frame_shape))
+            raise error.InvalidFrame("Your frame has shape {}, but the VideoRecorder is configured for shape {}.".format(frame.shape, self.frame_shape))
         if frame.dtype != np.uint8:
             raise error.InvalidFrame("Your frame has data type {}, but we require uint8 (i.e. RGB values from 0-255).".format(frame.dtype))
 


### PR DESCRIPTION
Hi,

on Gitter there came up an issue regarding the video recorder:
```
Traceback (most recent call last): File "Gym.py", line 95, in <module> ob, reward, done, _ = env.step(action) File "C:\Users\BlackBox\Anaconda3\envs\py27\lib\site-packages\gym-0.0.3-py2.7.egg\gym\core.py", line 74, in step done = self.monitor._after_step(observation, reward, done, info) File "C:\Users\BlackBox\Anaconda3\envs\py27\lib\site-packages\gym-0.0.3-py2.7.egg\gym\monitoring\monitor.py", line 211, in _after_step self.video_recorder.capture_frame() File "C:\Users\BlackBox\Anaconda3\envs\py27\lib\site-packages\gym-0.0.3-py2.7.egg\gym\monitoring\video_recorder.py", line 111, in capture_frame self._encode_image_frame(frame) File "C:\Users\BlackBox\Anaconda3\envs\py27\lib\site-packages\gym-0.0.3-py2.7.egg\gym\monitoring\video_recorder.py", line 161, in _encode_image_frame self.encoder.capture_frame(frame) File "C:\Users\BlackBox\Anaconda3\envs\py27\lib\site-packages\gym-0.0.3-py2.7.egg\gym\monitoring\video_recorder.py", line 280, in capture_frame raise error.InvalidFrame("Your frame has shape {}, but the VideoRecorder is configured for shape {}.".format(frame_shape, self.frame_shape)) NameError: global name 'frame_shape' is not defined [2016-05-03 11:11:00,476] Finished writing results. You can upload them to the scoreboard via gym.upload('C:\\tmp\\random-agent-results')
```

which I think is because of some small bug in the video recorder code. I already hanged frame_shape to frame.shape in this PR.
