### PR TITLE
LunarLander, BipedalWalker now count energy spent

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -81,21 +81,21 @@ register(
 # ----------------------------------------
 
 register(
-    id='LunarLander-v1',
+    id='LunarLander-v2',
     entry_point='gym.envs.box2d:LunarLander',
     timestep_limit=1000,
     reward_threshold=200,
 )
 
 register(
-    id='BipedalWalker-v1',
+    id='BipedalWalker-v2',
     entry_point='gym.envs.box2d:BipedalWalker',
     timestep_limit=1600,
     reward_threshold=300,
 )
 
 register(
-    id='BipedalWalkerHardcore-v1',
+    id='BipedalWalkerHardcore-v2',
     entry_point='gym.envs.box2d:BipedalWalkerHardcore',
     timestep_limit=2000,
     reward_threshold=300,

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -15,7 +15,9 @@ from gym import spaces
 # Landing pad is always at coordinates (0,0). Coordinates are the first two numbers in state vector.
 # Reward for moving from the top of the screen to landing pad and zero speed is about 100..140 points.
 # If lander moves away from landing pad it loses reward back. Episode finishes if the lander crashes or
-# comes to rest, receiving additional -100 or +100 points. Each leg ground contact is +10. Solved is 200 points.
+# comes to rest, receiving additional -100 or +100 points. Each leg ground contact is +10. Firing main
+# engine is -0.3 points each frame. Solved is 200 points.
+#
 # Landing outside landing pad is possible. Fuel is infinite, so an agent can learn to fly and then land
 # on its first attempt. Please see source code for details.
 #
@@ -263,6 +265,11 @@ class LunarLander(gym.Env):
         if self.prev_shaping is not None:
             reward = shaping - self.prev_shaping
         self.prev_shaping = shaping
+
+        if action==2:       # main engine
+            reward -= 0.30  # less fuel spent is better, about -30 for heurisic landing
+        elif action != 0:
+            reward -= 0.03
 
         done = False
         if self.game_over or abs(state[0]) >= 1.0:

--- a/gym/scoreboard/__init__.py
+++ b/gym/scoreboard/__init__.py
@@ -227,25 +227,52 @@ add_task(
     summary='Hex played on a 9x9 board.',
 )
 
+
 # box2d
 
 add_task(
-    id='LunarLander-v1',
+    id='LunarLander-v2',
     group='box2d',
     experimental=True,
+    description="""
+Landing pad is always at coordinates (0,0). Coordinates are the first two numbers in state vector.
+Reward for moving from the top of the screen to landing pad and zero speed is about 100..140 points.
+If lander moves away from landing pad it loses reward back. Episode finishes if the lander crashes or
+comes to rest, receiving additional -100 or +100 points. Each leg ground contact is +10. Firing main
+engine is -0.3 points each frame. Solved is 200 points.
+Landing outside landing pad is possible. Fuel is infinite, so an agent can learn to fly and then land
+on its first attempt.
+""")
+
+add_task(
+    id='BipedalWalker-v2',
+    group='box2d',
+    experimental=True,
+    description="""
+Reward is given for moving forward, total 300+ points up to the far end. If the robot falls,
+it gets -100. Applying motor torque costs a small amount of points, more optimal agent
+will get better score.
+State consists of hull angle speed, angular velocity, horizontal speed,
+vertical speed, position of joints and joints angular speed, legs contact with ground,
+and 10 lidar rangefinder measurements. There's no coordinates in the state vector.
+"""
 )
 
 add_task(
-    id='BipedalWalker-v1',
+    id='BipedalWalkerHardcore-v2',
     group='box2d',
     experimental=True,
+    description="""
+Hardcore version with ladders, stumps, pitfalls. Time limit is increased due to obstacles.
+Reward is given for moving forward, total 300+ points up to the far end. If the robot falls,
+it gets -100. Applying motor torque costs a small amount of points, more optimal agent
+will get better score.
+State consists of hull angle speed, angular velocity, horizontal speed,
+vertical speed, position of joints and joints angular speed, legs contact with ground,
+and 10 lidar rangefinder measurements. There's no coordinates in the state vector.
+"""
 )
 
-add_task(
-    id='BipedalWalkerHardcore-v1',
-    group='box2d',
-    experimental=True,
-)
 
 # mujoco
 


### PR DESCRIPTION
I've found first solutions!

* [BipedalWalker](https://gym.openai.com/evaluations/eval_zMeSs4TwTZOcQ8Vsxjzhw) jumping on one leg,

* [LunarLander](https://gym.openai.com/evaluations/eval_mmWmrxTbNN8WhhoUHfQ) 

The thing is, how do you compare more and less optimal solutions? For the Walker, it should count energy spent by applying motor torque. For Lander, it should count fuel spent.

This PR does this, renormalizes total reward, bumps version. Using heuristic, mean reward for successful episode tested to be:

* 315 for Walker (solved threshold is 300)

* 230 for Lander (solved threshold is 200)

I've also added description for scoreboard.
