### PR TITLE
Add swig to the list of dependencies to be installed with homebrew

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ On OSX:
 
 .. code:: shell
 
-	  brew install cmake boost boost-python sdl2
+	  brew install cmake boost boost-python sdl2 swig
 
 On Ubuntu 14.04:
 


### PR DESCRIPTION
Without this installing `gym[box2d]` on OSX fails with:
```
unable to execute 'swig': No such file or directory
error: command 'swig' failed with exit status 1"
```