### PR TITLE
Fixed broken build - nose2 module incorrectly imported from

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,9 @@ addons:
       - libblas-dev
       - liblapack-dev
       - gfortran
-matrix:
-    include:
-        - python: 2.7
-          env: DISPLAY=:12 TOX_ENV=py27
-        - python: 3.4
-          env: DISPLAY=:12 TOX_ENV=py34
+python:
+  - "2.7"
+  - "3.4"
 before_install:
   - Xvfb :12 -screen 0 800x600x24 +extension RANDR &
     # In a pull request, there are no secrets, and hence no MuJoCo:
@@ -40,11 +37,16 @@ before_install:
   # recording.) We should debug the memory usage at some stage, but
   # simply setting overcommit is a good starting point.
   - sudo sysctl -w vm.overcommit_memory=1
-install: pip install tox-travis
+  # Installs Miniconda to avoid having to compile NumPy, SciPy, etc.
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh && chmod +x miniconda.sh && ./miniconda.sh -b && export PATH=$HOME/miniconda2/bin:$PATH && conda update --yes conda
+env:
+  - DISPLAY=:12
+install:
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy
+  - pip install -r requirements.txt
+  - pip install -r requirements_dev.txt
 script:
-  - tox
-  - rm -rf ./.tox/$TOX_ENV/lib/python*/site-packages/gym*
-  - source ./.tox/$TOX_ENV/bin/activate && nose2
+  - nose2
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,12 @@ addons:
       - libblas-dev
       - liblapack-dev
       - gfortran
-python:
-  - "2.7"
-  - "3.4"
+matrix:
+    include:
+        - python: 2.7
+          env: DISPLAY=:12 TOX_ENV=py27
+        - python: 3.4
+          env: DISPLAY=:12 TOX_ENV=py34
 before_install:
   - Xvfb :12 -screen 0 800x600x24 +extension RANDR &
     # In a pull request, there are no secrets, and hence no MuJoCo:
@@ -37,10 +40,11 @@ before_install:
   # recording.) We should debug the memory usage at some stage, but
   # simply setting overcommit is a good starting point.
   - sudo sysctl -w vm.overcommit_memory=1
-env:
-  - DISPLAY=:12
 install: pip install tox-travis
-script: tox
+script:
+  - tox
+  - rm -rf ./.tox/$TOX_ENV/lib/python*/site-packages/gym*
+  - source ./.tox/$TOX_ENV/bin/activate && nose2
 
 notifications:
   slack:

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps =
     mock
 commands =
     pip install -e .[all]
-    nose2 {posargs}
 
 [testenv:py27]
 whitelist_externals=make
@@ -24,4 +23,3 @@ deps =
     mock
 commands =
     pip install -e .[all]
-    nose2 {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     mock
 commands =
     pip install -e .[all]
+    nose2 {posargs}
 
 [testenv:py27]
 whitelist_externals=make
@@ -23,3 +24,4 @@ deps =
     mock
 commands =
     pip install -e .[all]
+    nose2 {posargs}


### PR DESCRIPTION
Bug is caused by a conflict between 2 gym environments

1) Version being tested, downloaded from git repo (installed in $HOME/openai/gym/)
2) Version installed by tox in virtualenv (with pip install -e .[all])

I simply removed the 2nd version after tox installed gym dependencies.