### PR TITLE
fixes cartpole observation_space

### DIFF
--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -33,7 +33,12 @@ class CartPoleEnv(gym.Env):
         self.x_threshold = 2.4
 
         # Angle limit set to 2 * theta_threshold_radians so failing observation is still within bounds
-        high = np.array([self.x_threshold * 2, np.inf, self.theta_threshold_radians * 2, np.inf])
+        high = np.array([
+            self.x_threshold * 2,
+            np.finfo(np.float32).max,
+            self.theta_threshold_radians * 2,
+            np.finfo(np.float32).max])
+
         self.action_space = spaces.Discrete(2)
         self.observation_space = spaces.Box(-high, high)
 


### PR DESCRIPTION
Fixes #195.

I propose that for all spaces, the following property should hold:

`my_space.contains(my_space.sample())`

Infinite spaces violate this property because `sample()` returns `nan`.

Thus I propose that we either accept this PR or modify `sample()` such that it can sample from infinite spaces.