### PR TITLE
Removed legacy super() rendering calls

### DIFF
--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -132,5 +132,3 @@ class CartPoleEnv(gym.Env):
             return self.viewer.get_array()
         elif mode == 'human':
             pass
-        else:
-            return super(CartPoleEnv, self).render(mode=mode)

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -116,5 +116,3 @@ class MountainCarEnv(gym.Env):
             return self.viewer.get_array()
         elif mode == 'human':
             pass
-        else:
-            return super(MountainCarEnv, self).render(mode=mode)

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -82,8 +82,6 @@ class PendulumEnv(gym.Env):
             return self.viewer.get_array()
         elif mode == 'human':
             pass
-        else:
-            return super(PendulumEnv, self).render(mode=mode)
 
 def angle_normalize(x):
     return (((x+np.pi) % (2*np.pi)) - np.pi)


### PR DESCRIPTION
## Purpose

Several environments had `_render` calls that would (in some cases) call the `render` method on the super class.  This was left-over from a previous design and is no longer needed.