### PR TITLE
Make it possible to step() in a newly created env, rather than throwing AttributeError

### DIFF
--- a/gym/envs/toy_text/discrete.py
+++ b/gym/envs/toy_text/discrete.py
@@ -34,6 +34,7 @@ class DiscreteEnv(Env):
         self.P = P
         self.isd = isd
         self.lastaction=None # for rendering
+        self._reset()
 
     @property
     def nS(self):


### PR DESCRIPTION
Under the current implementation of Discrete, if I enter the following commands:
`env = gym.make('FrozenLake-v0') env.step(0)`
the resulting error is
`AttributeError: 'FrozenLakeEnv' object has no attribute 's'.`

The trouble is that Discrete environments (unlike other simple environments, such as CartPole or Copy) must be first reset before a step can be taken, even when the monitor is not turned on, otherwise the "s" attribute does not get set before it is accessed.