### PR TITLE
n-Chain environment added

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -99,7 +99,7 @@ register(
 register(
     id='NChain-v0',
     entry_point='gym.envs.toy_text:NChainEnv',
-    timestep_limit=200,
+    timestep_limit=1000,
 )
 
 register(

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -97,6 +97,12 @@ register(
 )
 
 register(
+    id='NChain-v0',
+    entry_point='gym.envs.toy_text:NChainEnv',
+    timestep_limit=200,
+)
+
+register(
     id='Roulette-v0',
     entry_point='gym.envs.toy_text:RouletteEnv',
     timestep_limit=100,

--- a/gym/envs/toy_text/__init__.py
+++ b/gym/envs/toy_text/__init__.py
@@ -1,2 +1,3 @@
 from gym.envs.toy_text.roulette import RouletteEnv
 from gym.envs.toy_text.frozen_lake import FrozenLakeEnv
+from gym.envs.toy_text.nchain import NChainEnv

--- a/gym/envs/toy_text/nchain.py
+++ b/gym/envs/toy_text/nchain.py
@@ -1,0 +1,51 @@
+import gym
+import random
+from gym import spaces
+
+
+class NChainEnv(gym.Env):
+    """n-Chain environment
+
+    This game presents moves along a linear chain of states, with two actions:
+     0) forward, which moves along the chain but returns no reward
+     1) backward, which returns to the beginning and has a small reward
+
+    The end of the chain, however, presents a large reward, and by moving
+    'forward' at the end of the chain this large reward can be repeated.
+
+    At each action, there is a small probability that the agent 'slips' and the
+    opposite transition is instead taken.
+
+    The observed state is the current state in the chain (0 to n-1).
+
+    This environment is described in section 6.1 of:
+    A Bayesian Framework for Reinforcement Learning by Malcolm Strens (2000)
+    http://ceit.aut.ac.ir/~shiry/lecture/machine-learning/papers/BRL-2000.pdf
+    """
+    def __init__(self, n=5, slip=0.2, small=2, large=10):
+        self.n = n
+        self.slip = slip  # probability of 'slipping' an action
+        self.small = small  # payout for 'backwards' action
+        self.large = large  # payout at end of chain for 'forwards' action
+        self.action_space = spaces.Discrete(2)
+        self.observation_space = spaces.Discrete(n)
+        self.state = 0  # Start at beginning of the chain
+
+    def _step(self, action):
+        assert(self.action_space.contains(action))
+        if random.random() < self.slip:
+            action = not action  # agent slipped, reverse action taken
+        if action:  # 'backwards': go back to the beginning, get small reward
+            reward = self.small
+            self.state = 0
+        elif self.state < self.n - 1:  # 'forwards': go up along the chain
+            reward = 0
+            self.state += 1
+        else:  # 'forwards': stay at the end of the chain, collect large reward
+            reward = self.large
+        done = False
+        return self.state, reward, done, {}
+
+    def _reset(self):
+        self.state = 0
+        return self.state


### PR DESCRIPTION
Another new environment, this one challenging agents' ability to explore and accurately model action value.  It's a linear chain of states where there is a small reward to go back to the beginning and no reward to advance, but at the end of the chain there is a large reward.  Confounding estimation is a chance of 'slipping' each action and doing the opposite of what was instructed.

This was introduced in [A Bayesian Framework for Reinforcement Learning](http://ceit.aut.ac.ir/~shiry/lecture/machine-learning/papers/BRL-2000.pdf) by Malcolm Strens (2000).

This was also used as a test of the GEQL algorithm in [Exploratory Gradient Boosting for Reinforcement Learning in Complex Domains](http://research.microsoft.com/en-us/um/people/alekha/arxiv_geql.pdf).