### PR TITLE
Added ability to seed the spaces

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -265,3 +265,9 @@ class Space(object):
         """Convert a JSONable data type to a batch of samples from this space."""
         # By default, assume identity is JSONable
         return sample_n
+
+    def seed_prng(self, seed):
+        """
+        Seed the random number generator associated with the class.
+        """
+        self.prng.seed_action_space(seed)

--- a/gym/spaces/__init__.py
+++ b/gym/spaces/__init__.py
@@ -1,7 +1,7 @@
 from gym.spaces.box import Box
 from gym.spaces.discrete import Discrete
 from gym.spaces.high_low import HighLow
-from gym.spaces.prng import seed
+from gym.spaces.prng import seed_action_space
 from gym.spaces.tuple_space import Tuple
 
 __all__ = ["Box", "Discrete", "HighLow", "Tuple"]

--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -17,6 +17,7 @@ class Box(gym.Space):
             Box(-1.0, 1.0, (3,4)) # low and high are scalars, and shape is provided
             Box(np.array([-1.0,-2.0]), np.array([2.0,4.0])) # low and high are arrays of the same shape
         """
+        self.prng = prng
         if shape is None:
             assert low.shape == high.shape
             self.low = low

--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -11,6 +11,7 @@ class Discrete(gym.Space):
     self.observation_space = spaces.Discrete(2)
     """
     def __init__(self, n):
+        self.prng = prng
         self.n = n
     def sample(self):
         return prng.np_random.randint(self.n)

--- a/gym/spaces/high_low.py
+++ b/gym/spaces/high_low.py
@@ -22,6 +22,7 @@ class HighLow(gym.Space):
 
         e.g. np.matrix([[0, 1, 0], [0, 1, 0], [0.0, 100.0, 2]])
         """
+        self.prng = prng
         (num_rows, num_cols) = matrix.shape
         assert num_rows >= 1
         assert num_cols == 3

--- a/gym/spaces/prng.py
+++ b/gym/spaces/prng.py
@@ -2,7 +2,7 @@ import numpy
 
 np_random = numpy.random.RandomState()
 
-def seed(seed=None):
+def seed_action_space(seed=None):
     """Seed the common numpy.random.RandomState used in spaces
 
     CF
@@ -17,4 +17,4 @@ def seed(seed=None):
 # This numpy.random.RandomState gets used in all spaces for their
 # 'sample' method. It's not really expected that people will be using
 # these in their algorithms.
-seed(0)
+seed_action_space(0)


### PR DESCRIPTION
Thanks for all your work on this. It looks like I am one of the edge cases from your [discussion](https://github.com/openai/gym/commit/58e6aa95e5af2c738557431f812abb81c505a7cf#commitcomment-17669277) about sampling the spaces. I am trying to reproduce trajectories from seed values in a web server that doesn't restart between requests, but I can't assign the seed of the space sampler to reproduce stochastic actions.

The spaces [all import](https://github.com/openai/gym/blob/master/gym/spaces/discrete.py#L4) a [PRNG helper](https://github.com/openai/gym/blob/master/gym/spaces/prng.py), but since the PRNG is imported outside the [space subclasses](https://github.com/openai/gym/blob/master/gym/spaces/discrete.py#L6) it is shared among all Space [instances](https://github.com/openai/gym/blob/master/examples/agents/random_agent.py#L33).

Calls to `env.monitor.start` with an assigned seed will not reset the space's seed. This seems reasonable to me, but the way the PRNG is imported into spaces makes it difficult to manually assign its seed. There is currently no way to re-run trajectories based on a seed value without, (a) removing stochastic actions, (b) opening a new Python shell, or (c) resorting to a dirty hack.

Suggested Fix (in this pull request):

Add an instance variable to each of the spaces referencing the shared PRNG so it can be referenced by a `seed_prng` function in the Spaces superclass. See code in pull request for details.
