### PR TITLE
Fixes tar file generation for upload on Windows

### DIFF
--- a/gym/scoreboard/api.py
+++ b/gym/scoreboard/api.py
@@ -177,8 +177,13 @@ def write_archive(videos, archive_file, env_id=None):
             tar.add(metadata_path, arcname=metadata_name, recursive=False)
 
         # Actually write the manifest file
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
+        # 'delete = False' avoids deleting the file when closing
+        with tempfile.NamedTemporaryFile(mode='w+', delete = False) as f:
             json.dump(manifest, f)
             f.flush()
-
+            # Closing the file is necessary before adding to tar in Windows
+            f.close()
+            
             tar.add(f.name, arcname='manifest.json')
+            # Manually delete temporary file
+            os.remove(f.name)

--- a/gym/scoreboard/api.py
+++ b/gym/scoreboard/api.py
@@ -178,7 +178,7 @@ def write_archive(videos, archive_file, env_id=None):
 
         # Actually write the manifest file
         # 'delete = False' avoids deleting the file when closing
-        with tempfile.NamedTemporaryFile(mode='w+', delete = False) as f:
+        with tempfile.NamedTemporaryFile(mode='w+', delete=False) as f:
             json.dump(manifest, f)
             f.flush()
             # Closing the file is necessary before adding to tar in Windows

--- a/gym/scoreboard/api.py
+++ b/gym/scoreboard/api.py
@@ -176,14 +176,11 @@ def write_archive(videos, archive_file, env_id=None):
             tar.add(video_path, arcname=video_name, recursive=False)
             tar.add(metadata_path, arcname=metadata_name, recursive=False)
 
-        # Actually write the manifest file
-        # 'delete = False' avoids deleting the file when closing
-        with tempfile.NamedTemporaryFile(mode='w+', delete=False) as f:
-            json.dump(manifest, f)
-            f.flush()
-            # Closing the file is necessary before adding to tar in Windows
-            f.close()
-            
-            tar.add(f.name, arcname='manifest.json')
-            # Manually delete temporary file
-            os.remove(f.name)
+        f = tempfile.NamedTemporaryFile(mode='w+', delete=False)
+        try:
+          json.dump(manifest, f)
+          f.close()
+          tar.add(f.name, arcname='manifest.json')
+        finally:
+          f.close()
+          os.remove(f.name) 

--- a/gym/scoreboard/api.py
+++ b/gym/scoreboard/api.py
@@ -178,9 +178,9 @@ def write_archive(videos, archive_file, env_id=None):
 
         f = tempfile.NamedTemporaryFile(mode='w+', delete=False)
         try:
-          json.dump(manifest, f)
-          f.close()
-          tar.add(f.name, arcname='manifest.json')
+            json.dump(manifest, f)
+            f.close()
+            tar.add(f.name, arcname='manifest.json')
         finally:
-          f.close()
-          os.remove(f.name) 
+            f.close()
+            os.remove(f.name) 


### PR DESCRIPTION
Temp file cannot be added to the tar while opened on Windows (tested on 8.1). Needs testing on Linux. Fix for issue https://github.com/openai/gym/issues/128.