### PR TITLE
Doom - Only setting seed once

### DIFF
--- a/gym/envs/doom/doom_env.py
+++ b/gym/envs/doom/doom_env.py
@@ -109,6 +109,7 @@ class DoomEnv(gym.Env, utils.EzPickle):
     def _start_episode(self):
         if self.curr_seed > 0:
             self.game.set_seed(self.curr_seed)
+            self.curr_seed = 0
         self.game.new_episode()
         return
 


### PR DESCRIPTION
Same seed was set on every episode start, leading to the same episode being played.

You might want to delete this evaluation:

https://gym.openai.com/evaluations/eval_QcNVA4JgRqaZ4E2h4oyw