### PR TITLE
Faster video recording

### DIFF
--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -468,13 +468,7 @@ class BipedalWalker(gym.Env):
         self.viewer.draw_polygon(f, color=(0.9,0.2,0) )
         self.viewer.draw_polyline(f + [f[0]], color=(0,0,0), linewidth=2 )
 
-        self.viewer.render()
-        if mode == 'rgb_array':
-            return self.viewer.get_array()
-        elif mode is 'human':
-            pass
-        else:
-            return super(BipedalWalker, self).render(mode=mode)
+        return self.viewer.render(return_rgb_array = mode=='rgb_array')
 
 class BipedalWalkerHardcore(BipedalWalker):
     hardcore = True

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -312,13 +312,7 @@ class LunarLander(gym.Env):
             self.viewer.draw_polyline( [(x, flagy1), (x, flagy2)], color=(1,1,1) )
             self.viewer.draw_polygon( [(x, flagy2), (x, flagy2-10/SCALE), (x+25/SCALE, flagy2-5/SCALE)], color=(0.8,0.8,0) )
 
-        self.viewer.render()
-        if mode == 'rgb_array':
-            return self.viewer.get_array()
-        elif mode is 'human':
-            pass
-        else:
-            return super(LunarLander, self).render(mode=mode)
+        return self.viewer.render(return_rgb_array = mode=='rgb_array')
 
 if __name__=="__main__":
     # Heuristic for testing.

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -191,11 +191,7 @@ class AcrobotEnv(core.Env):
             circ.set_color(.8, .8, 0)
             circ.add_attr(jtransform)
 
-        self.viewer.render()
-        if mode == 'rgb_array':
-            return self.viewer.get_array()
-        elif mode == 'human':
-            pass
+        return self.viewer.render(return_rgb_array = mode=='rgb_array')
 
 def wrap(x, m, M):
     """

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -129,8 +129,4 @@ class CartPoleEnv(gym.Env):
         self.carttrans.set_translation(cartx, carty)
         self.poletrans.set_rotation(-x[2])
 
-        self.viewer.render()
-        if mode == 'rgb_array':
-            return self.viewer.get_array()
-        elif mode == 'human':
-            pass
+        return self.viewer.render(return_rgb_array = mode=='rgb_array')

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -112,8 +112,4 @@ class MountainCarEnv(gym.Env):
         self.cartrans.set_translation((pos-self.min_position)*scale, self._height(pos)*scale)
         self.cartrans.set_rotation(math.cos(3 * pos))
 
-        self.viewer.render()
-        if mode == 'rgb_array':
-            return self.viewer.get_array()
-        elif mode == 'human':
-            pass
+        return self.viewer.render(return_rgb_array = mode=='rgb_array')

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -77,12 +77,7 @@ class PendulumEnv(gym.Env):
         if self.last_u:
             self.imgtrans.scale = (-self.last_u/2, np.abs(self.last_u)/2)
 
-
-        self.viewer.render()
-        if mode == 'rgb_array':
-            return self.viewer.get_array()
-        elif mode == 'human':
-            pass
+        return self.viewer.render(return_rgb_array = mode=='rgb_array')
 
 def angle_normalize(x):
     return (((x+np.pi) % (2*np.pi)) - np.pi)

--- a/gym/envs/classic_control/rendering.py
+++ b/gym/envs/classic_control/rendering.py
@@ -60,7 +60,7 @@ class Viewer(object):
     def add_onetime(self, geom):
         self.onetime_geoms.append(geom)
 
-    def render(self):
+    def render(self, return_rgb_array):
         glClearColor(1,1,1,1)
         self.window.clear()
         self.window.switch_to()
@@ -71,8 +71,15 @@ class Viewer(object):
         for geom in self.onetime_geoms:
             geom.render()
         self.transform.disable()
+        arr = None
+        if return_rgb_array:
+            image_data = pyglet.image.get_buffer_manager().get_color_buffer().get_image_data()
+            arr = np.fromstring(image_data.data, dtype=np.uint8, sep='')
+            arr = arr.reshape(self.height, self.width, 4)
+            arr = arr[::-1,:,0:3]
         self.window.flip()
         self.onetime_geoms = []
+        return arr
 
     # Convenience
     def draw_circle(self, radius=10, res=30, filled=True, **attrs):

--- a/gym/envs/classic_control/rendering.py
+++ b/gym/envs/classic_control/rendering.py
@@ -60,7 +60,7 @@ class Viewer(object):
     def add_onetime(self, geom):
         self.onetime_geoms.append(geom)
 
-    def render(self, return_rgb_array):
+    def render(self, return_rgb_array=False):
         glClearColor(1,1,1,1)
         self.window.clear()
         self.window.switch_to()


### PR DESCRIPTION
Running environments with video recording turned on is painfully slow. Let's investigate. In `random_agent.py`:

```python
        for j in range(max_steps):
            action = agent.act(ob, reward, done)
            import time
            t1 = time.time()
            ob, reward, done, _ = env.step(action)
            t2 = time.time()
            print "step %0.2fms" % ((t2-t1)*1000)
```

Now let's try `python examples/agents/random_agent.py CartPole-v0`

```
step 101.11ms
step 99.19ms
step 98.89ms
step 100.18ms
step 99.97ms
step 99.45ms
step 100.70ms
step 99.77ms
step 100.09ms
```

Why 100ms? My computer, MacBook Pro 13" is connected to 4K monitor. Refresh rate is 30 Hz. Pyglet window is created with vsync=True. Every `viewer.window.flip()` waits for vsync. Then `viewer.get_array()` contains another two `flip()`. 1000ms/30*3 = 100ms. Not only this waits for another two vsync events, but is also jitters image a frame back and it's visible.

It doesn't affect resulting encoded video, but the process doesn't look pretty. 

This PR returns array without extra `flip()`s.

```
step 26.68ms
step 39.91ms
step 26.64ms
step 38.33ms
```

Effect is identical for `CartPole`, `Acrobot`, `MountainCar`, `Pendulum`, `LunarLander`, `BipedalWalker`.

Atari and MuJoCo needs to be checked.
