### PR TITLE
Replaced `is` string comparison with `==` in several environments

### DIFF
--- a/gym/envs/atari/atari_env.py
+++ b/gym/envs/atari/atari_env.py
@@ -88,7 +88,7 @@ class AtariEnv(gym.Env, utils.EzPickle):
         img = self._get_image()
         if mode == 'rgb_array':
             return img
-        elif mode is 'human':
+        elif mode == 'human':
             from gym.envs.classic_control import rendering
             if self.viewer is None:
                 self.viewer = rendering.SimpleImageViewer()

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -193,7 +193,7 @@ class AcrobotEnv(core.Env):
         self.viewer.render()
         if mode == 'rgb_array':
             return self.viewer.get_array()
-        elif mode is 'human':
+        elif mode == 'human':
             pass
 
 def wrap(x, m, M):

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -130,7 +130,7 @@ class CartPoleEnv(gym.Env):
         self.viewer.render()
         if mode == 'rgb_array':
             return self.viewer.get_array()
-        elif mode is 'human':
+        elif mode == 'human':
             pass
         else:
             return super(CartPoleEnv, self).render(mode=mode)

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -114,7 +114,7 @@ class MountainCarEnv(gym.Env):
         self.viewer.render()
         if mode == 'rgb_array':
             return self.viewer.get_array()
-        elif mode is 'human':
+        elif mode == 'human':
             pass
         else:
             return super(MountainCarEnv, self).render(mode=mode)

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -80,7 +80,7 @@ class PendulumEnv(gym.Env):
         self.viewer.render()
         if mode == 'rgb_array':
             return self.viewer.get_array()
-        elif mode is 'human':
+        elif mode == 'human':
             pass
         else:
             return super(PendulumEnv, self).render(mode=mode)

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -114,7 +114,7 @@ class MujocoEnv(gym.Env):
             self._get_viewer().render()
             data, width, height = self._get_viewer().get_image()
             return np.fromstring(data, dtype='uint8').reshape(height, width, 3)[::-1,:,:]
-        elif mode is 'human':
+        elif mode == 'human':
             self._get_viewer().loop_once()
 
     def _get_viewer(self):


### PR DESCRIPTION
## Error Description

I encountered an issue with several environments the `CartPole-v0` environment where calling `env.render(mode='human')` would freeze for a moment and result in a Python exception:

```
<type 'exceptions.RuntimeError'>: maximum recursion depth exceeded while calling a Python object
```

The underlying issue is a comparison within the `CartPole-v0._render` method where `mode` is compared to `human` using the `is` operator.  Replacing `is` with `==` fixes the issue.  This bug only appeared for me because I was pulling the string describing the render mode from a command line argument, which produces a different string, breaking the `is` comparison.

The same issue was found in `MountainCar-v0` and `Pendulum-v0`.  With an eye toward consistency, the corresponding `_render` methods were also updated from `is` to `==` in the`atari_env`, `acrobot` and `mujoco_env`.

## Reproducing the Bug

The following code snippets operates properly before this PR:

```
env_name = 'MountainCar-v0'

def run_gym_good():
    env = gym.make(env_name)
    env.reset()
    env.render(mode='human')
    __obs, __reward, done, __info = env.step(env.action_space.sample())

```

The following code snippet results in the described error (after around 10 seconds on my machine):

```
env_name = 'MountainCar-v0'

def run_gym_bad():
    env = gym.make(env_name)
    env.reset()
    env.render(mode=''.join(['h', 'u', 'm', 'a', 'n']))
    __obs, __reward, done, __info = env.step(env.action_space.sample())
```

## Testing

I ran the tests locally and all passed (except for those using Mujoco - I've been unable to install that engine as of yet).  Also, I verified for the problematic environments that this fixes the reported issue.