### PR TITLE
Doom - Same Action Space Across Environments

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -1,5 +1,9 @@
 from gym.envs.registration import registry, register, make, spec
 
+# To be able to create new-style properties
+class Env(object):
+    pass
+
 # Algorithmic
 # ----------------------------------------
 
@@ -301,13 +305,15 @@ register(
     entry_point='gym.envs.doom:DoomBasicEnv',
     timestep_limit=10000,
     reward_threshold=10.0,
+    nondeterministic=True,
 )
 
 register(
     id='DoomCorridor-v0',
     entry_point='gym.envs.doom:DoomCorridorEnv',
     timestep_limit=10000,
-    reward_threshold=1270.0,
+    reward_threshold=1000.0,
+    nondeterministic=True,
 )
 
 register(
@@ -315,6 +321,7 @@ register(
     entry_point='gym.envs.doom:DoomDefendCenterEnv',
     timestep_limit=10000,
     reward_threshold=10.0,
+    nondeterministic=True,
 )
 
 register(
@@ -322,6 +329,7 @@ register(
     entry_point='gym.envs.doom:DoomDefendLineEnv',
     timestep_limit=10000,
     reward_threshold=15.0,
+    nondeterministic=True,
 )
 
 register(
@@ -329,6 +337,7 @@ register(
     entry_point='gym.envs.doom:DoomHealthGatheringEnv',
     timestep_limit=10000,
     reward_threshold=1000.0,
+    nondeterministic=True,
 )
 
 register(
@@ -336,6 +345,7 @@ register(
     entry_point='gym.envs.doom:DoomMyWayHomeEnv',
     timestep_limit=10000,
     reward_threshold=0.5,
+    nondeterministic=True,
 )
 
 register(
@@ -343,6 +353,7 @@ register(
     entry_point='gym.envs.doom:DoomPredictPositionEnv',
     timestep_limit=10000,
     reward_threshold=0.5,
+    nondeterministic=True,
 )
 
 register(
@@ -350,6 +361,7 @@ register(
     entry_point='gym.envs.doom:DoomTakeCoverEnv',
     timestep_limit=10000,
     reward_threshold=750.0,
+    nondeterministic=True,
 )
 
 register(
@@ -357,6 +369,7 @@ register(
     entry_point='gym.envs.doom:DoomDeathmatchEnv',
     timestep_limit=10000,
     reward_threshold=20.0,
+    nondeterministic=True,
 )
 
 # Debugging

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -1,9 +1,5 @@
 from gym.envs.registration import registry, register, make, spec
 
-# To be able to create new-style properties
-class Env(object):
-    pass
-
 # Algorithmic
 # ----------------------------------------
 

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -299,46 +299,64 @@ register(
 register(
     id='DoomBasic-v0',
     entry_point='gym.envs.doom:DoomBasicEnv',
+    timestep_limit=10000,
+    reward_threshold=10.0,
 )
 
 register(
     id='DoomCorridor-v0',
     entry_point='gym.envs.doom:DoomCorridorEnv',
+    timestep_limit=10000,
+    reward_threshold=1270.0,
 )
 
 register(
     id='DoomDefendCenter-v0',
     entry_point='gym.envs.doom:DoomDefendCenterEnv',
+    timestep_limit=10000,
+    reward_threshold=10.0,
 )
 
 register(
     id='DoomDefendLine-v0',
     entry_point='gym.envs.doom:DoomDefendLineEnv',
+    timestep_limit=10000,
+    reward_threshold=25.0,
 )
 
 register(
     id='DoomHealthGathering-v0',
     entry_point='gym.envs.doom:DoomHealthGatheringEnv',
+    timestep_limit=10000,
+    reward_threshold=1000.0,
 )
 
 register(
     id='DoomMyWayHome-v0',
     entry_point='gym.envs.doom:DoomMyWayHomeEnv',
+    timestep_limit=10000,
+    reward_threshold=0.5,
 )
 
 register(
     id='DoomPredictPosition-v0',
     entry_point='gym.envs.doom:DoomPredictPositionEnv',
+    timestep_limit=10000,
+    reward_threshold=0.5,
 )
 
 register(
     id='DoomTakeCover-v0',
     entry_point='gym.envs.doom:DoomTakeCoverEnv',
+    timestep_limit=10000,
+    reward_threshold=750.0,
 )
 
 register(
     id='DoomDeathmatch-v0',
     entry_point='gym.envs.doom:DoomDeathmatchEnv',
+    timestep_limit=10000,
+    reward_threshold=25.0,
 )
 
 # Debugging

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -321,7 +321,7 @@ register(
     id='DoomDefendLine-v0',
     entry_point='gym.envs.doom:DoomDefendLineEnv',
     timestep_limit=10000,
-    reward_threshold=25.0,
+    reward_threshold=15.0,
 )
 
 register(
@@ -356,7 +356,7 @@ register(
     id='DoomDeathmatch-v0',
     entry_point='gym.envs.doom:DoomDeathmatchEnv',
     timestep_limit=10000,
-    reward_threshold=25.0,
+    reward_threshold=20.0,
 )
 
 # Debugging

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -301,7 +301,6 @@ register(
     entry_point='gym.envs.doom:DoomBasicEnv',
     timestep_limit=10000,
     reward_threshold=10.0,
-    nondeterministic=True,
 )
 
 register(
@@ -309,7 +308,6 @@ register(
     entry_point='gym.envs.doom:DoomCorridorEnv',
     timestep_limit=10000,
     reward_threshold=1000.0,
-    nondeterministic=True,
 )
 
 register(
@@ -317,7 +315,6 @@ register(
     entry_point='gym.envs.doom:DoomDefendCenterEnv',
     timestep_limit=10000,
     reward_threshold=10.0,
-    nondeterministic=True,
 )
 
 register(
@@ -325,7 +322,6 @@ register(
     entry_point='gym.envs.doom:DoomDefendLineEnv',
     timestep_limit=10000,
     reward_threshold=15.0,
-    nondeterministic=True,
 )
 
 register(
@@ -333,7 +329,6 @@ register(
     entry_point='gym.envs.doom:DoomHealthGatheringEnv',
     timestep_limit=10000,
     reward_threshold=1000.0,
-    nondeterministic=True,
 )
 
 register(
@@ -341,7 +336,6 @@ register(
     entry_point='gym.envs.doom:DoomMyWayHomeEnv',
     timestep_limit=10000,
     reward_threshold=0.5,
-    nondeterministic=True,
 )
 
 register(
@@ -349,7 +343,6 @@ register(
     entry_point='gym.envs.doom:DoomPredictPositionEnv',
     timestep_limit=10000,
     reward_threshold=0.5,
-    nondeterministic=True,
 )
 
 register(
@@ -357,7 +350,6 @@ register(
     entry_point='gym.envs.doom:DoomTakeCoverEnv',
     timestep_limit=10000,
     reward_threshold=750.0,
-    nondeterministic=True,
 )
 
 register(
@@ -365,7 +357,6 @@ register(
     entry_point='gym.envs.doom:DoomDeathmatchEnv',
     timestep_limit=10000,
     reward_threshold=20.0,
-    nondeterministic=True,
 )
 
 # Debugging

--- a/gym/envs/doom/assets/basic.cfg
+++ b/gym/envs/doom/assets/basic.cfg
@@ -32,11 +32,29 @@ available_buttons =
 available_game_variables =
     {
         KILLCOUNT
+        ITEMCOUNT
+        SECRETCOUNT
+        FRAGCOUNT
         HEALTH
         ARMOR
+        DEAD
+        ON_GROUND
+        ATTACK_READY
+        ALTATTACK_READY
+
         SELECTED_WEAPON
         SELECTED_WEAPON_AMMO
+
+        AMMO1
         AMMO2
+        AMMO3
+        AMMO4
+        AMMO5
+        AMMO6
+        AMMO7
+        AMMO8
+        AMMO9
+        AMMO0
     }
 
 mode = PLAYER

--- a/gym/envs/doom/assets/basic.cfg
+++ b/gym/envs/doom/assets/basic.cfg
@@ -57,6 +57,4 @@ available_game_variables =
         AMMO0
     }
 
-mode = PLAYER
-doom_skill = 5
 sound_enabled = false

--- a/gym/envs/doom/assets/deadly_corridor.cfg
+++ b/gym/envs/doom/assets/deadly_corridor.cfg
@@ -35,11 +35,29 @@ available_buttons =
 available_game_variables =
     {
         KILLCOUNT
+        ITEMCOUNT
+        SECRETCOUNT
+        FRAGCOUNT
         HEALTH
         ARMOR
+        DEAD
+        ON_GROUND
+        ATTACK_READY
+        ALTATTACK_READY
+
         SELECTED_WEAPON
         SELECTED_WEAPON_AMMO
+
+        AMMO1
         AMMO2
+        AMMO3
+        AMMO4
+        AMMO5
+        AMMO6
+        AMMO7
+        AMMO8
+        AMMO9
+        AMMO0
     }
 
 mode = PLAYER

--- a/gym/envs/doom/assets/deadly_corridor.cfg
+++ b/gym/envs/doom/assets/deadly_corridor.cfg
@@ -60,6 +60,4 @@ available_game_variables =
         AMMO0
     }
 
-mode = PLAYER
-doom_skill = 5
 sound_enabled = false

--- a/gym/envs/doom/assets/deathmatch.cfg
+++ b/gym/envs/doom/assets/deathmatch.cfg
@@ -76,8 +76,15 @@ available_buttons =
 available_game_variables =
     {
         KILLCOUNT
+        ITEMCOUNT
+        SECRETCOUNT
+        FRAGCOUNT
         HEALTH
         ARMOR
+        DEAD
+        ON_GROUND
+        ATTACK_READY
+        ALTATTACK_READY
 
         SELECTED_WEAPON
         SELECTED_WEAPON_AMMO
@@ -88,6 +95,10 @@ available_game_variables =
         AMMO4
         AMMO5
         AMMO6
+        AMMO7
+        AMMO8
+        AMMO9
+        AMMO0
     }
 
 mode = PLAYER

--- a/gym/envs/doom/assets/deathmatch.cfg
+++ b/gym/envs/doom/assets/deathmatch.cfg
@@ -101,6 +101,4 @@ available_game_variables =
         AMMO0
     }
 
-mode = PLAYER
-doom_skill = 5
 sound_enabled = false

--- a/gym/envs/doom/assets/defend_the_center.cfg
+++ b/gym/envs/doom/assets/defend_the_center.cfg
@@ -57,6 +57,4 @@ available_game_variables =
         AMMO0
     }
 
-mode = PLAYER
-doom_skill = 3
 sound_enabled = false

--- a/gym/envs/doom/assets/defend_the_center.cfg
+++ b/gym/envs/doom/assets/defend_the_center.cfg
@@ -32,11 +32,29 @@ available_buttons =
 available_game_variables =
     {
         KILLCOUNT
+        ITEMCOUNT
+        SECRETCOUNT
+        FRAGCOUNT
         HEALTH
         ARMOR
+        DEAD
+        ON_GROUND
+        ATTACK_READY
+        ALTATTACK_READY
+
         SELECTED_WEAPON
         SELECTED_WEAPON_AMMO
+
+        AMMO1
         AMMO2
+        AMMO3
+        AMMO4
+        AMMO5
+        AMMO6
+        AMMO7
+        AMMO8
+        AMMO9
+        AMMO0
     }
 
 mode = PLAYER

--- a/gym/envs/doom/assets/defend_the_line.cfg
+++ b/gym/envs/doom/assets/defend_the_line.cfg
@@ -32,11 +32,29 @@ available_buttons =
 available_game_variables =
     {
         KILLCOUNT
+        ITEMCOUNT
+        SECRETCOUNT
+        FRAGCOUNT
         HEALTH
         ARMOR
+        DEAD
+        ON_GROUND
+        ATTACK_READY
+        ALTATTACK_READY
+
         SELECTED_WEAPON
         SELECTED_WEAPON_AMMO
+
+        AMMO1
         AMMO2
+        AMMO3
+        AMMO4
+        AMMO5
+        AMMO6
+        AMMO7
+        AMMO8
+        AMMO9
+        AMMO0
     }
 
 mode = PLAYER

--- a/gym/envs/doom/assets/defend_the_line.cfg
+++ b/gym/envs/doom/assets/defend_the_line.cfg
@@ -57,6 +57,4 @@ available_game_variables =
         AMMO0
     }
 
-mode = PLAYER
-doom_skill = 5
 sound_enabled = false

--- a/gym/envs/doom/assets/health_gathering.cfg
+++ b/gym/envs/doom/assets/health_gathering.cfg
@@ -58,7 +58,5 @@ available_game_variables =
         AMMO0
     }
 
-mode = PLAYER
-doom_skill = 5
 sound_enabled = false
 

--- a/gym/envs/doom/assets/health_gathering.cfg
+++ b/gym/envs/doom/assets/health_gathering.cfg
@@ -33,11 +33,29 @@ available_buttons =
 available_game_variables =
     {
         KILLCOUNT
+        ITEMCOUNT
+        SECRETCOUNT
+        FRAGCOUNT
         HEALTH
         ARMOR
+        DEAD
+        ON_GROUND
+        ATTACK_READY
+        ALTATTACK_READY
+
         SELECTED_WEAPON
         SELECTED_WEAPON_AMMO
+
+        AMMO1
         AMMO2
+        AMMO3
+        AMMO4
+        AMMO5
+        AMMO6
+        AMMO7
+        AMMO8
+        AMMO9
+        AMMO0
     }
 
 mode = PLAYER

--- a/gym/envs/doom/assets/my_way_home.cfg
+++ b/gym/envs/doom/assets/my_way_home.cfg
@@ -32,12 +32,29 @@ available_buttons =
 available_game_variables =
     {
         KILLCOUNT
+        ITEMCOUNT
+        SECRETCOUNT
+        FRAGCOUNT
         HEALTH
         ARMOR
+        DEAD
+        ON_GROUND
+        ATTACK_READY
+        ALTATTACK_READY
+
         SELECTED_WEAPON
         SELECTED_WEAPON_AMMO
-        AMMO0
+
+        AMMO1
         AMMO2
+        AMMO3
+        AMMO4
+        AMMO5
+        AMMO6
+        AMMO7
+        AMMO8
+        AMMO9
+        AMMO0
     }
 
 mode = PLAYER

--- a/gym/envs/doom/assets/my_way_home.cfg
+++ b/gym/envs/doom/assets/my_way_home.cfg
@@ -17,8 +17,8 @@ render_particles = false
 # make episodes start after 14 tics (after unholstering the gun) (35 tics per seconds)
 episode_start_time = 14
 
-# Make episodes finish after 4200 tics (2 minutes)
-episode_timeout = 4200
+# Make episodes finish after 2100 tics (1 minutes)
+episode_timeout = 2100
 
 # Available buttons
 available_buttons =

--- a/gym/envs/doom/assets/my_way_home.cfg
+++ b/gym/envs/doom/assets/my_way_home.cfg
@@ -57,6 +57,4 @@ available_game_variables =
         AMMO0
     }
 
-mode = PLAYER
-doom_skill = 5
 sound_enabled = false

--- a/gym/envs/doom/assets/predict_position.cfg
+++ b/gym/envs/doom/assets/predict_position.cfg
@@ -57,7 +57,5 @@ available_game_variables =
         AMMO0
     }
 
-mode = PLAYER
-doom_skill = 3
 sound_enabled = false
 

--- a/gym/envs/doom/assets/predict_position.cfg
+++ b/gym/envs/doom/assets/predict_position.cfg
@@ -32,11 +32,29 @@ available_buttons =
 available_game_variables =
     {
         KILLCOUNT
+        ITEMCOUNT
+        SECRETCOUNT
+        FRAGCOUNT
         HEALTH
         ARMOR
+        DEAD
+        ON_GROUND
+        ATTACK_READY
+        ALTATTACK_READY
+
         SELECTED_WEAPON
         SELECTED_WEAPON_AMMO
+
+        AMMO1
         AMMO2
+        AMMO3
+        AMMO4
+        AMMO5
+        AMMO6
+        AMMO7
+        AMMO8
+        AMMO9
+        AMMO0
     }
 
 mode = PLAYER

--- a/gym/envs/doom/assets/take_cover.cfg
+++ b/gym/envs/doom/assets/take_cover.cfg
@@ -56,6 +56,4 @@ available_game_variables =
         AMMO0
     }
 
-mode = PLAYER
-doom_skill = 5
 sound_enabled = false

--- a/gym/envs/doom/assets/take_cover.cfg
+++ b/gym/envs/doom/assets/take_cover.cfg
@@ -31,11 +31,29 @@ available_buttons =
 available_game_variables =
     {
         KILLCOUNT
+        ITEMCOUNT
+        SECRETCOUNT
+        FRAGCOUNT
         HEALTH
         ARMOR
+        DEAD
+        ON_GROUND
+        ATTACK_READY
+        ALTATTACK_READY
+
         SELECTED_WEAPON
         SELECTED_WEAPON_AMMO
+
+        AMMO1
         AMMO2
+        AMMO3
+        AMMO4
+        AMMO5
+        AMMO6
+        AMMO7
+        AMMO8
+        AMMO9
+        AMMO0
     }
 
 mode = PLAYER

--- a/gym/envs/doom/controls.md
+++ b/gym/envs/doom/controls.md
@@ -55,8 +55,8 @@ The full list of possible actions is:
 * [33] - SELECT_NEXT_ITEM                 - Select next item - Values 0 or 1
 * [34] - SELECT_PREV_ITEM                 - Select previous item - Values 0 or 1
 * [35] - DROP_SELECTED_ITEM               - Drop selected item - Values 0 or 1
-* [36] - LOOK_UP_DOWN_DELTA               - Disabled - Value of 0.
-* [37] - TURN_LEFT_RIGHT_DELTA            - Disabled - Value of 0.
-* [38] - MOVE_FORWARD_BACKWARD_DELTA      - Disabled - Value of 0.
-* [39] - MOVE_LEFT_RIGHT_DELTA            - Disabled - Value of 0.
-* [40] - MOVE_UP_DOWN_DELTA               - Disabled - Value of 0.
+* [36] - LOOK_UP_DOWN_DELTA               - Disabled - Value ignored - Range of -10 to 10.
+* [37] - TURN_LEFT_RIGHT_DELTA            - Disabled - Value ignored - Range of -10 to 10.
+* [38] - MOVE_FORWARD_BACKWARD_DELTA      - Disabled - Value ignored - Range 0 to 100.
+* [39] - MOVE_LEFT_RIGHT_DELTA            - Disabled - Value ignored - Range 0 to 100.
+* [40] - MOVE_UP_DOWN_DELTA               - Disabled - Value ignored - Range 0 to 100.

--- a/gym/envs/doom/controls.md
+++ b/gym/envs/doom/controls.md
@@ -76,3 +76,8 @@ The full list of possible actions is:
 * [42] - MOVE_UP_DOWN_DELTA               - Speed of up/down movement - Range -100 to 100 (integer).
                                           - +100 is max speed up, -100 is max speed down, 0 is no movement
 
+To control the player in 'human' mode, the following keys should work:
+
+* Arrow Keys for MOVE_FORWARD, MOVE_BACKWARD, LEFT_TURN, RIGHT_TURN
+* '<' and '>' for MOVE_RIGHT and MOVE_LEFT
+* Ctrl (or left mouse click) for ATTACK

--- a/gym/envs/doom/controls.md
+++ b/gym/envs/doom/controls.md
@@ -2,16 +2,24 @@
 
 Doom is usually played with a full keyboard, and multiple keys can be pressed at once.
 
-To replicate this, we broke down the possible actions in 41 keys. Each key can be pressed (value of 1), or unpressed (value of 0).
+To replicate this, we broke down the possible actions in 43 keys. Each key can be pressed (value of 1), or unpressed (value of 0).
+
+The last 5 commands are deltas. [38] - LOOK_UP_DOWN_DELTA and [39] - TURN_LEFT_RIGHT_DELTA replicate mouse movement where values are in the
+range -10 to +10. They represent mouse movement over the x and y axis. (e.g. +5 for LOOK_UP_DOWN_DELTA will make the player look up 5 degrees)
+
+[40] - MOVE_FORWARD_BACKWARD_DELTA, [41] - MOVE_LEFT_RIGHT_DELTA, and [42] - MOVE_UP_DOWN_DELTA represent the speed on an axis.
+Their values range from -100 to 100, where +100 is the maximum speed in one direction, and -100 is the maximum speed in the other.
+(e.g. MOVE_FORWARD_BACKWARD_DELTA of +100 will make the player move forward at 100% of max speed, and -100 will make the player
+move backward at 100% of max speed).
 
 A list of values is expected to be passed as the action (e.g. [0, 1, 0, 0, 1, 0, .... ]).
 
-Each map is restricted on what actions can be performed, but the mapping is the same across all maps.
+Each mission is restricted on what actions can be performed, but the mapping is the same across all missions.
 
 For example, if we want to [0] - ATTACK, [2] - JUMP, and [13] - MOVE_FORWARD at the same time, we would submit the following action:
 
 ```python
-action = [0] * 41
+action = [0] * 43
 action[0] = 1
 action[2] = 1
 action[13] = 1
@@ -37,26 +45,34 @@ The full list of possible actions is:
 * [15] - TURN_LEFT                        - Turn left - Values 0 or 1
 * [16] - LOOK_UP                          - Look up - Values 0 or 1
 * [17] - LOOK_DOWN                        - Look down - Values 0 or 1
-* [18] - LAND                             - Land (e.g. drop from ladder) - Values 0 or 1
-* [19] - SELECT_WEAPON1                   - Select weapon 1 - Values 0 or 1
-* [20] - SELECT_WEAPON2                   - Select weapon 2 - Values 0 or 1
-* [21] - SELECT_WEAPON3                   - Select weapon 3 - Values 0 or 1
-* [22] - SELECT_WEAPON4                   - Select weapon 4 - Values 0 or 1
-* [23] - SELECT_WEAPON5                   - Select weapon 5 - Values 0 or 1
-* [24] - SELECT_WEAPON6                   - Select weapon 6 - Values 0 or 1
-* [25] - SELECT_WEAPON7                   - Select weapon 7 - Values 0 or 1
-* [26] - SELECT_WEAPON8                   - Select weapon 8 - Values 0 or 1
-* [27] - SELECT_WEAPON9                   - Select weapon 9 - Values 0 or 1
-* [28] - SELECT_WEAPON0                   - Select weapon 0 - Values 0 or 1
-* [29] - SELECT_NEXT_WEAPON               - Select next weapon - Values 0 or 1
-* [30] - SELECT_PREV_WEAPON               - Select previous weapon - Values 0 or 1
-* [31] - DROP_SELECTED_WEAPON             - Drop selected weapon - Values 0 or 1
-* [32] - ACTIVATE_SELECTED_WEAPON         - Activate selected weapon - Values 0 or 1
-* [33] - SELECT_NEXT_ITEM                 - Select next item - Values 0 or 1
-* [34] - SELECT_PREV_ITEM                 - Select previous item - Values 0 or 1
-* [35] - DROP_SELECTED_ITEM               - Drop selected item - Values 0 or 1
-* [36] - LOOK_UP_DOWN_DELTA               - Disabled - Value ignored - Range of -10 to 10.
-* [37] - TURN_LEFT_RIGHT_DELTA            - Disabled - Value ignored - Range of -10 to 10.
-* [38] - MOVE_FORWARD_BACKWARD_DELTA      - Disabled - Value ignored - Range 0 to 100.
-* [39] - MOVE_LEFT_RIGHT_DELTA            - Disabled - Value ignored - Range 0 to 100.
-* [40] - MOVE_UP_DOWN_DELTA               - Disabled - Value ignored - Range 0 to 100.
+* [18] - MOVE_UP                          - Move up - Values 0 or 1
+* [19] - MOVE_DOWN                        - Move down - Values 0 or 1
+* [20] - LAND                             - Land (e.g. drop from ladder) - Values 0 or 1
+* [21] - SELECT_WEAPON1                   - Select weapon 1 - Values 0 or 1
+* [22] - SELECT_WEAPON2                   - Select weapon 2 - Values 0 or 1
+* [23] - SELECT_WEAPON3                   - Select weapon 3 - Values 0 or 1
+* [24] - SELECT_WEAPON4                   - Select weapon 4 - Values 0 or 1
+* [25] - SELECT_WEAPON5                   - Select weapon 5 - Values 0 or 1
+* [26] - SELECT_WEAPON6                   - Select weapon 6 - Values 0 or 1
+* [27] - SELECT_WEAPON7                   - Select weapon 7 - Values 0 or 1
+* [28] - SELECT_WEAPON8                   - Select weapon 8 - Values 0 or 1
+* [29] - SELECT_WEAPON9                   - Select weapon 9 - Values 0 or 1
+* [30] - SELECT_WEAPON0                   - Select weapon 0 - Values 0 or 1
+* [31] - SELECT_NEXT_WEAPON               - Select next weapon - Values 0 or 1
+* [32] - SELECT_PREV_WEAPON               - Select previous weapon - Values 0 or 1
+* [33] - DROP_SELECTED_WEAPON             - Drop selected weapon - Values 0 or 1
+* [34] - ACTIVATE_SELECTED_WEAPON         - Activate selected weapon - Values 0 or 1
+* [35] - SELECT_NEXT_ITEM                 - Select next item - Values 0 or 1
+* [36] - SELECT_PREV_ITEM                 - Select previous item - Values 0 or 1
+* [37] - DROP_SELECTED_ITEM               - Drop selected item - Values 0 or 1
+* [38] - LOOK_UP_DOWN_DELTA               - Look Up/Down - Range of -10 to 10 (integer).
+                                          - Value is the angle - +5 will look up 5 degrees, -5 will look down 5 degrees
+* [39] - TURN_LEFT_RIGHT_DELTA            - Turn Left/Right - Range of -10 to 10 (integer).
+                                          - Value is the angle - +5 will turn right 5 degrees, -5 will turn left 5 degrees
+* [40] - MOVE_FORWARD_BACKWARD_DELTA      - Speed of forward/backward movement - Range -100 to 100 (integer).
+                                          - +100 is max speed forward, -100 is max speed backward, 0 is no movement
+* [41] - MOVE_LEFT_RIGHT_DELTA            - Speed of left/right movement - Range -100 to 100 (integer).
+                                          - +100 is max speed right, -100 is max speed left, 0 is no movement
+* [42] - MOVE_UP_DOWN_DELTA               - Speed of up/down movement - Range -100 to 100 (integer).
+                                          - +100 is max speed up, -100 is max speed down, 0 is no movement
+

--- a/gym/envs/doom/controls.md
+++ b/gym/envs/doom/controls.md
@@ -2,21 +2,19 @@
 
 Doom is usually played with a full keyboard, and multiple keys can be pressed at once.
 
-To replicate this, we broke down the possible actions in 40 keys. Each key can be pressed (value of 1), or unpressed (value of 0).
-
-The deltas (35 to 39) indicate speed of change (values 0 to 10), where higher values will make the player move faster on an axis.
+To replicate this, we broke down the possible actions in 41 keys. Each key can be pressed (value of 1), or unpressed (value of 0).
 
 A list of values is expected to be passed as the action (e.g. [0, 1, 0, 0, 1, 0, .... ]).
 
 Each map is restricted on what actions can be performed, but the mapping is the same across all maps.
 
-For example, if we want to [0] - ATTACK, [2] - JUMP, and [12] - MOVE_FORWARD at the same time, we would submit the following action:
+For example, if we want to [0] - ATTACK, [2] - JUMP, and [13] - MOVE_FORWARD at the same time, we would submit the following action:
 
 ```python
-action = [0] * 40
+action = [0] * 41
 action[0] = 1
 action[2] = 1
-action[12] = 1
+action[13] = 1
 ```
 
 The full list of possible actions is:
@@ -26,38 +24,39 @@ The full list of possible actions is:
 * [2]  - JUMP                             - Jump - Values 0 or 1
 * [3]  - CROUCH                           - Crouch - Values 0 or 1
 * [4]  - TURN180                          - Perform 180 turn - Values 0 or 1
-* [5]  - RELOAD                           - Reload weapon - Values 0 or 1
-* [6]  - ZOOM                             - Toggle zoom in/out - Values 0 or 1
-* [7]  - SPEED                            - Run faster - Values 0 or 1
-* [8]  - STRAFE                           - Strafe (moving sideways in a circle) - Values 0 or 1
-* [9]  - MOVE_RIGHT                       - Move to the right - Values 0 or 1
-* [10] - MOVE_LEFT                        - Move to the left - Values 0 or 1
-* [11] - MOVE_BACKWARD                    - Move backward - Values 0 or 1
-* [12] - MOVE_FORWARD                     - Move forward - Values 0 or 1
-* [13] - TURN_RIGHT                       - Turn right - Values 0 or 1
-* [14] - TURN_LEFT                        - Turn left - Values 0 or 1
-* [15] - LOOK_UP                          - Look up - Values 0 or 1
-* [16] - LOOK_DOWN                        - Look down - Values 0 or 1
-* [17] - LAND                             - Land (e.g. drop from ladder) - Values 0 or 1
-* [18] - SELECT_WEAPON1                   - Select weapon 1 - Values 0 or 1
-* [19] - SELECT_WEAPON2                   - Select weapon 2 - Values 0 or 1
-* [20] - SELECT_WEAPON3                   - Select weapon 3 - Values 0 or 1
-* [21] - SELECT_WEAPON4                   - Select weapon 4 - Values 0 or 1
-* [22] - SELECT_WEAPON5                   - Select weapon 5 - Values 0 or 1
-* [23] - SELECT_WEAPON6                   - Select weapon 6 - Values 0 or 1
-* [24] - SELECT_WEAPON7                   - Select weapon 7 - Values 0 or 1
-* [25] - SELECT_WEAPON8                   - Select weapon 8 - Values 0 or 1
-* [26] - SELECT_WEAPON9                   - Select weapon 9 - Values 0 or 1
-* [27] - SELECT_WEAPON0                   - Select weapon 0 - Values 0 or 1
-* [28] - SELECT_NEXT_WEAPON               - Select next weapon - Values 0 or 1
-* [29] - SELECT_PREV_WEAPON               - Select previous weapon - Values 0 or 1
-* [30] - DROP_SELECTED_WEAPON             - Drop selected weapon - Values 0 or 1
-* [31] - ACTIVATE_SELECTED_WEAPON         - Activate selected weapon - Values 0 or 1
-* [32] - SELECT_NEXT_ITEM                 - Select next item - Values 0 or 1
-* [33] - SELECT_PREV_ITEM                 - Select previous item - Values 0 or 1
-* [34] - DROP_SELECTED_ITEM               - Drop selected item - Values 0 or 1
-* [35] - LOOK_UP_DOWN_DELTA               - Look Up - Values 0 to 10 (Higher value increases speed)
-* [36] - TURN_LEFT_RIGHT_DELTA            - Turn left/right - Values 0 to 10 (Higher value increases speed)
-* [37] - MOVE_FORWARD_BACKWARD_DELTA      - Move forward/backward - Values 0 to 10 (Higher value increases speed)
-* [38] - MOVE_LEFT_RIGHT_DELTA            - Move left/right - Values 0 to 10 (Higher value increases speed)
-* [39] - MOVE_UP_DOWN_DELTA               - Move up/down - Values 0 to 10 (Higher value increases speed)
+* [5] -  ALT_ATTACK                       - Perform alternate attack
+* [6]  - RELOAD                           - Reload weapon - Values 0 or 1
+* [7]  - ZOOM                             - Toggle zoom in/out - Values 0 or 1
+* [8]  - SPEED                            - Run faster - Values 0 or 1
+* [9]  - STRAFE                           - Strafe (moving sideways in a circle) - Values 0 or 1
+* [10] - MOVE_RIGHT                       - Move to the right - Values 0 or 1
+* [11] - MOVE_LEFT                        - Move to the left - Values 0 or 1
+* [12] - MOVE_BACKWARD                    - Move backward - Values 0 or 1
+* [13] - MOVE_FORWARD                     - Move forward - Values 0 or 1
+* [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+* [15] - TURN_LEFT                        - Turn left - Values 0 or 1
+* [16] - LOOK_UP                          - Look up - Values 0 or 1
+* [17] - LOOK_DOWN                        - Look down - Values 0 or 1
+* [18] - LAND                             - Land (e.g. drop from ladder) - Values 0 or 1
+* [19] - SELECT_WEAPON1                   - Select weapon 1 - Values 0 or 1
+* [20] - SELECT_WEAPON2                   - Select weapon 2 - Values 0 or 1
+* [21] - SELECT_WEAPON3                   - Select weapon 3 - Values 0 or 1
+* [22] - SELECT_WEAPON4                   - Select weapon 4 - Values 0 or 1
+* [23] - SELECT_WEAPON5                   - Select weapon 5 - Values 0 or 1
+* [24] - SELECT_WEAPON6                   - Select weapon 6 - Values 0 or 1
+* [25] - SELECT_WEAPON7                   - Select weapon 7 - Values 0 or 1
+* [26] - SELECT_WEAPON8                   - Select weapon 8 - Values 0 or 1
+* [27] - SELECT_WEAPON9                   - Select weapon 9 - Values 0 or 1
+* [28] - SELECT_WEAPON0                   - Select weapon 0 - Values 0 or 1
+* [29] - SELECT_NEXT_WEAPON               - Select next weapon - Values 0 or 1
+* [30] - SELECT_PREV_WEAPON               - Select previous weapon - Values 0 or 1
+* [31] - DROP_SELECTED_WEAPON             - Drop selected weapon - Values 0 or 1
+* [32] - ACTIVATE_SELECTED_WEAPON         - Activate selected weapon - Values 0 or 1
+* [33] - SELECT_NEXT_ITEM                 - Select next item - Values 0 or 1
+* [34] - SELECT_PREV_ITEM                 - Select previous item - Values 0 or 1
+* [35] - DROP_SELECTED_ITEM               - Drop selected item - Values 0 or 1
+* [36] - LOOK_UP_DOWN_DELTA               - Disabled - Value of 0.
+* [37] - TURN_LEFT_RIGHT_DELTA            - Disabled - Value of 0.
+* [38] - MOVE_FORWARD_BACKWARD_DELTA      - Disabled - Value of 0.
+* [39] - MOVE_LEFT_RIGHT_DELTA            - Disabled - Value of 0.
+* [40] - MOVE_UP_DOWN_DELTA               - Disabled - Value of 0.

--- a/gym/envs/doom/doom_basic.py
+++ b/gym/envs/doom/doom_basic.py
@@ -38,12 +38,12 @@ class DoomBasicEnv(doom_env.DoomEnv):
 
     Actions:
     Either of
-        1) action = [0, 1, 0]
+        1) action = [0, 1, 0]       # Recommended
             where parameter #1 is ATTACK (0 or 1)
             where parameter #2 is MOVE_RIGHT (0 or 1)
             where parameter #3 is MOVE_LEFT (0 or 1)
         or
-        2) actions = [0] * 41
+        2) actions = [0] * 41       # To train for the Deathmatch level
            actions[0] = 0       # ATTACK
            actions[10] = 1      # MOVE_RIGHT
            actions[11] = 0      # MOVE_LEFT
@@ -67,7 +67,7 @@ class DoomBasicEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [0, 10, 11] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 0, 0]] * 5))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
         self.action_space.allowed_actions = [0, 10, 11]
 

--- a/gym/envs/doom/doom_basic.py
+++ b/gym/envs/doom/doom_basic.py
@@ -44,9 +44,4 @@ class DoomBasicEnv(doom_env.DoomEnv):
     -----------------------------------------------------
     """
     def __init__(self):
-        super(DoomBasicEnv, self).__init__()
-        self.config = 'basic.cfg'
-        self.scenario = 'basic.wad'
-        self.map = 'map01'
-        self.difficulty = 5
-        self.allowed_actions = [0, 10, 11]
+        super(DoomBasicEnv, self).__init__(0)

--- a/gym/envs/doom/doom_basic.py
+++ b/gym/envs/doom/doom_basic.py
@@ -1,10 +1,4 @@
 import logging
-import os
-
-import numpy as np
-
-from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import spaces
 from gym.envs.doom import doom_env
 
 logger = logging.getLogger(__name__)
@@ -32,9 +26,10 @@ class DoomBasicEnv(doom_env.DoomEnv):
         Kill the monster in 3 secs with 1 shot
 
     Mode:
-        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
-        - 'normal' will run at roughly 30 fps (easier for human to watch)
+        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
+        - 'normal' will run at roughly 35 fps (easier for human to watch)
+        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
 
     Ends when:
         - Monster is dead
@@ -42,38 +37,16 @@ class DoomBasicEnv(doom_env.DoomEnv):
         - Timeout (10 seconds - 350 frames)
 
     Actions:
-    Either of
-        1) action = [0, 1, 0]       # Recommended
-            where parameter #1 is ATTACK (0 or 1)
-            where parameter #2 is MOVE_RIGHT (0 or 1)
-            where parameter #3 is MOVE_LEFT (0 or 1)
-        or
-        2) actions = [0] * 43       # To train for the Deathmatch level
-           actions[0] = 0       # ATTACK
-           actions[10] = 1      # MOVE_RIGHT
-           actions[11] = 0      # MOVE_LEFT
+        actions = [0] * 43
+        actions[0] = 0       # ATTACK
+        actions[10] = 1      # MOVE_RIGHT
+        actions[11] = 0      # MOVE_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
         super(DoomBasicEnv, self).__init__()
-        package_directory = os.path.dirname(os.path.abspath(__file__))
-        self.loader = Loader()
-        self.game = DoomGame()
-        self.game.load_config(os.path.join(package_directory, 'assets/basic.cfg'))
-        self.game.set_vizdoom_path(self.loader.get_vizdoom_path())
-        self.game.set_doom_game_path(self.loader.get_freedoom_path())
-        self.game.set_doom_scenario_path(self.loader.get_scenario_path('basic.wad'))
-        self.game.set_doom_map('map01')
-        self.screen_height = 480                    # Must match .cfg file
-        self.screen_width = 640                     # Must match .cfg file
-        self.game.set_window_visible(False)
-        self.viewer = None
-        self.game.init()
-        self.game.new_episode()
-
-        # 3 allowed actions [0, 10, 11] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
-        self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.action_space.allowed_actions = [0, 10, 11]
-
-        self._seed()
+        self.config = 'basic.cfg'
+        self.scenario = 'basic.wad'
+        self.map = 'map01'
+        self.difficulty = 5
+        self.allowed_actions = [0, 10, 11]

--- a/gym/envs/doom/doom_basic.py
+++ b/gym/envs/doom/doom_basic.py
@@ -20,7 +20,7 @@ class DoomBasicEnv(doom_env.DoomEnv):
     Rewards:
         +101    - Killing the monster
         -  5    - Missing a shot
-        -  1    - Several times per second - Kill the monster faster!
+        -  1    - 35 times per second - Kill the monster faster!
 
     Goal: 10 points
         Kill the monster in 3 secs with 1 shot

--- a/gym/envs/doom/doom_basic.py
+++ b/gym/envs/doom/doom_basic.py
@@ -19,8 +19,8 @@ class DoomBasicEnv(doom_env.DoomEnv):
 
     Allowed actions:
         [0]  - ATTACK                           - Shoot weapon - Values 0 or 1
-        [9]  - MOVE_RIGHT                       - Move to the right - Values 0 or 1
-        [10] - MOVE_LEFT                        - Move to the left - Values 0 or 1
+        [10] - MOVE_RIGHT                       - Move to the right - Values 0 or 1
+        [11] - MOVE_LEFT                        - Move to the left - Values 0 or 1
     Note: see controls.md for details
 
     Rewards:
@@ -54,8 +54,9 @@ class DoomBasicEnv(doom_env.DoomEnv):
         self.game.init()
         self.game.new_episode()
 
-        # 3 allowed actions [0, 9, 10] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 3))
+        # 3 allowed actions [0, 10, 11] (must match .cfg file)
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.allowed_actions = [0, 10, 11]
 
         self._seed()

--- a/gym/envs/doom/doom_basic.py
+++ b/gym/envs/doom/doom_basic.py
@@ -4,9 +4,8 @@ import os
 import numpy as np
 
 from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import error, spaces
+from gym import spaces
 from gym.envs.doom import doom_env
-from gym.utils import seeding
 
 logger = logging.getLogger(__name__)
 
@@ -60,8 +59,3 @@ class DoomBasicEnv(doom_env.DoomEnv):
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
 
         self._seed()
-
-    def _seed(self, seed=None):
-        seed = seeding.hash_seed(seed) % 2**32
-        self.game.set_seed(seed)
-        return [seed]

--- a/gym/envs/doom/doom_basic.py
+++ b/gym/envs/doom/doom_basic.py
@@ -35,6 +35,18 @@ class DoomBasicEnv(doom_env.DoomEnv):
         - Monster is dead
         - Player is dead
         - Timeout (10 seconds - 350 frames)
+
+    Actions:
+    Either of
+        1) action = [0, 1, 0]
+            where parameter #1 is ATTACK (0 or 1)
+            where parameter #2 is MOVE_RIGHT (0 or 1)
+            where parameter #3 is MOVE_LEFT (0 or 1)
+        or
+        2) actions = [0] * 41
+           actions[0] = 0       # ATTACK
+           actions[10] = 1      # MOVE_RIGHT
+           actions[11] = 0      # MOVE_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
@@ -55,8 +67,8 @@ class DoomBasicEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [0, 10, 11] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.allowed_actions = [0, 10, 11]
+        self.action_space.allowed_actions = [0, 10, 11]
 
         self._seed()

--- a/gym/envs/doom/doom_basic.py
+++ b/gym/envs/doom/doom_basic.py
@@ -31,6 +31,11 @@ class DoomBasicEnv(doom_env.DoomEnv):
     Goal: 10 points
         Kill the monster in 3 secs with 1 shot
 
+    Mode:
+        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
+        - 'normal' will run at roughly 30 fps (easier for human to watch)
+
     Ends when:
         - Monster is dead
         - Player is dead

--- a/gym/envs/doom/doom_basic.py
+++ b/gym/envs/doom/doom_basic.py
@@ -43,7 +43,7 @@ class DoomBasicEnv(doom_env.DoomEnv):
             where parameter #2 is MOVE_RIGHT (0 or 1)
             where parameter #3 is MOVE_LEFT (0 or 1)
         or
-        2) actions = [0] * 41       # To train for the Deathmatch level
+        2) actions = [0] * 43       # To train for the Deathmatch level
            actions[0] = 0       # ATTACK
            actions[10] = 1      # MOVE_RIGHT
            actions[11] = 0      # MOVE_LEFT
@@ -67,7 +67,7 @@ class DoomBasicEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [0, 10, 11] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 0, 0]] * 5))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
         self.action_space.allowed_actions = [0, 10, 11]
 

--- a/gym/envs/doom/doom_corridor.py
+++ b/gym/envs/doom/doom_corridor.py
@@ -31,7 +31,12 @@ class DoomCorridorEnv(doom_env.DoomEnv):
         -100    - Penalty for being killed
 
     Goal: 1,270 points
-     Reach the vest (try also killing guards, rather than just running)
+        Reach the vest (try also killing guards, rather than just running)
+
+    Mode:
+        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
+        - 'normal' will run at roughly 30 fps (easier for human to watch)
 
     Ends when:
         - Player touches vest

--- a/gym/envs/doom/doom_corridor.py
+++ b/gym/envs/doom/doom_corridor.py
@@ -49,8 +49,4 @@ class DoomCorridorEnv(doom_env.DoomEnv):
     -----------------------------------------------------
     """
     def __init__(self):
-        super(DoomCorridorEnv, self).__init__()
-        self.config = 'deadly_corridor.cfg'
-        self.scenario = 'deadly_corridor.wad'
-        self.difficulty = 1
-        self.allowed_actions = [0, 10, 11, 13, 14, 15]
+        super(DoomCorridorEnv, self).__init__(1)

--- a/gym/envs/doom/doom_corridor.py
+++ b/gym/envs/doom/doom_corridor.py
@@ -18,11 +18,11 @@ class DoomCorridorEnv(doom_env.DoomEnv):
 
     Allowed actions:
         [0]  - ATTACK                           - Shoot weapon - Values 0 or 1
-        [9]  - MOVE_RIGHT                       - Move to the right - Values 0 or 1
-        [10] - MOVE_LEFT                        - Move to the left - Values 0 or 1
-        [12] - MOVE_FORWARD                     - Move forward - Values 0 or 1
-        [13] - TURN_RIGHT                       - Turn right - Values 0 or 1
-        [14] - TURN_LEFT                        - Turn left - Values 0 or 1
+        [10] - MOVE_RIGHT                       - Move to the right - Values 0 or 1
+        [11] - MOVE_LEFT                        - Move to the left - Values 0 or 1
+        [13] - MOVE_FORWARD                     - Move forward - Values 0 or 1
+        [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+        [15] - TURN_LEFT                        - Turn left - Values 0 or 1
     Note: see controls.md for details
 
     Rewards:
@@ -55,8 +55,9 @@ class DoomCorridorEnv(doom_env.DoomEnv):
         self.game.init()
         self.game.new_episode()
 
-        # action indexes are [0, 9, 10, 12, 13, 14]
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 6))
+        # action indexes are [0, 10, 11, 13, 14, 15]
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.allowed_actions = [0, 10, 11, 13, 14, 15]
 
         self._seed()

--- a/gym/envs/doom/doom_corridor.py
+++ b/gym/envs/doom/doom_corridor.py
@@ -40,7 +40,7 @@ class DoomCorridorEnv(doom_env.DoomEnv):
 
     Actions:
     Either of
-        1) action = [0, 1, 0, 0, 0, 0]
+        1) action = [0, 1, 0, 0, 0, 0]      # Recommended
             where parameter #1 is ATTACK (0 or 1)
             where parameter #2 is MOVE_RIGHT (0 or 1)
             where parameter #3 is MOVE_LEFT (0 or 1)
@@ -48,7 +48,7 @@ class DoomCorridorEnv(doom_env.DoomEnv):
             where parameter #5 is TURN_RIGHT (0 or 1)
             where parameter #6 is TURN_LEFT (0 or 1)
         or
-        2) actions = [0] * 41
+        2) actions = [0] * 41               # To train for the Deathmatch level
            actions[0] = 0       # ATTACK
            actions[10] = 1      # MOVE_RIGHT
            actions[11] = 0      # MOVE_LEFT

--- a/gym/envs/doom/doom_corridor.py
+++ b/gym/envs/doom/doom_corridor.py
@@ -48,7 +48,7 @@ class DoomCorridorEnv(doom_env.DoomEnv):
             where parameter #5 is TURN_RIGHT (0 or 1)
             where parameter #6 is TURN_LEFT (0 or 1)
         or
-        2) actions = [0] * 41               # To train for the Deathmatch level
+        2) actions = [0] * 43               # To train for the Deathmatch level
            actions[0] = 0       # ATTACK
            actions[10] = 1      # MOVE_RIGHT
            actions[11] = 0      # MOVE_LEFT
@@ -74,7 +74,7 @@ class DoomCorridorEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # action indexes are [0, 10, 11, 13, 14, 15]
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
         self.action_space.allowed_actions = [0, 10, 11, 13, 14, 15]
 

--- a/gym/envs/doom/doom_corridor.py
+++ b/gym/envs/doom/doom_corridor.py
@@ -4,9 +4,8 @@ import os
 import numpy as np
 
 from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import error, spaces
+from gym import spaces
 from gym.envs.doom import doom_env
-from gym.utils import seeding
 
 logger = logging.getLogger(__name__)
 
@@ -61,8 +60,3 @@ class DoomCorridorEnv(doom_env.DoomEnv):
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
 
         self._seed()
-
-    def _seed(self, seed=None):
-        seed = seeding.hash_seed(seed) % 2**32
-        self.game.set_seed(seed)
-        return [seed]

--- a/gym/envs/doom/doom_corridor.py
+++ b/gym/envs/doom/doom_corridor.py
@@ -1,10 +1,4 @@
 import logging
-import os
-
-import numpy as np
-
-from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import spaces
 from gym.envs.doom import doom_env
 
 logger = logging.getLogger(__name__)
@@ -30,13 +24,14 @@ class DoomCorridorEnv(doom_env.DoomEnv):
         - dX    - For getting further from the vest
         -100    - Penalty for being killed
 
-    Goal: 1,270 points
-        Reach the vest (try also killing guards, rather than just running)
+    Goal: 1,000 points
+        Reach the vest (or at least get past the guards in the 3rd group)
 
     Mode:
-        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
-        - 'normal' will run at roughly 30 fps (easier for human to watch)
+        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
+        - 'normal' will run at roughly 35 fps (easier for human to watch)
+        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
 
     Ends when:
         - Player touches vest
@@ -44,43 +39,18 @@ class DoomCorridorEnv(doom_env.DoomEnv):
         - Timeout (1 minutes - 2,100 frames)
 
     Actions:
-    Either of
-        1) action = [0, 1, 0, 0, 0, 0]      # Recommended
-            where parameter #1 is ATTACK (0 or 1)
-            where parameter #2 is MOVE_RIGHT (0 or 1)
-            where parameter #3 is MOVE_LEFT (0 or 1)
-            where parameter #4 is MOVE_FORWARD (0 or 1)
-            where parameter #5 is TURN_RIGHT (0 or 1)
-            where parameter #6 is TURN_LEFT (0 or 1)
-        or
-        2) actions = [0] * 43               # To train for the Deathmatch level
-           actions[0] = 0       # ATTACK
-           actions[10] = 1      # MOVE_RIGHT
-           actions[11] = 0      # MOVE_LEFT
-           actions[13] = 0      # MOVE_FORWARD
-           actions[14] = 0      # TURN_RIGHT
-           actions[15] = 0      # TURN_LEFT
+        actions = [0] * 43
+        actions[0] = 0       # ATTACK
+        actions[10] = 1      # MOVE_RIGHT
+        actions[11] = 0      # MOVE_LEFT
+        actions[13] = 0      # MOVE_FORWARD
+        actions[14] = 0      # TURN_RIGHT
+        actions[15] = 0      # TURN_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
         super(DoomCorridorEnv, self).__init__()
-        package_directory = os.path.dirname(os.path.abspath(__file__))
-        self.loader = Loader()
-        self.game = DoomGame()
-        self.game.load_config(os.path.join(package_directory, 'assets/deadly_corridor.cfg'))
-        self.game.set_vizdoom_path(self.loader.get_vizdoom_path())
-        self.game.set_doom_game_path(self.loader.get_freedoom_path())
-        self.game.set_doom_scenario_path(self.loader.get_scenario_path('deadly_corridor.wad'))
-        self.screen_height = 480                    # Must match .cfg file
-        self.screen_width = 640                     # Must match .cfg file
-        self.game.set_window_visible(False)
-        self.viewer = None
-        self.game.init()
-        self.game.new_episode()
-
-        # action indexes are [0, 10, 11, 13, 14, 15]
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
-        self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.action_space.allowed_actions = [0, 10, 11, 13, 14, 15]
-
-        self._seed()
+        self.config = 'deadly_corridor.cfg'
+        self.scenario = 'deadly_corridor.wad'
+        self.difficulty = 1
+        self.allowed_actions = [0, 10, 11, 13, 14, 15]

--- a/gym/envs/doom/doom_corridor.py
+++ b/gym/envs/doom/doom_corridor.py
@@ -37,6 +37,24 @@ class DoomCorridorEnv(doom_env.DoomEnv):
         - Player touches vest
         - Player is dead
         - Timeout (1 minutes - 2,100 frames)
+
+    Actions:
+    Either of
+        1) action = [0, 1, 0, 0, 0, 0]
+            where parameter #1 is ATTACK (0 or 1)
+            where parameter #2 is MOVE_RIGHT (0 or 1)
+            where parameter #3 is MOVE_LEFT (0 or 1)
+            where parameter #4 is MOVE_FORWARD (0 or 1)
+            where parameter #5 is TURN_RIGHT (0 or 1)
+            where parameter #6 is TURN_LEFT (0 or 1)
+        or
+        2) actions = [0] * 41
+           actions[0] = 0       # ATTACK
+           actions[10] = 1      # MOVE_RIGHT
+           actions[11] = 0      # MOVE_LEFT
+           actions[13] = 0      # MOVE_FORWARD
+           actions[14] = 0      # TURN_RIGHT
+           actions[15] = 0      # TURN_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
@@ -56,8 +74,8 @@ class DoomCorridorEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # action indexes are [0, 10, 11, 13, 14, 15]
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.allowed_actions = [0, 10, 11, 13, 14, 15]
+        self.action_space.allowed_actions = [0, 10, 11, 13, 14, 15]
 
         self._seed()

--- a/gym/envs/doom/doom_deathmatch.py
+++ b/gym/envs/doom/doom_deathmatch.py
@@ -29,19 +29,13 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
         - Timeout (3 minutes - 6,300 frames)
 
     Actions:
-        1) actions = [0] * 36
-           actions[0] = 0       # ATTACK
-           actions[1] = 0       # USE
-           [...]
-           actions[35] = 0      # DROP_SELECTED_ITEM
-        or
-        2) actions = [0] * 41
-           actions[0] = 0       # ATTACK
-           actions[1] = 0       # USE
-           [...]
-           actions[40] = 0      # MOVE_UP_DOWN_DELTA
-           N.B. actions 36 to 40 (Deltas) are ignored
-           A full list of possible actions is available in controls.md
+       actions = [0] * 41
+       actions[0] = 0       # ATTACK
+       actions[1] = 0       # USE
+       [...]
+       actions[40] = 0      # MOVE_UP_DOWN_DELTA
+       N.B. actions 36 to 40 (Deltas) are ignored
+       A full list of possible actions is available in controls.md
     -----------------------------------------------------
     """
     def __init__(self):

--- a/gym/envs/doom/doom_deathmatch.py
+++ b/gym/envs/doom/doom_deathmatch.py
@@ -15,7 +15,7 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
     Kill as many monsters as possible without being killed.
 
     Allowed actions:
-        ALL (except Deltas)
+        ALL
     Note: see controls.md for details
 
     Rewards:
@@ -29,12 +29,11 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
         - Timeout (3 minutes - 6,300 frames)
 
     Actions:
-       actions = [0] * 41
+       actions = [0] * 43
        actions[0] = 0       # ATTACK
        actions[1] = 0       # USE
        [...]
-       actions[40] = 0      # MOVE_UP_DOWN_DELTA
-       N.B. actions 36 to 40 (Deltas) are ignored
+       actions[42] = 0      # MOVE_UP_DOWN_DELTA
        A full list of possible actions is available in controls.md
     -----------------------------------------------------
     """
@@ -54,10 +53,10 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
         self.game.init()
         self.game.new_episode()
 
-        # 41 allowed actions (must match .cfg file)
-        # [0 to 35 are either 0 or 1, 36 to 40 (delta) are disabled
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
+        # 43 allowed actions (must match .cfg file)
+        # [0 to 37 are either 0 or 1, 38 and 39 are -10 to +10, 40 to 42 are -100 to +100]
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.action_space.allowed_actions = list(range(36))
+        self.action_space.allowed_actions = list(range(43))
 
         self._seed()

--- a/gym/envs/doom/doom_deathmatch.py
+++ b/gym/envs/doom/doom_deathmatch.py
@@ -21,8 +21,8 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
     Rewards:
         +1      - Killing a monster
 
-    Goal: 25 points
-        Kill 25 monsters without being killed
+    Goal: 20 points
+        Kill 20 monsters without being killed
 
     Ends when:
         - Player is dead

--- a/gym/envs/doom/doom_deathmatch.py
+++ b/gym/envs/doom/doom_deathmatch.py
@@ -4,8 +4,7 @@ import os
 import numpy as np
 
 from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import error, spaces
-from gym.utils import seeding
+from gym import spaces
 from gym.envs.doom import doom_env
 
 logger = logging.getLogger(__name__)
@@ -51,8 +50,3 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
 
         self._seed()
-
-    def _seed(self, seed=None):
-        seed = seeding.hash_seed(seed) % 2**32
-        self.game.set_seed(seed)
-        return [seed]

--- a/gym/envs/doom/doom_deathmatch.py
+++ b/gym/envs/doom/doom_deathmatch.py
@@ -1,10 +1,4 @@
 import logging
-import os
-
-import numpy as np
-
-from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import spaces
 from gym.envs.doom import doom_env
 
 logger = logging.getLogger(__name__)
@@ -22,46 +16,30 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
         +1      - Killing a monster
 
     Goal: 20 points
-        Kill 20 monsters without being killed
+        Kill 20 monsters
 
     Mode:
-        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
-        - 'normal' will run at roughly 30 fps (easier for human to watch)
+        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
+        - 'normal' will run at roughly 35 fps (easier for human to watch)
+        - 'human' will let you play the game (mouse and full keyboard)
 
     Ends when:
         - Player is dead
         - Timeout (3 minutes - 6,300 frames)
 
     Actions:
-       actions = [0] * 43
-       actions[0] = 0       # ATTACK
-       actions[1] = 0       # USE
-       [...]
-       actions[42] = 0      # MOVE_UP_DOWN_DELTA
-       A full list of possible actions is available in controls.md
+        actions = [0] * 43
+        actions[0] = 0       # ATTACK
+        actions[1] = 0       # USE
+        [...]
+        actions[42] = 0      # MOVE_UP_DOWN_DELTA
+        A full list of possible actions is available in controls.md
     -----------------------------------------------------
     """
     def __init__(self):
         super(DoomDeathmatchEnv, self).__init__()
-        package_directory = os.path.dirname(os.path.abspath(__file__))
-        self.loader = Loader()
-        self.game = DoomGame()
-        self.game.load_config(os.path.join(package_directory, 'assets/deathmatch.cfg'))
-        self.game.set_vizdoom_path(self.loader.get_vizdoom_path())
-        self.game.set_doom_game_path(self.loader.get_freedoom_path())
-        self.game.set_doom_scenario_path(self.loader.get_scenario_path('deathmatch.wad'))
-        self.screen_height = 480                    # Must match .cfg file
-        self.screen_width = 640                     # Must match .cfg file
-        self.game.set_window_visible(False)
-        self.viewer = None
-        self.game.init()
-        self.game.new_episode()
-
-        # 43 allowed actions (must match .cfg file)
-        # [0 to 37 are either 0 or 1, 38 and 39 are -10 to +10, 40 to 42 are -100 to +100]
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
-        self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.action_space.allowed_actions = list(range(43))
-
-        self._seed()
+        self.config = 'deathmatch.cfg'
+        self.scenario = 'deathmatch.wad'
+        self.difficulty = 5
+        self.allowed_actions = list(range(43))

--- a/gym/envs/doom/doom_deathmatch.py
+++ b/gym/envs/doom/doom_deathmatch.py
@@ -46,7 +46,9 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 41 allowed actions (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 39 + [[0, 10, 0]] * 5))
+        # [0 to 35 are either 0 or 1, 36 to 40 (delta) are disabled (value of 0)
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.allowed_actions = list(range(41))
 
         self._seed()

--- a/gym/envs/doom/doom_deathmatch.py
+++ b/gym/envs/doom/doom_deathmatch.py
@@ -15,7 +15,7 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
     Kill as many monsters as possible without being killed.
 
     Allowed actions:
-        ALL
+        ALL (except Deltas)
     Note: see controls.md for details
 
     Rewards:
@@ -27,6 +27,21 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
     Ends when:
         - Player is dead
         - Timeout (3 minutes - 6,300 frames)
+
+    Actions:
+        1) actions = [0] * 36
+           actions[0] = 0       # ATTACK
+           actions[1] = 0       # USE
+           [...]
+           actions[35] = 0      # DROP_SELECTED_ITEM
+        or
+        2) actions = [0] * 41
+           actions[0] = 0       # ATTACK
+           actions[1] = 0       # USE
+           [...]
+           actions[40] = 0      # MOVE_UP_DOWN_DELTA
+           N.B. actions 36 to 40 (Deltas) are ignored
+           A full list of possible actions is available in controls.md
     -----------------------------------------------------
     """
     def __init__(self):
@@ -46,9 +61,9 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 41 allowed actions (must match .cfg file)
-        # [0 to 35 are either 0 or 1, 36 to 40 (delta) are disabled (value of 0)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
+        # [0 to 35 are either 0 or 1, 36 to 40 (delta) are disabled
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.allowed_actions = list(range(41))
+        self.action_space.allowed_actions = list(range(36))
 
         self._seed()

--- a/gym/envs/doom/doom_deathmatch.py
+++ b/gym/envs/doom/doom_deathmatch.py
@@ -24,6 +24,11 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
     Goal: 20 points
         Kill 20 monsters without being killed
 
+    Mode:
+        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
+        - 'normal' will run at roughly 30 fps (easier for human to watch)
+
     Ends when:
         - Player is dead
         - Timeout (3 minutes - 6,300 frames)

--- a/gym/envs/doom/doom_deathmatch.py
+++ b/gym/envs/doom/doom_deathmatch.py
@@ -38,8 +38,4 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
     -----------------------------------------------------
     """
     def __init__(self):
-        super(DoomDeathmatchEnv, self).__init__()
-        self.config = 'deathmatch.cfg'
-        self.scenario = 'deathmatch.wad'
-        self.difficulty = 5
-        self.allowed_actions = list(range(43))
+        super(DoomDeathmatchEnv, self).__init__(8)

--- a/gym/envs/doom/doom_defend_center.py
+++ b/gym/envs/doom/doom_defend_center.py
@@ -10,7 +10,7 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
     You will also need to keep an eye on your ammunition level. You are only
     rewarded for kills, so figure out how to stay alive.
 
-    The map is a circle with monsters in the middle. Monsters will
+    The map is a circle with monsters. You are in the middle. Monsters will
     respawn with additional health when killed. Kill as many as you can
     before you run out of ammo.
 

--- a/gym/envs/doom/doom_defend_center.py
+++ b/gym/envs/doom/doom_defend_center.py
@@ -44,7 +44,7 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
             where parameter #2 is TURN_RIGHT (0 or 1)
             where parameter #3 is TURN_LEFT (0 or 1)
         or
-        2) actions = [0] * 41       # To train for the Deathmatch level
+        2) actions = [0] * 43       # To train for the Deathmatch level
            actions[0] = 0       # ATTACK
            actions[14] = 1      # TURN_RIGHT
            actions[15] = 0      # TURN_LEFT
@@ -67,7 +67,7 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [0, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
         self.action_space.allowed_actions = [0, 14, 15]
 

--- a/gym/envs/doom/doom_defend_center.py
+++ b/gym/envs/doom/doom_defend_center.py
@@ -45,8 +45,4 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
     -----------------------------------------------------
     """
     def __init__(self):
-        super(DoomDefendCenterEnv, self).__init__()
-        self.config = 'defend_the_center.cfg'
-        self.scenario = 'defend_the_center.wad'
-        self.difficulty = 3
-        self.allowed_actions = [0, 14, 15]
+        super(DoomDefendCenterEnv, self).__init__(2)

--- a/gym/envs/doom/doom_defend_center.py
+++ b/gym/envs/doom/doom_defend_center.py
@@ -33,6 +33,11 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
     Goal: 10 points
         Kill 10 monsters (you have 26 ammo)
 
+    Mode:
+        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
+        - 'normal' will run at roughly 30 fps (easier for human to watch)
+
     Ends when:
         - Player is dead
         - Timeout (60 seconds - 2100 frames)

--- a/gym/envs/doom/doom_defend_center.py
+++ b/gym/envs/doom/doom_defend_center.py
@@ -39,12 +39,12 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
 
     Actions:
     Either of
-        1) action = [0, 1, 0]
+        1) action = [0, 1, 0]       # Recommended
             where parameter #1 is ATTACK (0 or 1)
             where parameter #2 is TURN_RIGHT (0 or 1)
             where parameter #3 is TURN_LEFT (0 or 1)
         or
-        2) actions = [0] * 41
+        2) actions = [0] * 41       # To train for the Deathmatch level
            actions[0] = 0       # ATTACK
            actions[14] = 1      # TURN_RIGHT
            actions[15] = 0      # TURN_LEFT

--- a/gym/envs/doom/doom_defend_center.py
+++ b/gym/envs/doom/doom_defend_center.py
@@ -36,6 +36,18 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
     Ends when:
         - Player is dead
         - Timeout (60 seconds - 2100 frames)
+
+    Actions:
+    Either of
+        1) action = [0, 1, 0]
+            where parameter #1 is ATTACK (0 or 1)
+            where parameter #2 is TURN_RIGHT (0 or 1)
+            where parameter #3 is TURN_LEFT (0 or 1)
+        or
+        2) actions = [0] * 41
+           actions[0] = 0       # ATTACK
+           actions[14] = 1      # TURN_RIGHT
+           actions[15] = 0      # TURN_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
@@ -55,8 +67,8 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [0, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.allowed_actions = [0, 14, 15]
+        self.action_space.allowed_actions = [0, 14, 15]
 
         self._seed()

--- a/gym/envs/doom/doom_defend_center.py
+++ b/gym/envs/doom/doom_defend_center.py
@@ -22,8 +22,8 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
 
     Allowed actions:
         [0]  - ATTACK                           - Shoot weapon - Values 0 or 1
-        [13] - TURN_RIGHT                       - Turn right - Values 0 or 1
-        [14] - TURN_LEFT                        - Turn left - Values 0 or 1
+        [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+        [15] - TURN_LEFT                        - Turn left - Values 0 or 1
     Note: see controls.md for details
 
     Rewards:
@@ -54,8 +54,9 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
         self.game.init()
         self.game.new_episode()
 
-        # 3 allowed actions [0, 13, 14] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 3))
+        # 3 allowed actions [0, 14, 15] (must match .cfg file)
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.allowed_actions = [0, 14, 15]
 
         self._seed()

--- a/gym/envs/doom/doom_defend_center.py
+++ b/gym/envs/doom/doom_defend_center.py
@@ -4,9 +4,8 @@ import os
 import numpy as np
 
 from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import error, spaces
+from gym import spaces
 from gym.envs.doom import doom_env
-from gym.utils import seeding
 
 logger = logging.getLogger(__name__)
 
@@ -60,8 +59,3 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
 
         self._seed()
-
-    def _seed(self, seed=None):
-        seed = seeding.hash_seed(seed) % 2**32
-        self.game.set_seed(seed)
-        return [seed]

--- a/gym/envs/doom/doom_defend_center.py
+++ b/gym/envs/doom/doom_defend_center.py
@@ -1,10 +1,4 @@
 import logging
-import os
-
-import numpy as np
-
-from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import spaces
 from gym.envs.doom import doom_env
 
 logger = logging.getLogger(__name__)
@@ -27,53 +21,32 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
     Note: see controls.md for details
 
     Rewards:
-        +  1    - Killing the monster
+        +  1    - Killing a monster
         -  1    - Penalty for being killed
 
     Goal: 10 points
-        Kill 10 monsters (you have 26 ammo)
+        Kill 11 monsters (you have 26 ammo)
 
     Mode:
-        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
-        - 'normal' will run at roughly 30 fps (easier for human to watch)
+        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
+        - 'normal' will run at roughly 35 fps (easier for human to watch)
+        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
 
     Ends when:
         - Player is dead
         - Timeout (60 seconds - 2100 frames)
 
     Actions:
-    Either of
-        1) action = [0, 1, 0]       # Recommended
-            where parameter #1 is ATTACK (0 or 1)
-            where parameter #2 is TURN_RIGHT (0 or 1)
-            where parameter #3 is TURN_LEFT (0 or 1)
-        or
-        2) actions = [0] * 43       # To train for the Deathmatch level
-           actions[0] = 0       # ATTACK
-           actions[14] = 1      # TURN_RIGHT
-           actions[15] = 0      # TURN_LEFT
+        actions = [0] * 43
+        actions[0] = 0       # ATTACK
+        actions[14] = 1      # TURN_RIGHT
+        actions[15] = 0      # TURN_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
         super(DoomDefendCenterEnv, self).__init__()
-        package_directory = os.path.dirname(os.path.abspath(__file__))
-        self.loader = Loader()
-        self.game = DoomGame()
-        self.game.load_config(os.path.join(package_directory, 'assets/defend_the_center.cfg'))
-        self.game.set_vizdoom_path(self.loader.get_vizdoom_path())
-        self.game.set_doom_game_path(self.loader.get_freedoom_path())
-        self.game.set_doom_scenario_path(self.loader.get_scenario_path('defend_the_center.wad'))
-        self.screen_height = 480                    # Must match .cfg file
-        self.screen_width = 640                     # Must match .cfg file
-        self.game.set_window_visible(False)
-        self.viewer = None
-        self.game.init()
-        self.game.new_episode()
-
-        # 3 allowed actions [0, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
-        self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.action_space.allowed_actions = [0, 14, 15]
-
-        self._seed()
+        self.config = 'defend_the_center.cfg'
+        self.scenario = 'defend_the_center.wad'
+        self.difficulty = 3
+        self.allowed_actions = [0, 14, 15]

--- a/gym/envs/doom/doom_defend_line.py
+++ b/gym/envs/doom/doom_defend_line.py
@@ -45,8 +45,4 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
     -----------------------------------------------------
     """
     def __init__(self):
-        super(DoomDefendLineEnv, self).__init__()
-        self.config = 'defend_the_line.cfg'
-        self.scenario = 'defend_the_line.wad'
-        self.difficulty = 5
-        self.allowed_actions = [0, 14, 15]
+        super(DoomDefendLineEnv, self).__init__(3)

--- a/gym/envs/doom/doom_defend_line.py
+++ b/gym/envs/doom/doom_defend_line.py
@@ -30,8 +30,8 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
         +  1    - Killing the monster
         -  1    - Penalty for being killed
 
-    Goal: 25 points
-        Kill 25 monsters
+    Goal: 15 points
+        Kill 15 monsters
 
     Ends when:
         - Player is dead

--- a/gym/envs/doom/doom_defend_line.py
+++ b/gym/envs/doom/doom_defend_line.py
@@ -36,6 +36,19 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
     Ends when:
         - Player is dead
         - Timeout (60 seconds - 2100 frames)
+
+
+    Actions:
+    Either of
+        1) action = [0, 1, 0]
+            where parameter #1 is ATTACK (0 or 1)
+            where parameter #2 is TURN_RIGHT (0 or 1)
+            where parameter #3 is TURN_LEFT (0 or 1)
+        or
+        2) actions = [0] * 41
+           actions[0] = 0       # ATTACK
+           actions[14] = 1      # TURN_RIGHT
+           actions[15] = 0      # TURN_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
@@ -55,8 +68,8 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [0, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.allowed_actions = [0, 14, 15]
+        self.action_space.allowed_actions = [0, 14, 15]
 
         self._seed()

--- a/gym/envs/doom/doom_defend_line.py
+++ b/gym/envs/doom/doom_defend_line.py
@@ -1,10 +1,4 @@
 import logging
-import os
-
-import numpy as np
-
-from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import spaces
 from gym.envs.doom import doom_env
 
 logger = logging.getLogger(__name__)
@@ -27,53 +21,32 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
     Note: see controls.md for details
 
     Rewards:
-        +  1    - Killing the monster
+        +  1    - Killing a monster
         -  1    - Penalty for being killed
 
     Goal: 15 points
-        Kill 15 monsters
+        Kill 16 monsters
 
     Mode:
-        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
-        - 'normal' will run at roughly 30 fps (easier for human to watch)
+        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
+        - 'normal' will run at roughly 35 fps (easier for human to watch)
+        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
 
     Ends when:
         - Player is dead
         - Timeout (60 seconds - 2100 frames)
 
     Actions:
-    Either of
-        1) action = [0, 1, 0]       # Recommended
-            where parameter #1 is ATTACK (0 or 1)
-            where parameter #2 is TURN_RIGHT (0 or 1)
-            where parameter #3 is TURN_LEFT (0 or 1)
-        or
-        2) actions = [0] * 43       # To train for the Deathmatch level
-           actions[0] = 0       # ATTACK
-           actions[14] = 1      # TURN_RIGHT
-           actions[15] = 0      # TURN_LEFT
+        actions = [0] * 43
+        actions[0] = 0       # ATTACK
+        actions[14] = 1      # TURN_RIGHT
+        actions[15] = 0      # TURN_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
         super(DoomDefendLineEnv, self).__init__()
-        package_directory = os.path.dirname(os.path.abspath(__file__))
-        self.loader = Loader()
-        self.game = DoomGame()
-        self.game.load_config(os.path.join(package_directory, 'assets/defend_the_line.cfg'))
-        self.game.set_vizdoom_path(self.loader.get_vizdoom_path())
-        self.game.set_doom_game_path(self.loader.get_freedoom_path())
-        self.game.set_doom_scenario_path(self.loader.get_scenario_path('defend_the_line.wad'))
-        self.screen_height = 480                    # Must match .cfg file
-        self.screen_width = 640                     # Must match .cfg file
-        self.game.set_window_visible(False)
-        self.viewer = None
-        self.game.init()
-        self.game.new_episode()
-
-        # 3 allowed actions [0, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
-        self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.action_space.allowed_actions = [0, 14, 15]
-
-        self._seed()
+        self.config = 'defend_the_line.cfg'
+        self.scenario = 'defend_the_line.wad'
+        self.difficulty = 5
+        self.allowed_actions = [0, 14, 15]

--- a/gym/envs/doom/doom_defend_line.py
+++ b/gym/envs/doom/doom_defend_line.py
@@ -44,7 +44,7 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
             where parameter #2 is TURN_RIGHT (0 or 1)
             where parameter #3 is TURN_LEFT (0 or 1)
         or
-        2) actions = [0] * 41       # To train for the Deathmatch level
+        2) actions = [0] * 43       # To train for the Deathmatch level
            actions[0] = 0       # ATTACK
            actions[14] = 1      # TURN_RIGHT
            actions[15] = 0      # TURN_LEFT
@@ -67,7 +67,7 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [0, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
         self.action_space.allowed_actions = [0, 14, 15]
 

--- a/gym/envs/doom/doom_defend_line.py
+++ b/gym/envs/doom/doom_defend_line.py
@@ -4,9 +4,8 @@ import os
 import numpy as np
 
 from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import error, spaces
+from gym import spaces
 from gym.envs.doom import doom_env
-from gym.utils import seeding
 
 logger = logging.getLogger(__name__)
 
@@ -52,14 +51,11 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
         self.screen_width = 640                     # Must match .cfg file
         self.game.set_window_visible(False)
         self.viewer = None
-        # 3 allowed actions [0, 13, 14] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 3))
-        self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self._seed()
         self.game.init()
         self.game.new_episode()
 
-    def _seed(self, seed=None):
-        seed = seeding.hash_seed(seed) % 2**32
-        self.game.set_seed(seed)
-        return [seed]
+        # 3 allowed actions [0, 13, 14] (must match .cfg file)
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 3))
+        self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+
+        self._seed()

--- a/gym/envs/doom/doom_defend_line.py
+++ b/gym/envs/doom/doom_defend_line.py
@@ -33,6 +33,11 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
     Goal: 15 points
         Kill 15 monsters
 
+    Mode:
+        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
+        - 'normal' will run at roughly 30 fps (easier for human to watch)
+
     Ends when:
         - Player is dead
         - Timeout (60 seconds - 2100 frames)

--- a/gym/envs/doom/doom_defend_line.py
+++ b/gym/envs/doom/doom_defend_line.py
@@ -10,7 +10,7 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
     Your ammo will automatically replenish. You are only rewarded for kills,
     so figure out how to stay alive.
 
-    The map is a rectangle with monsters in the middle. Monsters will
+    The map is a rectangle with monsters on the other side. Monsters will
     respawn with additional health when killed. Kill as many as you can
     before they kill you. This map is harder than the previous.
 

--- a/gym/envs/doom/doom_defend_line.py
+++ b/gym/envs/doom/doom_defend_line.py
@@ -37,15 +37,14 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
         - Player is dead
         - Timeout (60 seconds - 2100 frames)
 
-
     Actions:
     Either of
-        1) action = [0, 1, 0]
+        1) action = [0, 1, 0]       # Recommended
             where parameter #1 is ATTACK (0 or 1)
             where parameter #2 is TURN_RIGHT (0 or 1)
             where parameter #3 is TURN_LEFT (0 or 1)
         or
-        2) actions = [0] * 41
+        2) actions = [0] * 41       # To train for the Deathmatch level
            actions[0] = 0       # ATTACK
            actions[14] = 1      # TURN_RIGHT
            actions[15] = 0      # TURN_LEFT

--- a/gym/envs/doom/doom_defend_line.py
+++ b/gym/envs/doom/doom_defend_line.py
@@ -22,8 +22,8 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
 
     Allowed actions:
         [0]  - ATTACK                           - Shoot weapon - Values 0 or 1
-        [13] - TURN_RIGHT                       - Turn right - Values 0 or 1
-        [14] - TURN_LEFT                        - Turn left - Values 0 or 1
+        [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+        [15] - TURN_LEFT                        - Turn left - Values 0 or 1
     Note: see controls.md for details
 
     Rewards:
@@ -54,8 +54,9 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
         self.game.init()
         self.game.new_episode()
 
-        # 3 allowed actions [0, 13, 14] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 3))
+        # 3 allowed actions [0, 14, 15] (must match .cfg file)
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.allowed_actions = [0, 14, 15]
 
         self._seed()

--- a/gym/envs/doom/doom_env.py
+++ b/gym/envs/doom/doom_env.py
@@ -21,8 +21,9 @@ class DoomEnv(gym.Env, utils.EzPickle):
         utils.EzPickle.__init__(self)
 
     def _step(self, action):
-        # action is a np array but DoomGame.make_action expects a list of ints
-        list_action = [int(x) for x in action]
+        # action is a list of numbers but DoomGame.make_action expects a list of ints
+        # Only passing allowed actions
+        list_action = [int(action[x]) for x in self.allowed_actions]
         try:
             state = self.game.get_state()
             reward = self.game.make_action(list_action)

--- a/gym/envs/doom/doom_env.py
+++ b/gym/envs/doom/doom_env.py
@@ -31,6 +31,7 @@ class DoomEnv(gym.Env, utils.EzPickle):
         self.map = ''                               # Map
         self.difficulty = 5                         # Difficulty (1 = Easy, 10 = Impossible)
         self.viewer = None
+        self.is_initialized = False                 # Indicates that reset() has been called
         self.screen_height = 480
         self.screen_width = 640
         self.action_space = spaces.HighLow(
@@ -66,7 +67,11 @@ class DoomEnv(gym.Env, utils.EzPickle):
             return np.zeros(shape=self.observation_space.shape, dtype=np.uint8), 0, True, {}
 
     def _reset(self):
+        if self.is_initialized and not self._closed:
+            self.game.new_episode()
+            return self.game.get_state().image_buffer.copy()
         self._closed = False
+
         package_directory = os.path.dirname(os.path.abspath(__file__))
 
         # Common settings
@@ -89,6 +94,7 @@ class DoomEnv(gym.Env, utils.EzPickle):
             self.no_render = False
             self.game.init()
             self.game.new_episode()
+            self.is_initialized = True
             return self.game.get_state().image_buffer.copy()
 
         # Human mode
@@ -99,6 +105,7 @@ class DoomEnv(gym.Env, utils.EzPickle):
             self.no_render = True
             self.game.init()
             self.game.new_episode()
+            self.is_initialized = True
 
             while not self.game.is_episode_finished():
                 self.game.advance_action()

--- a/gym/envs/doom/doom_env.py
+++ b/gym/envs/doom/doom_env.py
@@ -1,7 +1,7 @@
 import logging
 from time import sleep
 
-import numpy
+import numpy as np
 
 import gym
 from gym import utils
@@ -32,12 +32,13 @@ class DoomEnv(gym.Env, utils.EzPickle):
             reward = self.game.make_action(list_action)
             if self.game.is_episode_finished():
                 is_finished = True
+                return np.zeros(shape=self.observation_space.shape), reward, is_finished, {}
             else:
                 is_finished = False
-            return state.image_buffer.copy(), reward, is_finished, {}
+                return state.image_buffer.copy(), reward, is_finished, {}
 
         except doom_py.vizdoom.ViZDoomIsNotRunningException:
-            return [], 0, True, {}
+            return np.zeros(shape=self.observation_space.shape), 0, True, {}
 
     def _reset(self):
         self.game.new_episode()
@@ -56,7 +57,7 @@ class DoomEnv(gym.Env, utils.EzPickle):
             # VizDoom returns None if the episode is finished, let's make it
             # an empty image so the recorder doesn't stop
             if img is None:
-                img = numpy.zeros((self.screen_height, self.screen_width, 3), dtype=numpy.uint8)
+                img = np.zeros(shape=self.observation_space.shape)
             if mode == 'rgb_array':
                 return img
             elif mode is 'human':

--- a/gym/envs/doom/doom_env.py
+++ b/gym/envs/doom/doom_env.py
@@ -19,6 +19,7 @@ class DoomEnv(gym.Env, utils.EzPickle):
 
     def __init__(self):
         utils.EzPickle.__init__(self)
+        self.mode = 'fast'
 
     def _step(self, action):
         # action is a list of numbers but DoomGame.make_action expects a list of ints
@@ -65,7 +66,8 @@ class DoomEnv(gym.Env, utils.EzPickle):
                 if self.viewer is None:
                     self.viewer = rendering.SimpleImageViewer()
                 self.viewer.imshow(img)
-                sleep(0.02857)  # 35 fps = 0.02857 sleep between frames
+                if 'fast' != self.mode:
+                    sleep(0.02857)  # 35 fps = 0.02857 sleep between frames
         except doom_py.vizdoom.ViZDoomIsNotRunningException:
             pass # Doom has been closed
 

--- a/gym/envs/doom/doom_env.py
+++ b/gym/envs/doom/doom_env.py
@@ -1,49 +1,117 @@
-import logging
+import logging, warnings, os
 from time import sleep
 
 import numpy as np
 
 import gym
-from gym import utils
+from gym import utils, spaces
 from gym.utils import seeding
 
 try:
     import doom_py
+    from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
 except ImportError as e:
     raise gym.error.DependencyNotInstalled("{}. (HINT: you can install Doom dependencies with 'pip install gym[doom].)'".format(e))
 
 logger = logging.getLogger(__name__)
 
 class DoomEnv(gym.Env, utils.EzPickle):
-    metadata = {'render.modes': ['human', 'rgb_array']}
+    metadata = {'render.modes': ['human', 'rgb_array'], 'video.frames_per_second': 35}
 
     def __init__(self):
         utils.EzPickle.__init__(self)
-        self.mode = 'fast'
+        self.game = DoomGame()
+        self.mode = 'fast'                          # 'human', 'fast' or 'normal'
+        self.no_render = False                      # To disable double rendering in human mode
+        self.config = ''                            # Configuration file
+        self.scenario = ''                          # Scenario file
+        self.map = ''                               # Map
+        self.difficulty = 5                         # Difficulty (1 = Easy, 10 = Impossible)
+        self.viewer = None
+        self.screen_height = 480
+        self.screen_width = 640
+        self.action_space = spaces.HighLow(
+            np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3, dtype=np.int8))
+        self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.allowed_actions = list(range(43))
 
     def _step(self, action):
+        if 43 != len(action):
+            warnings.warn('Doom action list must contain 43 items. Padding missing items with 0')
+            old_action = action
+            action = [0] * 43
+            for i in range(len(old_action)):
+                action[i] = old_action[i]
         # action is a list of numbers but DoomGame.make_action expects a list of ints
-        if len(action) > len(self.action_space.allowed_actions):
-            # Long list of actions passed
-            list_action = [int(action[x]) for x in self.action_space.allowed_actions]
+        if len(self.allowed_actions) > 0:
+            list_action = [int(action[x]) for x in self.allowed_actions]
         else:
             list_action = [int(x) for x in action]
         try:
-            state = self.game.get_state()
             reward = self.game.make_action(list_action)
+            state = self.game.get_state()
+            info = self._get_game_variables(state.game_variables, self.game.get_total_reward())
+
             if self.game.is_episode_finished():
                 is_finished = True
-                return np.zeros(shape=self.observation_space.shape), reward, is_finished, {}
+                return np.zeros(shape=self.observation_space.shape, dtype=np.uint8), reward, is_finished, info
             else:
                 is_finished = False
-                return state.image_buffer.copy(), reward, is_finished, {}
+                return state.image_buffer.copy(), reward, is_finished, info
 
         except doom_py.vizdoom.ViZDoomIsNotRunningException:
-            return np.zeros(shape=self.observation_space.shape), 0, True, {}
+            return np.zeros(shape=self.observation_space.shape, dtype=np.uint8), 0, True, {}
 
     def _reset(self):
-        self.game.new_episode()
-        return self.game.get_state().image_buffer.copy()
+        self._closed = False
+        package_directory = os.path.dirname(os.path.abspath(__file__))
+
+        # Common settings
+        self.loader = Loader()
+        self.game = DoomGame()
+        if self.config != '':
+            self.game.load_config(os.path.join(package_directory, 'assets/%s' % self.config))
+        self.game.set_vizdoom_path(self.loader.get_vizdoom_path())
+        self.game.set_doom_game_path(self.loader.get_freedoom_path())
+        if self.scenario != '':
+            self.game.set_doom_scenario_path(self.loader.get_scenario_path(self.scenario))
+        if self.map != '':
+            self.game.set_doom_map(self.map)
+        self.game.set_doom_skill(self.difficulty)
+
+        # Algo mode
+        if 'human' != self.mode:
+            self.game.set_window_visible(False)
+            self.game.set_mode(Mode.PLAYER)
+            self.no_render = False
+            self.game.init()
+            self.game.new_episode()
+            return self.game.get_state().image_buffer.copy()
+
+        # Human mode
+        else:
+            self.game.add_game_args('+freelook 1')
+            self.game.set_window_visible(True)
+            self.game.set_mode(Mode.SPECTATOR)
+            self.no_render = True
+            self.game.init()
+            self.game.new_episode()
+
+            while not self.game.is_episode_finished():
+                self.game.advance_action()
+                state = self.game.get_state()
+                info = state.game_variables
+                total_reward = self.game.get_total_reward()
+                print('===============================')
+                print('State: #' + str(state.number))
+                print('Action: \t' + str(self.game.get_last_action()) + '\t (=> only allowed actions)')
+                print('Reward: \t' + str(self.game.get_last_reward()))
+                print('Total Reward: \t' + str(total_reward))
+                print('Variables: \n' + str(self._get_game_variables(info, total_reward)))
+                sleep(0.02857)  # 35 fps = 0.02857 sleep between frames
+            print('===============================')
+            print('Done')
+            return
 
     def _render(self, mode='human', close=False):
         if close:
@@ -53,12 +121,13 @@ class DoomEnv(gym.Env, utils.EzPickle):
                 self.viewer = None
             return
         try:
+            if 'human' == mode and self.no_render: return
             state = self.game.get_state()
             img = state.image_buffer
             # VizDoom returns None if the episode is finished, let's make it
             # an empty image so the recorder doesn't stop
             if img is None:
-                img = np.zeros(shape=self.observation_space.shape)
+                img = np.zeros(shape=self.observation_space.shape, dtype=np.uint8)
             if mode == 'rgb_array':
                 return img
             elif mode is 'human':
@@ -66,7 +135,7 @@ class DoomEnv(gym.Env, utils.EzPickle):
                 if self.viewer is None:
                     self.viewer = rendering.SimpleImageViewer()
                 self.viewer.imshow(img)
-                if 'fast' != self.mode:
+                if 'normal' == self.mode:
                     sleep(0.02857)  # 35 fps = 0.02857 sleep between frames
         except doom_py.vizdoom.ViZDoomIsNotRunningException:
             pass # Doom has been closed
@@ -78,3 +147,31 @@ class DoomEnv(gym.Env, utils.EzPickle):
         seed = seeding.hash_seed(seed) % 2 ** 32
         self.game.set_seed(seed)
         return [seed]
+
+    def _get_game_variables(self, state_variables, total_reward):
+        info = {}
+        if state_variables is None: return info
+        info['KILLCOUNT'] = state_variables[0]
+        info['ITEMCOUNT'] = state_variables[1]
+        info['SECRETCOUNT'] = state_variables[2]
+        info['FRAGCOUNT'] = state_variables[3]
+        info['HEALTH'] = state_variables[4]
+        info['ARMOR'] = state_variables[5]
+        info['DEAD'] = state_variables[6]
+        info['ON_GROUND'] = state_variables[7]
+        info['ATTACK_READY'] = state_variables[8]
+        info['ALTATTACK_READY'] = state_variables[9]
+        info['SELECTED_WEAPON'] = state_variables[10]
+        info['SELECTED_WEAPON_AMMO'] = state_variables[11]
+        info['AMMO1'] = state_variables[12]
+        info['AMMO2'] = state_variables[13]
+        info['AMMO3'] = state_variables[14]
+        info['AMMO4'] = state_variables[15]
+        info['AMMO5'] = state_variables[16]
+        info['AMMO6'] = state_variables[17]
+        info['AMMO7'] = state_variables[18]
+        info['AMMO8'] = state_variables[19]
+        info['AMMO9'] = state_variables[20]
+        info['AMMO0'] = state_variables[21]
+        info['TOTAL_REWARD'] = total_reward
+        return info

--- a/gym/envs/doom/doom_env.py
+++ b/gym/envs/doom/doom_env.py
@@ -15,6 +15,9 @@ except ImportError as e:
 
 logger = logging.getLogger(__name__)
 
+# Constants
+NUM_ACTIONS = 43
+
 class DoomEnv(gym.Env, utils.EzPickle):
     metadata = {'render.modes': ['human', 'rgb_array'], 'video.frames_per_second': 35}
 
@@ -33,18 +36,18 @@ class DoomEnv(gym.Env, utils.EzPickle):
         self.action_space = spaces.HighLow(
             np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3, dtype=np.int8))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.allowed_actions = list(range(43))
+        self.allowed_actions = list(range(NUM_ACTIONS))
 
     def _step(self, action):
-        if 43 != len(action):
-            logger.warn('Doom action list must contain 43 items. Padding missing items with 0')
+        if NUM_ACTIONS != len(action):
+            logger.warn('Doom action list must contain %d items. Padding missing items with 0' % NUM_ACTIONS)
             old_action = action
-            action = [0] * 43
+            action = [0] * NUM_ACTIONS
             for i in range(len(old_action)):
                 action[i] = old_action[i]
         # action is a list of numbers but DoomGame.make_action expects a list of ints
         if len(self.allowed_actions) > 0:
-            list_action = [int(action[x]) for x in self.allowed_actions]
+            list_action = [int(action[action_idx]) for action_idx in self.allowed_actions]
         else:
             list_action = [int(x) for x in action]
         try:

--- a/gym/envs/doom/doom_env.py
+++ b/gym/envs/doom/doom_env.py
@@ -22,8 +22,11 @@ class DoomEnv(gym.Env, utils.EzPickle):
 
     def _step(self, action):
         # action is a list of numbers but DoomGame.make_action expects a list of ints
-        # Only passing allowed actions
-        list_action = [int(action[x]) for x in self.allowed_actions]
+        if len(action) > len(self.action_space.allowed_actions):
+            # Long list of actions passed
+            list_action = [int(action[x]) for x in self.action_space.allowed_actions]
+        else:
+            list_action = [int(x) for x in action]
         try:
             state = self.game.get_state()
             reward = self.game.make_action(list_action)

--- a/gym/envs/doom/doom_env.py
+++ b/gym/envs/doom/doom_env.py
@@ -1,4 +1,4 @@
-import logging, warnings, os
+import logging, os
 from time import sleep
 
 import numpy as np
@@ -37,7 +37,7 @@ class DoomEnv(gym.Env, utils.EzPickle):
 
     def _step(self, action):
         if 43 != len(action):
-            warnings.warn('Doom action list must contain 43 items. Padding missing items with 0')
+            logger.warn('Doom action list must contain 43 items. Padding missing items with 0')
             old_action = action
             action = [0] * 43
             for i in range(len(old_action)):

--- a/gym/envs/doom/doom_env.py
+++ b/gym/envs/doom/doom_env.py
@@ -5,6 +5,7 @@ import numpy
 
 import gym
 from gym import utils
+from gym.utils import seeding
 
 try:
     import doom_py
@@ -65,3 +66,8 @@ class DoomEnv(gym.Env, utils.EzPickle):
 
     def _close(self):
         self.game.close()
+
+    def _seed(self, seed=None):
+        seed = seeding.hash_seed(seed) % 2 ** 32
+        self.game.set_seed(seed)
+        return [seed]

--- a/gym/envs/doom/doom_health_gathering.py
+++ b/gym/envs/doom/doom_health_gathering.py
@@ -18,7 +18,7 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
     Note: see controls.md for details
 
     Rewards:
-        +  1    - Several times per second - Survive as long as possible
+        +  1    - 35 times per second - Survive as long as possible
         -100    - Death penalty
 
     Goal: 1000 points

--- a/gym/envs/doom/doom_health_gathering.py
+++ b/gym/envs/doom/doom_health_gathering.py
@@ -42,9 +42,4 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
     -----------------------------------------------------
     """
     def __init__(self):
-        super(DoomHealthGatheringEnv, self).__init__()
-        self.config = 'health_gathering.cfg'
-        self.scenario = 'health_gathering.wad'
-        self.map = 'map01'
-        self.difficulty = 5
-        self.allowed_actions = [13, 14, 15]
+        super(DoomHealthGatheringEnv, self).__init__(4)

--- a/gym/envs/doom/doom_health_gathering.py
+++ b/gym/envs/doom/doom_health_gathering.py
@@ -33,6 +33,18 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
     Ends when:
         - Player is dead
         - Timeout (60 seconds - 2,100 frames)
+
+    Actions:
+    Either of
+        1) action = [0, 1, 0]
+            where parameter #1 is MOVE_FORWARD (0 or 1)
+            where parameter #2 is TURN_RIGHT (0 or 1)
+            where parameter #3 is TURN_LEFT (0 or 1)
+        or
+        2) actions = [0] * 41
+           actions[13] = 0      # MOVE_FORWARD
+           actions[14] = 1      # TURN_RIGHT
+           actions[15] = 0      # TURN_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
@@ -53,8 +65,8 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [13, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.allowed_actions = [13, 14, 15]
+        self.action_space.allowed_actions = [13, 14, 15]
 
         self._seed()

--- a/gym/envs/doom/doom_health_gathering.py
+++ b/gym/envs/doom/doom_health_gathering.py
@@ -4,9 +4,8 @@ import os
 import numpy as np
 
 from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import error, spaces
+from gym import spaces
 from gym.envs.doom import doom_env
-from gym.utils import seeding
 
 logger = logging.getLogger(__name__)
 
@@ -58,8 +57,3 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
 
         self._seed()
-
-    def _seed(self, seed=None):
-        seed = seeding.hash_seed(seed) % 2**32
-        self.game.set_seed(seed)
-        return [seed]

--- a/gym/envs/doom/doom_health_gathering.py
+++ b/gym/envs/doom/doom_health_gathering.py
@@ -41,7 +41,7 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
             where parameter #2 is TURN_RIGHT (0 or 1)
             where parameter #3 is TURN_LEFT (0 or 1)
         or
-        2) actions = [0] * 41       # To train for the Deathmatch level
+        2) actions = [0] * 43       # To train for the Deathmatch level
            actions[13] = 0      # MOVE_FORWARD
            actions[14] = 1      # TURN_RIGHT
            actions[15] = 0      # TURN_LEFT
@@ -65,7 +65,7 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [13, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
         self.action_space.allowed_actions = [13, 14, 15]
 

--- a/gym/envs/doom/doom_health_gathering.py
+++ b/gym/envs/doom/doom_health_gathering.py
@@ -1,10 +1,4 @@
 import logging
-import os
-
-import numpy as np
-
-from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import spaces
 from gym.envs.doom import doom_env
 
 logger = logging.getLogger(__name__)
@@ -31,47 +25,26 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
         Stay alive long enough to reach 1,000 points (~ 30 secs)
 
     Mode:
-        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
-        - 'normal' will run at roughly 30 fps (easier for human to watch)
+        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
+        - 'normal' will run at roughly 35 fps (easier for human to watch)
+        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
 
     Ends when:
         - Player is dead
         - Timeout (60 seconds - 2,100 frames)
 
     Actions:
-    Either of
-        1) action = [0, 1, 0]       # Recommended
-            where parameter #1 is MOVE_FORWARD (0 or 1)
-            where parameter #2 is TURN_RIGHT (0 or 1)
-            where parameter #3 is TURN_LEFT (0 or 1)
-        or
-        2) actions = [0] * 43       # To train for the Deathmatch level
-           actions[13] = 0      # MOVE_FORWARD
-           actions[14] = 1      # TURN_RIGHT
-           actions[15] = 0      # TURN_LEFT
+        actions = [0] * 43
+        actions[13] = 0      # MOVE_FORWARD
+        actions[14] = 1      # TURN_RIGHT
+        actions[15] = 0      # TURN_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
         super(DoomHealthGatheringEnv, self).__init__()
-        package_directory = os.path.dirname(os.path.abspath(__file__))
-        self.loader = Loader()
-        self.game = DoomGame()
-        self.game.load_config(os.path.join(package_directory, 'assets/health_gathering.cfg'))
-        self.game.set_vizdoom_path(self.loader.get_vizdoom_path())
-        self.game.set_doom_game_path(self.loader.get_freedoom_path())
-        self.game.set_doom_scenario_path(self.loader.get_scenario_path('health_gathering.wad'))
-        self.game.set_doom_map('map01')
-        self.screen_height = 480                    # Must match .cfg file
-        self.screen_width = 640                     # Must match .cfg file
-        self.game.set_window_visible(False)
-        self.viewer = None
-        self.game.init()
-        self.game.new_episode()
-
-        # 3 allowed actions [13, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
-        self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.action_space.allowed_actions = [13, 14, 15]
-
-        self._seed()
+        self.config = 'health_gathering.cfg'
+        self.scenario = 'health_gathering.wad'
+        self.map = 'map01'
+        self.difficulty = 5
+        self.allowed_actions = [13, 14, 15]

--- a/gym/envs/doom/doom_health_gathering.py
+++ b/gym/envs/doom/doom_health_gathering.py
@@ -36,12 +36,12 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
 
     Actions:
     Either of
-        1) action = [0, 1, 0]
+        1) action = [0, 1, 0]       # Recommended
             where parameter #1 is MOVE_FORWARD (0 or 1)
             where parameter #2 is TURN_RIGHT (0 or 1)
             where parameter #3 is TURN_LEFT (0 or 1)
         or
-        2) actions = [0] * 41
+        2) actions = [0] * 41       # To train for the Deathmatch level
            actions[13] = 0      # MOVE_FORWARD
            actions[14] = 1      # TURN_RIGHT
            actions[15] = 0      # TURN_LEFT

--- a/gym/envs/doom/doom_health_gathering.py
+++ b/gym/envs/doom/doom_health_gathering.py
@@ -30,6 +30,11 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
     Goal: 1000 points
         Stay alive long enough to reach 1,000 points (~ 30 secs)
 
+    Mode:
+        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
+        - 'normal' will run at roughly 30 fps (easier for human to watch)
+
     Ends when:
         - Player is dead
         - Timeout (60 seconds - 2,100 frames)

--- a/gym/envs/doom/doom_health_gathering.py
+++ b/gym/envs/doom/doom_health_gathering.py
@@ -18,9 +18,9 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
     additional kits will spawn at interval.
 
     Allowed actions:
-        [12] - MOVE_FORWARD                     - Move forward - Values 0 or 1
-        [13] - TURN_RIGHT                       - Turn right - Values 0 or 1
-        [14] - TURN_LEFT                        - Turn left - Values 0 or 1
+        [13] - MOVE_FORWARD                     - Move forward - Values 0 or 1
+        [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+        [15] - TURN_LEFT                        - Turn left - Values 0 or 1
     Note: see controls.md for details
 
     Rewards:
@@ -52,8 +52,9 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
         self.game.init()
         self.game.new_episode()
 
-        # 3 allowed actions [12, 13, 14] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 3))
+        # 3 allowed actions [13, 14, 15] (must match .cfg file)
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.allowed_actions = [13, 14, 15]
 
         self._seed()

--- a/gym/envs/doom/doom_my_way_home.py
+++ b/gym/envs/doom/doom_my_way_home.py
@@ -36,12 +36,12 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
 
     Actions:
     Either of
-        1) action = [0, 1, 0]
+        1) action = [0, 1, 0]       # Recommended
             where parameter #1 is MOVE_FORWARD (0 or 1)
             where parameter #2 is TURN_RIGHT (0 or 1)
             where parameter #3 is TURN_LEFT (0 or 1)
         or
-        2) actions = [0] * 41
+        2) actions = [0] * 41       # To train for the Deathmatch level
            actions[13] = 0      # MOVE_FORWARD
            actions[14] = 1      # TURN_RIGHT
            actions[15] = 0      # TURN_LEFT

--- a/gym/envs/doom/doom_my_way_home.py
+++ b/gym/envs/doom/doom_my_way_home.py
@@ -4,9 +4,8 @@ import os
 import numpy as np
 
 from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import error, spaces
+from gym import spaces
 from gym.envs.doom import doom_env
-from gym.utils import seeding
 
 logger = logging.getLogger(__name__)
 
@@ -57,8 +56,3 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
 
         self._seed()
-
-    def _seed(self, seed=None):
-        seed = seeding.hash_seed(seed) % 2**32
-        self.game.set_seed(seed)
-        return [seed]

--- a/gym/envs/doom/doom_my_way_home.py
+++ b/gym/envs/doom/doom_my_way_home.py
@@ -33,6 +33,18 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
     Ends when:
         - Vest is found
         - Timeout (2 minutes - 4,200 frames)
+
+    Actions:
+    Either of
+        1) action = [0, 1, 0]
+            where parameter #1 is MOVE_FORWARD (0 or 1)
+            where parameter #2 is TURN_RIGHT (0 or 1)
+            where parameter #3 is TURN_LEFT (0 or 1)
+        or
+        2) actions = [0] * 41
+           actions[13] = 0      # MOVE_FORWARD
+           actions[14] = 1      # TURN_RIGHT
+           actions[15] = 0      # TURN_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
@@ -52,8 +64,8 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [13, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.allowed_actions = [13, 14, 15]
+        self.action_space.allowed_actions = [13, 14, 15]
 
         self._seed()

--- a/gym/envs/doom/doom_my_way_home.py
+++ b/gym/envs/doom/doom_my_way_home.py
@@ -18,9 +18,9 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
     The vest is always in the same room. Player must find the vest.
 
     Allowed actions:
-        [12] - MOVE_FORWARD                     - Move forward - Values 0 or 1
-        [13] - TURN_RIGHT                       - Turn right - Values 0 or 1
-        [14] - TURN_LEFT                        - Turn left - Values 0 or 1
+        [13] - MOVE_FORWARD                     - Move forward - Values 0 or 1
+        [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+        [15] - TURN_LEFT                        - Turn left - Values 0 or 1
     Note: see controls.md for details
 
     Rewards:
@@ -51,8 +51,9 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
         self.game.init()
         self.game.new_episode()
 
-        # 3 allowed actions [12, 13, 14] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 3))
+        # 3 allowed actions [13, 14, 15] (must match .cfg file)
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.allowed_actions = [13, 14, 15]
 
         self._seed()

--- a/gym/envs/doom/doom_my_way_home.py
+++ b/gym/envs/doom/doom_my_way_home.py
@@ -32,7 +32,7 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
 
     Ends when:
         - Vest is found
-        - Timeout (2 minutes - 4,200 frames)
+        - Timeout (1 minutes - 2,100 frames)
 
     Actions:
         actions = [0] * 43
@@ -42,8 +42,4 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
     -----------------------------------------------------
     """
     def __init__(self):
-        super(DoomMyWayHomeEnv, self).__init__()
-        self.config = 'my_way_home.cfg'
-        self.scenario = 'my_way_home.wad'
-        self.difficulty = 5
-        self.allowed_actions = [13, 14, 15]
+        super(DoomMyWayHomeEnv, self).__init__(5)

--- a/gym/envs/doom/doom_my_way_home.py
+++ b/gym/envs/doom/doom_my_way_home.py
@@ -30,6 +30,11 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
     Goal: 0.50 point
         Find the vest
 
+    Mode:
+        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
+        - 'normal' will run at roughly 30 fps (easier for human to watch)
+
     Ends when:
         - Vest is found
         - Timeout (2 minutes - 4,200 frames)

--- a/gym/envs/doom/doom_my_way_home.py
+++ b/gym/envs/doom/doom_my_way_home.py
@@ -1,10 +1,4 @@
 import logging
-import os
-
-import numpy as np
-
-from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import spaces
 from gym.envs.doom import doom_env
 
 logger = logging.getLogger(__name__)
@@ -31,46 +25,25 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
         Find the vest
 
     Mode:
-        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
-        - 'normal' will run at roughly 30 fps (easier for human to watch)
+        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
+        - 'normal' will run at roughly 35 fps (easier for human to watch)
+        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
 
     Ends when:
         - Vest is found
         - Timeout (2 minutes - 4,200 frames)
 
     Actions:
-    Either of
-        1) action = [0, 1, 0]       # Recommended
-            where parameter #1 is MOVE_FORWARD (0 or 1)
-            where parameter #2 is TURN_RIGHT (0 or 1)
-            where parameter #3 is TURN_LEFT (0 or 1)
-        or
-        2) actions = [0] * 43       # To train for the Deathmatch level
-           actions[13] = 0      # MOVE_FORWARD
-           actions[14] = 1      # TURN_RIGHT
-           actions[15] = 0      # TURN_LEFT
+        actions = [0] * 43
+        actions[13] = 0      # MOVE_FORWARD
+        actions[14] = 1      # TURN_RIGHT
+        actions[15] = 0      # TURN_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
         super(DoomMyWayHomeEnv, self).__init__()
-        package_directory = os.path.dirname(os.path.abspath(__file__))
-        self.loader = Loader()
-        self.game = DoomGame()
-        self.game.load_config(os.path.join(package_directory, 'assets/my_way_home.cfg'))
-        self.game.set_vizdoom_path(self.loader.get_vizdoom_path())
-        self.game.set_doom_game_path(self.loader.get_freedoom_path())
-        self.game.set_doom_scenario_path(self.loader.get_scenario_path('my_way_home.wad'))
-        self.screen_height = 480                    # Must match .cfg file
-        self.screen_width = 640                     # Must match .cfg file
-        self.game.set_window_visible(False)
-        self.viewer = None
-        self.game.init()
-        self.game.new_episode()
-
-        # 3 allowed actions [13, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
-        self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.action_space.allowed_actions = [13, 14, 15]
-
-        self._seed()
+        self.config = 'my_way_home.cfg'
+        self.scenario = 'my_way_home.wad'
+        self.difficulty = 5
+        self.allowed_actions = [13, 14, 15]

--- a/gym/envs/doom/doom_my_way_home.py
+++ b/gym/envs/doom/doom_my_way_home.py
@@ -41,7 +41,7 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
             where parameter #2 is TURN_RIGHT (0 or 1)
             where parameter #3 is TURN_LEFT (0 or 1)
         or
-        2) actions = [0] * 41       # To train for the Deathmatch level
+        2) actions = [0] * 43       # To train for the Deathmatch level
            actions[13] = 0      # MOVE_FORWARD
            actions[14] = 1      # TURN_RIGHT
            actions[15] = 0      # TURN_LEFT
@@ -64,7 +64,7 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [13, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
         self.action_space.allowed_actions = [13, 14, 15]
 

--- a/gym/envs/doom/doom_my_way_home.py
+++ b/gym/envs/doom/doom_my_way_home.py
@@ -19,7 +19,7 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
 
     Rewards:
         +  1    - Finding the vest
-        -0.0001 - Several times per second - Find the vest quick!
+        -0.0001 - 35 times per second - Find the vest quick!
 
     Goal: 0.50 point
         Find the vest

--- a/gym/envs/doom/doom_predict_position.py
+++ b/gym/envs/doom/doom_predict_position.py
@@ -4,9 +4,8 @@ import os
 import numpy as np
 
 from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import error, spaces
+from gym import spaces
 from gym.envs.doom import doom_env
-from gym.utils import seeding
 
 logger = logging.getLogger(__name__)
 
@@ -62,9 +61,3 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
 
         self._seed()
-
-    def _seed(self, seed=None):
-        # Derive a random seed.
-        seed = seeding.hash_seed(seed) % 2**32
-        self.game.set_seed(seed)
-        return [seed]

--- a/gym/envs/doom/doom_predict_position.py
+++ b/gym/envs/doom/doom_predict_position.py
@@ -20,7 +20,7 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
 
     Rewards:
         +  1    - Killing the monster
-        -0.0001 - Several times per second - Kill the monster faster!
+        -0.0001 - 35 times per second - Kill the monster faster!
 
     Goal: 0.5 point
         Kill the monster

--- a/gym/envs/doom/doom_predict_position.py
+++ b/gym/envs/doom/doom_predict_position.py
@@ -41,12 +41,12 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
 
     Actions:
     Either of
-        1) action = [0, 1, 0]
+        1) action = [0, 1, 0]       # Recommended
             where parameter #1 is ATTACK (0 or 1)
             where parameter #2 is TURN_RIGHT (0 or 1)
             where parameter #3 is TURN_LEFT (0 or 1)
         or
-        2) actions = [0] * 41
+        2) actions = [0] * 41       # To train for the Deathmatch level
            actions[0] = 0       # ATTACK
            actions[14] = 1      # TURN_RIGHT
            actions[15] = 0      # TURN_LEFT

--- a/gym/envs/doom/doom_predict_position.py
+++ b/gym/envs/doom/doom_predict_position.py
@@ -1,10 +1,4 @@
 import logging
-import os
-
-import numpy as np
-
-from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import spaces
 from gym.envs.doom import doom_env
 
 logger = logging.getLogger(__name__)
@@ -35,9 +29,10 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
         before trying to fire it.
 
     Mode:
-        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
-        - 'normal' will run at roughly 30 fps (easier for human to watch)
+        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
+        - 'normal' will run at roughly 35 fps (easier for human to watch)
+        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
 
     Ends when:
         - Monster is dead
@@ -45,38 +40,16 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
         - Timeout (20 seconds - 700 frames)
 
     Actions:
-    Either of
-        1) action = [0, 1, 0]       # Recommended
-            where parameter #1 is ATTACK (0 or 1)
-            where parameter #2 is TURN_RIGHT (0 or 1)
-            where parameter #3 is TURN_LEFT (0 or 1)
-        or
-        2) actions = [0] * 43       # To train for the Deathmatch level
-           actions[0] = 0       # ATTACK
-           actions[14] = 1      # TURN_RIGHT
-           actions[15] = 0      # TURN_LEFT
+        actions = [0] * 43
+        actions[0] = 0       # ATTACK
+        actions[14] = 1      # TURN_RIGHT
+        actions[15] = 0      # TURN_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
         super(DoomPredictPositionEnv, self).__init__()
-        package_directory = os.path.dirname(os.path.abspath(__file__))
-        self.loader = Loader()
-        self.game = DoomGame()
-        self.game.load_config(os.path.join(package_directory, 'assets/predict_position.cfg'))
-        self.game.set_vizdoom_path(self.loader.get_vizdoom_path())
-        self.game.set_doom_game_path(self.loader.get_freedoom_path())
-        self.game.set_doom_scenario_path(self.loader.get_scenario_path('predict_position.wad'))
-        self.game.set_doom_map('map01')
-        self.screen_height = 480                    # Must match .cfg file
-        self.screen_width = 640                     # Must match .cfg file
-        self.game.set_window_visible(False)
-        self.viewer = None
-        self.game.init()
-        self.game.new_episode()
-
-        # 3 allowed actions [0, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
-        self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.action_space.allowed_actions = [0, 14, 15]
-
-        self._seed()
+        self.config = 'predict_position.cfg'
+        self.scenario = 'predict_position.wad'
+        self.map = 'map01'
+        self.difficulty = 3
+        self.allowed_actions = [0, 14, 15]

--- a/gym/envs/doom/doom_predict_position.py
+++ b/gym/envs/doom/doom_predict_position.py
@@ -38,6 +38,18 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
         - Monster is dead
         - Out of missile (you only have one)
         - Timeout (20 seconds - 700 frames)
+
+    Actions:
+    Either of
+        1) action = [0, 1, 0]
+            where parameter #1 is ATTACK (0 or 1)
+            where parameter #2 is TURN_RIGHT (0 or 1)
+            where parameter #3 is TURN_LEFT (0 or 1)
+        or
+        2) actions = [0] * 41
+           actions[0] = 0       # ATTACK
+           actions[14] = 1      # TURN_RIGHT
+           actions[15] = 0      # TURN_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
@@ -57,8 +69,8 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [0, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.allowed_actions = [0, 14, 15]
+        self.action_space.allowed_actions = [0, 14, 15]
 
         self._seed()

--- a/gym/envs/doom/doom_predict_position.py
+++ b/gym/envs/doom/doom_predict_position.py
@@ -20,8 +20,8 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
 
     Allowed actions:
         [0]  - ATTACK                           - Shoot weapon - Values 0 or 1
-        [13] - TURN_RIGHT                       - Turn right - Values 0 or 1
-        [14] - TURN_LEFT                        - Turn left - Values 0 or 1
+        [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+        [15] - TURN_LEFT                        - Turn left - Values 0 or 1
     Note: see controls.md for details
 
     Rewards:
@@ -56,8 +56,9 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
         self.game.init()
         self.game.new_episode()
 
-        # 3 allowed actions [0, 13, 14] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 3))
+        # 3 allowed actions [0, 14, 15] (must match .cfg file)
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.allowed_actions = [0, 14, 15]
 
         self._seed()

--- a/gym/envs/doom/doom_predict_position.py
+++ b/gym/envs/doom/doom_predict_position.py
@@ -34,6 +34,11 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
     Hint: Missile launcher takes longer to load. You must wait a good second after the game starts
         before trying to fire it.
 
+    Mode:
+        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
+        - 'normal' will run at roughly 30 fps (easier for human to watch)
+
     Ends when:
         - Monster is dead
         - Out of missile (you only have one)
@@ -53,6 +58,7 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
     -----------------------------------------------------
     """
     def __init__(self):
+        super(DoomPredictPositionEnv, self).__init__()
         package_directory = os.path.dirname(os.path.abspath(__file__))
         self.loader = Loader()
         self.game = DoomGame()

--- a/gym/envs/doom/doom_predict_position.py
+++ b/gym/envs/doom/doom_predict_position.py
@@ -46,7 +46,7 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
             where parameter #2 is TURN_RIGHT (0 or 1)
             where parameter #3 is TURN_LEFT (0 or 1)
         or
-        2) actions = [0] * 41       # To train for the Deathmatch level
+        2) actions = [0] * 43       # To train for the Deathmatch level
            actions[0] = 0       # ATTACK
            actions[14] = 1      # TURN_RIGHT
            actions[15] = 0      # TURN_LEFT
@@ -69,7 +69,7 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 3 allowed actions [0, 14, 15] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
         self.action_space.allowed_actions = [0, 14, 15]
 

--- a/gym/envs/doom/doom_predict_position.py
+++ b/gym/envs/doom/doom_predict_position.py
@@ -47,9 +47,4 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
     -----------------------------------------------------
     """
     def __init__(self):
-        super(DoomPredictPositionEnv, self).__init__()
-        self.config = 'predict_position.cfg'
-        self.scenario = 'predict_position.wad'
-        self.map = 'map01'
-        self.difficulty = 3
-        self.allowed_actions = [0, 14, 15]
+        super(DoomPredictPositionEnv, self).__init__(6)

--- a/gym/envs/doom/doom_take_cover.py
+++ b/gym/envs/doom/doom_take_cover.py
@@ -33,11 +33,11 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
 
     Actions:
     Either of
-        1) action = [0, 1]
+        1) action = [0, 1]          # Recommended
             where parameter #1 is MOVE_RIGHT (0 or 1)
             where parameter #2 is MOVE_LEFT (0 or 1)
         or
-        2) actions = [0] * 41
+        2) actions = [0] * 41       # To train for the Deathmatch level
            actions[10] = 0      # MOVE_RIGHT
            actions[11] = 1      # MOVE_LEFT
     -----------------------------------------------------

--- a/gym/envs/doom/doom_take_cover.py
+++ b/gym/envs/doom/doom_take_cover.py
@@ -37,7 +37,7 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
             where parameter #1 is MOVE_RIGHT (0 or 1)
             where parameter #2 is MOVE_LEFT (0 or 1)
         or
-        2) actions = [0] * 41       # To train for the Deathmatch level
+        2) actions = [0] * 43       # To train for the Deathmatch level
            actions[10] = 0      # MOVE_RIGHT
            actions[11] = 1      # MOVE_LEFT
     -----------------------------------------------------
@@ -60,7 +60,7 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 2 allowed actions [10, 11] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
         self.action_space.allowed_actions = [10, 11]
 

--- a/gym/envs/doom/doom_take_cover.py
+++ b/gym/envs/doom/doom_take_cover.py
@@ -38,9 +38,4 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
     -----------------------------------------------------
     """
     def __init__(self):
-        super(DoomTakeCoverEnv, self).__init__()
-        self.config = 'take_cover.cfg'
-        self.scenario = 'take_cover.wad'
-        self.map = 'map01'
-        self.difficulty = 5
-        self.allowed_actions = [10, 11]
+        super(DoomTakeCoverEnv, self).__init__(7)

--- a/gym/envs/doom/doom_take_cover.py
+++ b/gym/envs/doom/doom_take_cover.py
@@ -27,6 +27,11 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
     Goal: 750 points
         Survive for ~ 20 seconds
 
+    Mode:
+        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
+        - 'normal' will run at roughly 30 fps (easier for human to watch)
+
     Ends when:
         - Player is dead (one or two fireballs should be enough to kill you)
         - Timeout (60 seconds - 2,100 frames)

--- a/gym/envs/doom/doom_take_cover.py
+++ b/gym/envs/doom/doom_take_cover.py
@@ -4,9 +4,8 @@ import os
 import numpy as np
 
 from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import error, spaces
+from gym import spaces
 from gym.envs.doom import doom_env
-from gym.utils import seeding
 
 logger = logging.getLogger(__name__)
 
@@ -55,8 +54,3 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
 
         self._seed()
-
-    def _seed(self, seed=None):
-        seed = seeding.hash_seed(seed) % 2**32
-        self.game.set_seed(seed)
-        return [seed]

--- a/gym/envs/doom/doom_take_cover.py
+++ b/gym/envs/doom/doom_take_cover.py
@@ -17,7 +17,7 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
     at you. You need to survive as long as possible.
 
     Allowed actions:
-        [10]  - MOVE_RIGHT                       - Move to the right - Values 0 or 1
+        [10] - MOVE_RIGHT                       - Move to the right - Values 0 or 1
         [11] - MOVE_LEFT                        - Move to the left - Values 0 or 1
     Note: see controls.md for details
 
@@ -30,6 +30,16 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
     Ends when:
         - Player is dead (one or two fireballs should be enough to kill you)
         - Timeout (60 seconds - 2,100 frames)
+
+    Actions:
+    Either of
+        1) action = [0, 1]
+            where parameter #1 is MOVE_RIGHT (0 or 1)
+            where parameter #2 is MOVE_LEFT (0 or 1)
+        or
+        2) actions = [0] * 41
+           actions[10] = 0      # MOVE_RIGHT
+           actions[11] = 1      # MOVE_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
@@ -50,8 +60,8 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
         self.game.new_episode()
 
         # 2 allowed actions [10, 11] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[-10, 10, 0]] * 2 + [[0, 100, 0]] * 3))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.allowed_actions = [10, 11]
+        self.action_space.allowed_actions = [10, 11]
 
         self._seed()

--- a/gym/envs/doom/doom_take_cover.py
+++ b/gym/envs/doom/doom_take_cover.py
@@ -16,7 +16,7 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
     Note: see controls.md for details
 
     Rewards:
-        +  1    - Several times per second - Survive as long as possible
+        +  1    - 35 times per second - Survive as long as possible
 
     Goal: 750 points
         Survive for ~ 20 seconds

--- a/gym/envs/doom/doom_take_cover.py
+++ b/gym/envs/doom/doom_take_cover.py
@@ -1,10 +1,4 @@
 import logging
-import os
-
-import numpy as np
-
-from doom_py import DoomGame, Mode, Button, GameVariable, ScreenFormat, ScreenResolution, Loader
-from gym import spaces
 from gym.envs.doom import doom_env
 
 logger = logging.getLogger(__name__)
@@ -28,45 +22,25 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
         Survive for ~ 20 seconds
 
     Mode:
-        - env.mode can be 'fast' or 'normal' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation, harder for human to watch)
-        - 'normal' will run at roughly 30 fps (easier for human to watch)
+        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
+        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
+        - 'normal' will run at roughly 35 fps (easier for human to watch)
+        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
 
     Ends when:
         - Player is dead (one or two fireballs should be enough to kill you)
         - Timeout (60 seconds - 2,100 frames)
 
     Actions:
-    Either of
-        1) action = [0, 1]          # Recommended
-            where parameter #1 is MOVE_RIGHT (0 or 1)
-            where parameter #2 is MOVE_LEFT (0 or 1)
-        or
-        2) actions = [0] * 43       # To train for the Deathmatch level
-           actions[10] = 0      # MOVE_RIGHT
-           actions[11] = 1      # MOVE_LEFT
+        actions = [0] * 43
+        actions[10] = 0      # MOVE_RIGHT
+        actions[11] = 1      # MOVE_LEFT
     -----------------------------------------------------
     """
     def __init__(self):
         super(DoomTakeCoverEnv, self).__init__()
-        package_directory = os.path.dirname(os.path.abspath(__file__))
-        self.loader = Loader()
-        self.game = DoomGame()
-        self.game.load_config(os.path.join(package_directory, 'assets/take_cover.cfg'))
-        self.game.set_vizdoom_path(self.loader.get_vizdoom_path())
-        self.game.set_doom_game_path(self.loader.get_freedoom_path())
-        self.game.set_doom_scenario_path(self.loader.get_scenario_path('take_cover.wad'))
-        self.game.set_doom_map('map01')
-        self.screen_height = 480                    # Must match .cfg file
-        self.screen_width = 640                     # Must match .cfg file
-        self.game.set_window_visible(False)
-        self.viewer = None
-        self.game.init()
-        self.game.new_episode()
-
-        # 2 allowed actions [10, 11] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 38 + [[-10, 10, 0]] * 2 + [[-100, 100, 0]] * 3))
-        self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
-        self.action_space.allowed_actions = [10, 11]
-
-        self._seed()
+        self.config = 'take_cover.cfg'
+        self.scenario = 'take_cover.wad'
+        self.map = 'map01'
+        self.difficulty = 5
+        self.allowed_actions = [10, 11]

--- a/gym/envs/doom/doom_take_cover.py
+++ b/gym/envs/doom/doom_take_cover.py
@@ -17,8 +17,8 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
     at you. You need to survive as long as possible.
 
     Allowed actions:
-        [9]  - MOVE_RIGHT                       - Move to the right - Values 0 or 1
-        [10] - MOVE_LEFT                        - Move to the left - Values 0 or 1
+        [10]  - MOVE_RIGHT                       - Move to the right - Values 0 or 1
+        [11] - MOVE_LEFT                        - Move to the left - Values 0 or 1
     Note: see controls.md for details
 
     Rewards:
@@ -49,8 +49,9 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
         self.game.init()
         self.game.new_episode()
 
-        # 2 allowed actions [9, 10] (must match .cfg file)
-        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 2))
+        # 2 allowed actions [10, 11] (must match .cfg file)
+        self.action_space = spaces.HighLow(np.matrix([[0, 1, 0]] * 36 + [[0, 0, 0]] * 5))
         self.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.allowed_actions = [10, 11]
 
         self._seed()

--- a/gym/envs/tests/test_envs.py
+++ b/gym/envs/tests/test_envs.py
@@ -22,6 +22,11 @@ def should_skip_env_spec_for_tests(spec):
         logger.warn("Skipping tests for box2d env {}".format(spec._entry_point))
         return True
 
+    # TODO: Issue #167 - Re-enable these tests after fixing DoomDeathmatch crash
+    if spec._entry_point.startswith('gym.envs.doom:DoomDeathmatchEnv'):
+        logger.warn("Skipping tests for DoomDeathmatchEnv {}".format(spec._entry_point))
+        return True
+
     # Skip ConvergenceControl tests (the only env in parameter_tuning) according to pull #104
     if spec._entry_point.startswith('gym.envs.parameter_tuning:'):
         logger.warn("Skipping tests for parameter_tuning env {}".format(spec._entry_point))

--- a/gym/scoreboard/__init__.py
+++ b/gym/scoreboard/__init__.py
@@ -640,6 +640,31 @@ add_task(
     group='doom',
     experimental=True,
     contributor='ppaquette',
+    summary='Mission #1 - Kill a single monster using your pistol.',
+    description="""
+This map is rectangular with gray walls, ceiling and floor.
+You are spawned in the center of the longer wall, and a red
+circular monster is spawned randomly on the opposite wall.
+You need to kill the monster (one bullet is enough).
+
+Allowed actions:
+    [0]  - ATTACK                           - Shoot weapon - Values 0 or 1
+    [10] - MOVE_RIGHT                       - Move to the right - Values 0 or 1
+    [11] - MOVE_LEFT                        - Move to the left - Values 0 or 1
+
+Rewards:
+    +101    - Killing the monster
+    -  5    - Missing a shot
+    -  1    - 35 times per second - Kill the monster faster!
+
+Goal: 10 points
+    Kill the monster in 3 secs with 1 shot
+
+Ends when:
+    - Monster is dead
+    - Player is dead
+    - Timeout (10 seconds - 350 frames)
+"""
 )
 
 add_task(
@@ -647,6 +672,33 @@ add_task(
     group='doom',
     experimental=True,
     contributor='ppaquette',
+    summary='Mission #2 - Run as fast as possible to grab a vest.',
+    description="""
+This map is designed to improve your navigation. There is a vest
+at the end of the corridor, with 6 enemies (3 groups of 2). Your goal
+is to get to the vest as soon as possible, without being killed.
+
+Allowed actions:
+    [0]  - ATTACK                           - Shoot weapon - Values 0 or 1
+    [10] - MOVE_RIGHT                       - Move to the right - Values 0 or 1
+    [11] - MOVE_LEFT                        - Move to the left - Values 0 or 1
+    [13] - MOVE_FORWARD                     - Move forward - Values 0 or 1
+    [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+    [15] - TURN_LEFT                        - Turn left - Values 0 or 1
+
+Rewards:
+    + dX    - For getting closer to the vest
+    - dX    - For getting further from the vest
+    -100    - Penalty for being killed
+
+Goal: 1,000 points
+    Reach the vest (or at least get past the guards in the 3rd group)
+
+Ends when:
+    - Player touches vest
+    - Player is dead
+    - Timeout (1 minutes - 2,100 frames)
+"""
 )
 
 add_task(
@@ -654,6 +706,32 @@ add_task(
     group='doom',
     experimental=True,
     contributor='ppaquette',
+    summary='Mission #3 - Kill enemies coming at your from all sides.',
+    description="""
+This map is designed to teach you how to kill and how to stay alive.
+You will also need to keep an eye on your ammunition level. You are only
+rewarded for kills, so figure out how to stay alive.
+
+The map is a circle with monsters. You are in the middle. Monsters will
+respawn with additional health when killed. Kill as many as you can
+before you run out of ammo.
+
+Allowed actions:
+    [0]  - ATTACK                           - Shoot weapon - Values 0 or 1
+    [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+    [15] - TURN_LEFT                        - Turn left - Values 0 or 1
+
+Rewards:
+    +  1    - Killing a monster
+    -  1    - Penalty for being killed
+
+Goal: 10 points
+    Kill 11 monsters (you have 26 ammo)
+
+Ends when:
+    - Player is dead
+    - Timeout (60 seconds - 2100 frames)
+"""
 )
 
 add_task(
@@ -661,6 +739,32 @@ add_task(
     group='doom',
     experimental=True,
     contributor='ppaquette',
+    summary='Mission #4 - Kill enemies on the other side of the room.',
+    description="""
+This map is designed to teach you how to kill and how to stay alive.
+Your ammo will automatically replenish. You are only rewarded for kills,
+so figure out how to stay alive.
+
+The map is a rectangle with monsters on the other side. Monsters will
+respawn with additional health when killed. Kill as many as you can
+before they kill you. This map is harder than the previous.
+
+Allowed actions:
+    [0]  - ATTACK                           - Shoot weapon - Values 0 or 1
+    [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+    [15] - TURN_LEFT                        - Turn left - Values 0 or 1
+
+Rewards:
+    +  1    - Killing a monster
+    -  1    - Penalty for being killed
+
+Goal: 15 points
+    Kill 16 monsters
+
+Ends when:
+    - Player is dead
+    - Timeout (60 seconds - 2100 frames)
+"""
 )
 
 add_task(
@@ -668,6 +772,29 @@ add_task(
     group='doom',
     experimental=True,
     contributor='ppaquette',
+    summary='Mission #5 - Learn to grad medkits to survive as long as possible.',
+    description="""
+This map is a guide on how to survive by collecting health packs.
+It is a rectangle with green, acidic floor which hurts the player
+periodically. There are also medkits spread around the map, and
+additional kits will spawn at interval.
+
+Allowed actions:
+    [13] - MOVE_FORWARD                     - Move forward - Values 0 or 1
+    [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+    [15] - TURN_LEFT                        - Turn left - Values 0 or 1
+
+Rewards:
+    +  1    - 35 times per second - Survive as long as possible
+    -100    - Death penalty
+
+Goal: 1000 points
+    Stay alive long enough to reach 1,000 points (~ 30 secs)
+
+Ends when:
+    - Player is dead
+    - Timeout (60 seconds - 2,100 frames)
+"""
 )
 
 add_task(
@@ -675,6 +802,29 @@ add_task(
     group='doom',
     experimental=True,
     contributor='ppaquette',
+    summary='Mission #6 - Find the vest in one the 4 rooms.',
+    description="""
+This map is designed to improve navigational skills. It is a series of
+interconnected rooms and 1 corridor with a dead end. Each room
+has a separate color. There is a green vest in one of the room.
+The vest is always in the same room. Player must find the vest.
+
+Allowed actions:
+    [13] - MOVE_FORWARD                     - Move forward - Values 0 or 1
+    [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+    [15] - TURN_LEFT                        - Turn left - Values 0 or 1
+
+Rewards:
+    +  1    - Finding the vest
+    -0.0001 - 35 times per second - Find the vest quick!
+
+Goal: 0.50 point
+    Find the vest
+
+Ends when:
+    - Vest is found
+    - Timeout (1 minutes - 2,100 frames)
+"""
 )
 
 add_task(
@@ -682,6 +832,34 @@ add_task(
     group='doom',
     experimental=True,
     contributor='ppaquette',
+    summary='Mission #7 - Learn how to kill an enemy with a rocket launcher.',
+    description="""
+This map is designed to train you on using a rocket launcher.
+It is a rectangular map with a monster on the opposite side. You need
+to use your rocket launcher to kill it. The rocket adds a delay between
+the moment it is fired and the moment it reaches the other side of the room.
+You need to predict the position of the monster to kill it.
+
+Allowed actions:
+    [0]  - ATTACK                           - Shoot weapon - Values 0 or 1
+    [14] - TURN_RIGHT                       - Turn right - Values 0 or 1
+    [15] - TURN_LEFT                        - Turn left - Values 0 or 1
+
+Rewards:
+    +  1    - Killing the monster
+    -0.0001 - 35 times per second - Kill the monster faster!
+
+Goal: 0.5 point
+    Kill the monster
+
+Hint: Missile launcher takes longer to load. You must wait a good second after the game starts
+    before trying to fire it.
+
+Ends when:
+    - Monster is dead
+    - Out of missile (you only have one)
+    - Timeout (20 seconds - 700 frames)
+"""
 )
 
 add_task(
@@ -689,6 +867,26 @@ add_task(
     group='doom',
     experimental=True,
     contributor='ppaquette',
+    summary='Mission #8 - Survive as long as possible with enemies shooting at you.',
+    description="""
+This map is to train you on the damage of incoming missiles.
+It is a rectangular map with monsters firing missiles and fireballs
+at you. You need to survive as long as possible.
+
+Allowed actions:
+    [10] - MOVE_RIGHT                       - Move to the right - Values 0 or 1
+    [11] - MOVE_LEFT                        - Move to the left - Values 0 or 1
+
+Rewards:
+    +  1    - 35 times per second - Survive as long as possible
+
+Goal: 750 points
+    Survive for ~ 20 seconds
+
+Ends when:
+    - Player is dead (one or two fireballs should be enough to kill you)
+    - Timeout (60 seconds - 2,100 frames)
+"""
 )
 
 add_task(
@@ -696,6 +894,23 @@ add_task(
     group='doom',
     experimental=True,
     contributor='ppaquette',
+    summary='Mission #9 - Kill as many enemies as possible without being killed.',
+    description="""
+Kill as many monsters as possible without being killed.
+
+Allowed actions:
+    ALL
+
+Rewards:
+    +1      - Killing a monster
+
+Goal: 20 points
+    Kill 20 monsters
+
+Ends when:
+    - Player is dead
+    - Timeout (3 minutes - 6,300 frames)
+"""
 )
 
 

--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import gym
+import gym, time
 from gym.spaces import prng
 
 class Discrete(gym.Space):
@@ -13,6 +13,9 @@ class Discrete(gym.Space):
     def __init__(self, n):
         self.n = n
     def sample(self):
+        # prng is terminating VizDoom with Fatal Error - Address not mapped to object (signal 11)
+        # 82 is for HexEnv (9x9), which is the environment causing the Vizdoom crash
+        if 82 == self.n: return int(round(time.time(), -1) % self.n)
         return prng.np_random.randint(self.n)
     def contains(self, x):
         if isinstance(x, int):

--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -13,9 +13,6 @@ class Discrete(gym.Space):
     def __init__(self, n):
         self.n = n
     def sample(self):
-        # prng is terminating VizDoom with Fatal Error - Address not mapped to object (signal 11)
-        # 82 is for HexEnv (9x9), which is the environment causing the Vizdoom crash
-        if 82 == self.n: return int(round(time.time(), -1) % self.n)
         return prng.np_random.randint(self.n)
     def contains(self, x):
         if isinstance(x, int):

--- a/gym/spaces/high_low.py
+++ b/gym/spaces/high_low.py
@@ -8,9 +8,9 @@ class HighLow(gym.Space):
     A matrix of dimensions n x 3, where
 
     - n is the number of options in the space (e.g. buttons that can be pressed simultaneously)
-    - u[1] (the first column) is the minimum value (inclusive) that the option can have
-    - u[2] (the second column) is the maximum value (inclusive) that the option can have
-    - u[3] (the third column) is the precision (0 = rounded to integer, 2 = rounded to 2 decimals)
+    - u[0] (the first column) is the minimum value (inclusive) that the option can have
+    - u[1] (the second column) is the maximum value (inclusive) that the option can have
+    - u[2] (the third column) is the precision (0 = rounded to integer, 2 = rounded to 2 decimals)
 
     e.g. if the space is composed of ATTACK (values: 0-100), MOVE_LEFT(0-1), MOVE_RIGHT(0,1)
     the space would be [ [0.0, 100.0, 2], [0, 1, 0], [0, 1, 0] ]
@@ -35,10 +35,10 @@ class HighLow(gym.Space):
         rounded_matrix = np.zeros(self.num_rows)
         for i in range(self.num_rows):
             rounded_matrix[i] = round(random_matrix[i, 0], int(self.matrix[i, 2]))
-        return rounded_matrix
+        return rounded_matrix.tolist()
 
     def contains(self, x):
-        if x.shape[0] != self.num_rows:
+        if len(x) != self.num_rows:
             return False
         for i in range(self.num_rows):
             if not (self.matrix[i, 0] <= x[i] <= self.matrix[i, 1]):

--- a/gym/spaces/high_low.py
+++ b/gym/spaces/high_low.py
@@ -27,6 +27,7 @@ class HighLow(gym.Space):
         assert num_cols == 3
         self.matrix = matrix
         self.num_rows = num_rows
+        self.allowed_actions = []
 
     def sample(self):
         # For each row: round(random .* (max - min) + min, precision)
@@ -38,12 +39,20 @@ class HighLow(gym.Space):
         return rounded_matrix.tolist()
 
     def contains(self, x):
-        if len(x) != self.num_rows:
+        if len(x) != self.num_rows and len(x) != len(self.allowed_actions):
             return False
-        for i in range(self.num_rows):
-            if not (self.matrix[i, 0] <= x[i] <= self.matrix[i, 1]):
-                return False
-        return True
+        if len(x) == len(self.allowed_actions):
+            # Short list (only allowed actions)
+            for i in range(len(self.allowed_actions)):
+                if not (self.matrix[self.allowed_actions[i], 0] <= x[i] <= self.matrix[self.allowed_actions[i], 1]):
+                    return False
+            return True
+        else:
+            # Long list (all actions)
+            for i in range(self.num_rows):
+                if not (self.matrix[i, 0] <= x[i] <= self.matrix[i, 1]):
+                    return False
+            return True
 
     def to_jsonable(self, sample_n):
         return np.array(sample_n).tolist()

--- a/gym/spaces/high_low.py
+++ b/gym/spaces/high_low.py
@@ -36,7 +36,14 @@ class HighLow(gym.Space):
         rounded_matrix = np.zeros(self.num_rows)
         for i in range(self.num_rows):
             rounded_matrix[i] = round(random_matrix[i, 0], int(self.matrix[i, 2]))
-        return rounded_matrix.tolist()
+        if len(self.allowed_actions) == 0:
+            return rounded_matrix.tolist()
+        else:
+            # Returning small list
+            small_list = [0] * len(self.allowed_actions)
+            for j in range(len(self.allowed_actions)):
+                small_list[j] = rounded_matrix[self.allowed_actions[j]]
+            return small_list
 
     def contains(self, x):
         if len(x) != self.num_rows and len(x) != len(self.allowed_actions):
@@ -61,7 +68,7 @@ class HighLow(gym.Space):
 
     @property
     def shape(self):
-        return self.matrix.shape
+        return self.matrix.shape[0]
     def __repr__(self):
         return "High-Low" + str(self.shape)
     def __eq__(self, other):


### PR DESCRIPTION
This PR adds another commit to the previous PR.

- It adds ALT_ATTACK as the 6th command for Doom
- It makes a default action space for all Doom environments, with some controls disabled between environments.

VizDoom is a series of mission that build on each other. 
This PR creates a standard action space of 41 commands (similar to a keyboard to the human player), that is the same between environments (e.g. first command is always ATTACK, second command is always JUMP, etc.) .
With this setup, it becomes possible to run an algorithm on all the Doom environments in sequence (which is likely required to beat the Deathmatch level).

The actions to be performed are submitted as a list of 41 integers, with 1 being active and 0 being inactive.

e.g. 
actions = [0] * 41
actions[0] = 1          # ATTACK
actions[13] = 1        # MOVE_FORWARD

The first levels only allow certain commands, the disabled commands are ignored.

The full list of commands is in controls.md