### PR TITLE
tuple spaces will consider lists for contains check

### DIFF
--- a/gym/spaces/tuple_space.py
+++ b/gym/spaces/tuple_space.py
@@ -11,6 +11,8 @@ class Tuple(Space):
         return tuple([space.sample() for space in self.spaces])
 
     def contains(self, x):
+        if isinstance(x, list):
+            x = tuple(x)  # Promote list to tuple for contains check
         return isinstance(x, tuple) and len(x) == len(self.spaces) and all(
             space.contains(part) for (space,part) in zip(self.spaces,x))
 


### PR DESCRIPTION
When evaluating `contains` for tuple spaces, accept lists and check them as tuples.

Before fix:
```
In [32]: d = spaces.Tuple((spaces.Discrete(2), spaces.Discrete(2)))

In [33]: d.contains([0,0])
Out[33]: False

In [34]: d.contains((0,0))
Out[34]: True
```