### PR TITLE
Fix Python3 compatibility in Go env

### DIFF
--- a/examples/scripts/play_go
+++ b/examples/scripts/play_go
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from six.moves import input as raw_input
 import argparse
 import pachi_py
 import gym
@@ -28,8 +29,8 @@ def main():
             break
 
     print
-    print 'You win!' if r > 0 else 'Opponent wins!'
-    print 'Final score:', env._state.board.official_score
+    print('You win!' if r > 0 else 'Opponent wins!')
+    print('Final score:', env._state.board.official_score)
 
 if __name__ == '__main__':
     main()

--- a/gym/envs/board_game/go.py
+++ b/gym/envs/board_game/go.py
@@ -38,7 +38,7 @@ def _action_to_coord(board, a):
     return board.ij_to_coord(a // board.size, a % board.size)
 
 def str_to_action(board, s):
-    return _coord_to_action(board, board.str_to_coord(s))
+    return _coord_to_action(board, board.str_to_coord(s.encode()))
 
 class GoState(object):
     '''
@@ -67,7 +67,7 @@ class GoState(object):
             pachi_py.stone_other(self.color))
 
     def __repr__(self):
-        return 'To play: {}\n{}'.format(six.u(pachi_py.color_to_str(self.color)), six.u(self.board.__repr__()))
+        return 'To play: {}\n{}'.format(six.u(pachi_py.color_to_str(self.color)), self.board.__repr__().decode())
 
 
 ### Adversary policies ###


### PR DESCRIPTION
Under Python3, user inputs are in string format and needs be converted
into bytes before passing to pachi-py. The returned __repr__ from
pachi-py for the boards are bytes and needs be converted into string for
line breaks to work.

Also fixed raw_input and print functions in play_go under
examples/scripts with six package.