### PR TITLE
use imageio in video_recorder

### DIFF
--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -116,8 +116,7 @@ class MujocoEnv(gym.Env):
 
     def _get_viewer(self):
         if self.viewer is None:
-            self.viewer = mujoco_py.MjViewer()
-            #self.viewer = mujoco_py.MjViewer(init_width=512,init_height=512)
+            self.viewer = mujoco_py.MjViewer(init_width=512,init_height=512)
             self.viewer.start()
             self.viewer.set_model(self.model)
             self.viewer_setup()

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -117,6 +117,7 @@ class MujocoEnv(gym.Env):
     def _get_viewer(self):
         if self.viewer is None:
             self.viewer = mujoco_py.MjViewer()
+            #self.viewer = mujoco_py.MjViewer(init_width=512,init_height=512)
             self.viewer.start()
             self.viewer.set_model(self.model)
             self.viewer_setup()

--- a/gym/monitoring/video_recorder.py
+++ b/gym/monitoring/video_recorder.py
@@ -234,69 +234,17 @@ class TextEncoder(object):
     def version_info(self):
         return {'backend':'TextEncoder','version':1}
 
+import imageio
 class ImageEncoder(object):
     def __init__(self, output_path, frame_shape, frames_per_sec):
-        self.proc = None
-        self.output_path = output_path
-        # Frame shape should be lines-first, so w and h are swapped
-        h, w, pixfmt = frame_shape
-        if pixfmt != 3 and pixfmt != 4:
-            raise error.InvalidFrame("Your frame has shape {}, but we require (w,h,3) or (w,h,4), i.e. RGB values for a w-by-h image, with an optional alpha channl.".format(frame_shape))
-        self.wh = (w,h)
-        self.includes_alpha = (pixfmt == 4)
-        self.frame_shape = frame_shape
-        self.frames_per_sec = frames_per_sec
-
-        if distutils.spawn.find_executable('ffmpeg') is not None:
-            self.backend = 'ffmpeg'
-        elif distutils.spawn.find_executable('avconv') is not None:
-            self.backend = 'avconv'
-        else:
-            raise error.DependencyNotInstalled("""Found neither the ffmpeg nor avconv executables. On OS X, you can install ffmpeg via `brew install ffmpeg`. On most Ubuntu variants, `sudo apt-get install ffmpeg` should do it. On Ubuntu 14.04, however, you'll need to install avconv with `sudo apt-get install libav-tools`.""")
-
-        self.start()
+        self.writer = imageio.get_writer(output_path, fps=frames_per_sec)
 
     @property
     def version_info(self):
-        return {'backend':self.backend,'version':str(subprocess.check_output([self.backend, '-version'])),'cmdline':self.cmdline}
-
-    def start(self):
-        self.cmdline = (self.backend,
-                     '-nostats',
-                     '-loglevel', 'error', # suppress warnings
-                     '-y',
-                     '-r', '%d' % self.frames_per_sec,
-
-                     # input
-                     '-f', 'rawvideo',
-                     '-s:v', '{}x{}'.format(*self.wh),
-                     '-pix_fmt',('rgb32' if self.includes_alpha else 'rgb24'),
-                     '-i', '-', # this used to be /dev/stdin, which is not Windows-friendly
-
-                     # output
-                     '-vcodec', 'libx264',
-                     '-pix_fmt', 'yuv420p',
-                     self.output_path
-                     )
-
-        logger.debug('Starting ffmpeg with "%s"', ' '.join(self.cmdline))
-        self.proc = subprocess.Popen(self.cmdline, stdin=subprocess.PIPE)
+        return {'backend': 'imageio','version': imageio.__version__}
 
     def capture_frame(self, frame):
-        if not isinstance(frame, (np.ndarray, np.generic)):
-            raise error.InvalidFrame('Wrong type {} for {} (must be np.ndarray or np.generic)'.format(type(frame), frame))
-        if frame.shape != self.frame_shape:
-            raise error.InvalidFrame("Your frame has shape {}, but the VideoRecorder is configured for shape {}.".format(frame.shape, self.frame_shape))
-        if frame.dtype != np.uint8:
-            raise error.InvalidFrame("Your frame has data type {}, but we require uint8 (i.e. RGB values from 0-255).".format(frame.dtype))
-
-        if distutils.version.LooseVersion(np.__version__) >= distutils.version.LooseVersion('1.9.0'):
-            self.proc.stdin.write(frame.tobytes())
-        else:
-            self.proc.stdin.write(frame.tostring())
+        self.writer.append_data(frame)
 
     def close(self):
-        self.proc.stdin.close()
-        ret = self.proc.wait()
-        if ret != 0:
-            logger.error("VideoRecorder encoder exited with status {}".format(ret))
+        self.writer.close()

--- a/gym/monitoring/video_recorder.py
+++ b/gym/monitoring/video_recorder.py
@@ -237,8 +237,8 @@ class TextEncoder(object):
 import imageio
 class ImageEncoder(object):
     def __init__(self, output_path, frame_shape, frames_per_sec):
-        self.writer = imageio.get_writer(output_path, fps=frames_per_sec)
-
+        self.writer = imageio.get_writer(output_path, fps=frames_per_sec, ffmpeg_params=['-loglevel','error'])
+    
     @property
     def version_info(self):
         return {'backend': 'imageio','version': imageio.__version__}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.10.4
 requests>=2.0
 six
 pyglet
+imageio


### PR DESCRIPTION
Hey, I couldn't install ffmpeg because I'm on a university cluster without root rights. But today I stumbled upon the imageio package (https://github.com/imageio/imageio). It downloads and compiles ffmpeg on its own when used for the first time. As a bonus, it would simplify the video_recorder code a bit.

Should work on all OS but I only tested it on CentOS 7.

Issues:
There is this warning that appears for many environments when using imageio:
```bash
[swscaler @ 0x37f6060] Warning: data is not aligned! This can lead to a speedloss
[2016-06-02 22:57:27,990] IMAGEIO FFMPEG_WRITER WARNING: input image is not divisible by macro_block_size=16, resizing from (500, 500) to (512, 512) to ensure video compatibility with most codecs and players. To prevent resizing, make your input image divisible by the macro_block_size or set the macro_block_size to None (risking incompatibility). You may also see a FFMPEG warning concerning speedloss due to data not being aligned.
```
