### PR TITLE
fixed global variable reference when ssl verification is off

### DIFF
--- a/gym/scoreboard/client/http_client.py
+++ b/gym/scoreboard/client/http_client.py
@@ -18,7 +18,6 @@ def render_post_data(post_data):
         return None
 
 class RequestsClient(object):
-    global warned
     name = 'requests'
 
     def __init__(self, verify_ssl_certs=True):
@@ -26,6 +25,7 @@ class RequestsClient(object):
         self.session = requests.Session()
 
     def request(self, method, url, headers, post_data=None, files=None):
+        global warned
         kwargs = {}
 
         # Really, really only turn this off while debugging.

--- a/gym/scoreboard/client/http_client.py
+++ b/gym/scoreboard/client/http_client.py
@@ -18,6 +18,7 @@ def render_post_data(post_data):
         return None
 
 class RequestsClient(object):
+    global warned
     name = 'requests'
 
     def __init__(self, verify_ssl_certs=True):


### PR DESCRIPTION
warned isn't accessed properly, this crash only occurs when SSL verification is off