### PR TITLE
Remove unused destination in Taxi-v0

### DIFF
--- a/gym/envs/toy_text/taxi.py
+++ b/gym/envs/toy_text/taxi.py
@@ -11,7 +11,7 @@ MAP = [
     "| : : : : |",
     "| : : : : |",
     "| | :F| : |",
-    "|Y| : |B: |",
+    "|Y| : | : |",
     "+---------+",
 ]
 
@@ -34,7 +34,7 @@ class TaxiEnv(discrete.DiscreteEnv):
     def __init__(self):
         self.desc = np.asarray(MAP,dtype='c')
 
-        self.locs = locs = [(0,0), (0,4), (4,0), (3,2), (4,3)]
+        self.locs = locs = [(0,0), (0,4), (4,0), (3,2), "Inside the taxi"]
 
         nS = 500
         nR = 5


### PR DESCRIPTION
Hi friends!
The "B" location doesn't function as an actual destination, although it looks like one in the rendering. This doesn't affect non-human agents, but it confused my friend when I had him play the game by hand.

![taxi](https://cloud.githubusercontent.com/assets/306655/15088388/b67cb45c-13a7-11e6-87c5-e70b68d97cde.gif)
