### PR TITLE
Support disabling videos by passing video_callable=False

### DIFF
--- a/gym/monitoring/monitor.py
+++ b/gym/monitoring/monitor.py
@@ -165,9 +165,9 @@ class Monitor(object):
         if not self.enabled:
             return
         self.stats_recorder.close()
-        self.flush()
         if self.video_recorder is not None:
             self._close_video_recorder()
+        self.flush()
 
         # Note we'll close the env's rendering window even if we did
         # not open it. There isn't a particular great way to know if

--- a/gym/monitoring/monitor.py
+++ b/gym/monitoring/monitor.py
@@ -38,6 +38,9 @@ def capped_cubic_video_schedule(episode_id):
     else:
         return episode_id % 1000 == 0
 
+def disable_videos(episode_id):
+    return False
+
 monitor_closer = closer.Closer()
 
 # This method gets used for a sanity check in scoreboard/api.py. It's
@@ -90,7 +93,7 @@ class Monitor(object):
 
         Args:
             directory (str): A per-training run directory where to record stats.
-            video_callable (Optional[function]): function that takes in the index of the episode and outputs a boolean, indicating whether we should record a video on this episode. The default (for video_callable is None) is to take perfect cubes.
+            video_callable (Optional[function, False]): function that takes in the index of the episode and outputs a boolean, indicating whether we should record a video on this episode. The default (for video_callable is None) is to take perfect cubes, capped at 1000. False disables video recording.
             force (bool): Clear out existing training data from this directory (by deleting every file prefixed with "openaigym.").
             resume (bool): Retain the training data already in this directory, which will be merged with our new data
             seed (Optional[int]): The seed to run this environment with. By default, a random seed will be chosen.
@@ -104,6 +107,8 @@ class Monitor(object):
 
         if video_callable is None:
             video_callable = capped_cubic_video_schedule
+        elif video_callable == False:
+            video_callable = disable_videos
         elif not callable(video_callable):
             raise error.Error('You must provide a function, None, or False for video_callable, not {}: {}'.format(type(video_callable), video_callable))
 

--- a/gym/monitoring/tests/test_monitor.py
+++ b/gym/monitoring/tests/test_monitor.py
@@ -3,6 +3,7 @@ import os
 
 import gym
 from gym import error
+from gym import monitoring
 from gym.monitoring import monitor
 from gym.monitoring.tests import helpers
 
@@ -28,15 +29,33 @@ def test_close_monitor():
         manifests = monitor.detect_training_manifests(temp)
         assert len(manifests) == 1
 
-def test_video_callable():
+def test_video_callable_true_not_allowed():
     with helpers.tempdir() as temp:
         env = gym.make('Acrobot-v0')
         try:
-            env.monitor.start(temp, video_callable=False)
+            env.monitor.start(temp, video_callable=True)
         except error.Error:
             pass
         else:
             assert False
+
+def test_video_callable_false_does_not_record():
+    with helpers.tempdir() as temp:
+        env = gym.make('Acrobot-v0')
+        env.monitor.start(temp, video_callable=False)
+        env.reset()
+        env.monitor.close()
+        results = monitoring.load_results(temp)
+        assert len(results['videos']) == 0
+
+def test_video_callable_records_videos():
+    with helpers.tempdir() as temp:
+        env = gym.make('Acrobot-v0')
+        env.monitor.start(temp)
+        env.reset()
+        env.monitor.close()
+        results = monitoring.load_results(temp)
+        assert len(results['videos']) == 1, "Videos: {}".format(results['videos'])
 
 def test_env_reuse():
     with helpers.tempdir() as temp:


### PR DESCRIPTION
I find myself disabling videos enough (it really speeds things up when you're hacking around) that it seems worth having a helper. I could be convinced we still don't need it though. @joschu what do you think?