### PR TITLE
Fix Issue #257 and Issue #248 - Added params to configure() method for Doom

### DIFF
--- a/gym/envs/doom/doom_basic.py
+++ b/gym/envs/doom/doom_basic.py
@@ -26,12 +26,6 @@ class DoomBasicEnv(doom_env.DoomEnv):
     Goal: 10 points
         Kill the monster in 3 secs with 1 shot
 
-    Mode:
-        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
-        - 'normal' will run at roughly 35 fps (easier for human to watch)
-        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
-
     Ends when:
         - Monster is dead
         - Player is dead
@@ -42,6 +36,69 @@ class DoomBasicEnv(doom_env.DoomEnv):
         actions[0] = 0       # ATTACK
         actions[10] = 1      # MOVE_RIGHT
         actions[11] = 0      # MOVE_LEFT
+
+    Configuration:
+
+        After creating the env, you can call env.configure() to configure some parameters.
+
+        - lock [e.g. env.configure(lock=multiprocessing_lock)]
+
+            VizDoom requires a multiprocessing lock when running across multiple processes, otherwise the vizdoom instance
+            might crash on launch
+
+            You can either:
+
+            1) [Preferred] Create a multiprocessing.Lock() and pass it as a parameter to the configure() method
+                [e.g. env.configure(lock=multiprocessing_lock)]
+
+            2) Create and close a Doom environment before running your multiprocessing routine, this will create
+                a singleton lock that will be cached in memory, and be used by all Doom environments afterwards
+                [e.g. env = gym.make('Doom-...'); env.close()]
+
+            3) Manually wrap calls to reset() and close() in a multiprocessing.Lock()
+
+    Wrappers:
+
+        You can use wrappers to further customize the environment
+
+            import gym
+            from gym.wrappers import doom
+            env = doom.WrapperTwo(doom.WrapperOne(gym.make('DoomBasic-v0'))
+
+        - Observation space:
+
+            You can use the following wrappers to change the screen resolution
+
+            'Res160x120', 'Res200x125', 'Res200x150', 'Res256x144', 'Res256x160', 'Res256x192', 'Res320x180', 'Res320x200',
+            'Res320x240', 'Res320x256', 'Res400x225', 'Res400x250', 'Res400x300', 'Res512x288', 'Res512x320', 'Res512x384',
+            'Res640x360', 'Res640x400', 'Res640x480', 'Res800x450', 'Res800x500', 'Res800x600', 'Res1024x576', 'Res1024x640',
+            'Res1024x768', 'Res1280x720', 'Res1280x800', 'Res1280x960', 'Res1280x1024', '1400x787', 'Res1400x875',
+            'Res1400x1050', 'Res1600x900', 'Res1600x1000', 'Res1600x1200', 'Res1920x1080'
+
+        - Action space:
+
+            'DiscreteMinimal' - Discrete action space with NOOP and only the level's allowed actions
+            'Discrete7'       - Discrete action space with NOOP + 7 minimum actions required to complete all levels
+            'Discrete17'      - Discrete action space with NOOP + 17 most common actions
+            'DiscreteFull'    - Discrete action space with all available actions (Deltas will not work, since their range is restricted)
+
+            'BoxMinimal'      - Box action space with only the level's allowed actions
+            'Box7'            - Box action space with 7 minimum actions required to complete all levels
+            'Box17'           - Box action space with 17 most common actions
+            'BoxFull'         - Box action space with all available actions
+
+            Note: Discrete action spaces only allow one action at a time, Box action spaces support simultaneous actions
+
+        - Control:
+
+            'HumanPlayer' - Use this wrapper if you want to play the game yourself or look around a certain level
+                            (controls are Arrow Keys, '<', '>' and Ctrl)
+            'Skip1'       - Sends action and repeats it for 1 additional step   (~ 18 fps)
+            'Skip2'       - Sends action and repeats it for 2 additional steps  (~ 12 fps)
+            'Skip3'       - Sends action and repeats it for 3 additional steps  (~ 9 fps)
+            'Skip4'       - Sends action and repeats it for 4 additional steps  (~ 7 fps)
+            'Skip5'       - Sends action and repeats it for 5 additional steps  (~ 6 fps)
+
     -----------------------------------------------------
     """
     def __init__(self):

--- a/gym/envs/doom/doom_corridor.py
+++ b/gym/envs/doom/doom_corridor.py
@@ -28,12 +28,6 @@ class DoomCorridorEnv(doom_env.DoomEnv):
     Goal: 1,000 points
         Reach the vest (or at least get past the guards in the 3rd group)
 
-    Mode:
-        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
-        - 'normal' will run at roughly 35 fps (easier for human to watch)
-        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
-
     Ends when:
         - Player touches vest
         - Player is dead
@@ -47,6 +41,68 @@ class DoomCorridorEnv(doom_env.DoomEnv):
         actions[13] = 0      # MOVE_FORWARD
         actions[14] = 0      # TURN_RIGHT
         actions[15] = 0      # TURN_LEFT
+
+    Configuration:
+        After creating the env, you can call env.configure() to configure some parameters.
+
+        - lock [e.g. env.configure(lock=multiprocessing_lock)]
+
+            VizDoom requires a multiprocessing lock when running across multiple processes, otherwise the vizdoom instance
+            might crash on launch
+
+            You can either:
+
+            1) [Preferred] Create a multiprocessing.Lock() and pass it as a parameter to the configure() method
+                [e.g. env.configure(lock=multiprocessing_lock)]
+
+            2) Create and close a Doom environment before running your multiprocessing routine, this will create
+                a singleton lock that will be cached in memory, and be used by all Doom environments afterwards
+                [e.g. env = gym.make('Doom-...'); env.close()]
+
+            3) Manually wrap calls to reset() and close() in a multiprocessing.Lock()
+
+    Wrappers:
+
+        You can use wrappers to further customize the environment
+
+            import gym
+            from gym.wrappers import doom
+            env = doom.WrapperTwo(doom.WrapperOne(gym.make('DoomCorridor-v0'))
+
+        - Observation space:
+
+            You can use the following wrappers to change the screen resolution
+
+            'Res160x120', 'Res200x125', 'Res200x150', 'Res256x144', 'Res256x160', 'Res256x192', 'Res320x180', 'Res320x200',
+            'Res320x240', 'Res320x256', 'Res400x225', 'Res400x250', 'Res400x300', 'Res512x288', 'Res512x320', 'Res512x384',
+            'Res640x360', 'Res640x400', 'Res640x480', 'Res800x450', 'Res800x500', 'Res800x600', 'Res1024x576', 'Res1024x640',
+            'Res1024x768', 'Res1280x720', 'Res1280x800', 'Res1280x960', 'Res1280x1024', '1400x787', 'Res1400x875',
+            'Res1400x1050', 'Res1600x900', 'Res1600x1000', 'Res1600x1200', 'Res1920x1080'
+
+        - Action space:
+
+            'DiscreteMinimal' - Discrete action space with NOOP and only the level's allowed actions
+            'Discrete7'       - Discrete action space with NOOP + 7 minimum actions required to complete all levels
+            'Discrete17'      - Discrete action space with NOOP + 17 most common actions
+            'DiscreteFull'    - Discrete action space with all available actions (Deltas will not work, since their range is restricted)
+
+            'BoxMinimal'      - Box action space with only the level's allowed actions
+            'Box7'            - Box action space with 7 minimum actions required to complete all levels
+            'Box17'           - Box action space with 17 most common actions
+            'BoxFull'         - Box action space with all available actions
+
+            Note: Discrete action spaces only allow one action at a time, Box action spaces support simultaneous actions
+
+        - Control:
+
+            'HumanPlayer' - Use this wrapper if you want to play the game yourself or look around a certain level
+                            (controls are Arrow Keys, '<', '>' and Ctrl)
+            'Skip1'       - Sends action and repeats it for 1 additional step   (~ 18 fps)
+            'Skip2'       - Sends action and repeats it for 2 additional steps  (~ 12 fps)
+            'Skip3'       - Sends action and repeats it for 3 additional steps  (~ 9 fps)
+            'Skip4'       - Sends action and repeats it for 4 additional steps  (~ 7 fps)
+            'Skip5'       - Sends action and repeats it for 5 additional steps  (~ 6 fps)
+
     -----------------------------------------------------
     """
     def __init__(self):

--- a/gym/envs/doom/doom_deathmatch.py
+++ b/gym/envs/doom/doom_deathmatch.py
@@ -19,12 +19,6 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
     Goal: 20 points
         Kill 20 monsters
 
-    Mode:
-        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
-        - 'normal' will run at roughly 35 fps (easier for human to watch)
-        - 'human' will let you play the game (mouse and full keyboard)
-
     Ends when:
         - Player is dead
         - Timeout (3 minutes - 6,300 frames)
@@ -39,6 +33,68 @@ class DoomDeathmatchEnv(doom_env.DoomEnv):
 
     Note:
         actions[33] (DROP_SELECTED_WEAPON) is currently disabled, because it causes VizDoom to crash
+
+    Configuration:
+        After creating the env, you can call env.configure() to configure some parameters.
+
+        - lock [e.g. env.configure(lock=multiprocessing_lock)]
+
+            VizDoom requires a multiprocessing lock when running across multiple processes, otherwise the vizdoom instance
+            might crash on launch
+
+            You can either:
+
+            1) [Preferred] Create a multiprocessing.Lock() and pass it as a parameter to the configure() method
+                [e.g. env.configure(lock=multiprocessing_lock)]
+
+            2) Create and close a Doom environment before running your multiprocessing routine, this will create
+                a singleton lock that will be cached in memory, and be used by all Doom environments afterwards
+                [e.g. env = gym.make('Doom-...'); env.close()]
+
+            3) Manually wrap calls to reset() and close() in a multiprocessing.Lock()
+
+    Wrappers:
+
+        You can use wrappers to further customize the environment
+
+            import gym
+            from gym.wrappers import doom
+            env = doom.WrapperTwo(doom.WrapperOne(gym.make('DoomDeathmatch-v0'))
+
+        - Observation space:
+
+            You can use the following wrappers to change the screen resolution
+
+            'Res160x120', 'Res200x125', 'Res200x150', 'Res256x144', 'Res256x160', 'Res256x192', 'Res320x180', 'Res320x200',
+            'Res320x240', 'Res320x256', 'Res400x225', 'Res400x250', 'Res400x300', 'Res512x288', 'Res512x320', 'Res512x384',
+            'Res640x360', 'Res640x400', 'Res640x480', 'Res800x450', 'Res800x500', 'Res800x600', 'Res1024x576', 'Res1024x640',
+            'Res1024x768', 'Res1280x720', 'Res1280x800', 'Res1280x960', 'Res1280x1024', '1400x787', 'Res1400x875',
+            'Res1400x1050', 'Res1600x900', 'Res1600x1000', 'Res1600x1200', 'Res1920x1080'
+
+        - Action space:
+
+            'DiscreteMinimal' - Discrete action space with NOOP and only the level's allowed actions
+            'Discrete7'       - Discrete action space with NOOP + 7 minimum actions required to complete all levels
+            'Discrete17'      - Discrete action space with NOOP + 17 most common actions
+            'DiscreteFull'    - Discrete action space with all available actions (Deltas will not work, since their range is restricted)
+
+            'BoxMinimal'      - Box action space with only the level's allowed actions
+            'Box7'            - Box action space with 7 minimum actions required to complete all levels
+            'Box17'           - Box action space with 17 most common actions
+            'BoxFull'         - Box action space with all available actions
+
+            Note: Discrete action spaces only allow one action at a time, Box action spaces support simultaneous actions
+
+        - Control:
+
+            'HumanPlayer' - Use this wrapper if you want to play the game yourself or look around a certain level
+                            (controls are Arrow Keys, '<', '>' and Ctrl)
+            'Skip1'       - Sends action and repeats it for 1 additional step   (~ 18 fps)
+            'Skip2'       - Sends action and repeats it for 2 additional steps  (~ 12 fps)
+            'Skip3'       - Sends action and repeats it for 3 additional steps  (~ 9 fps)
+            'Skip4'       - Sends action and repeats it for 4 additional steps  (~ 7 fps)
+            'Skip5'       - Sends action and repeats it for 5 additional steps  (~ 6 fps)
+
     -----------------------------------------------------
     """
     def __init__(self):

--- a/gym/envs/doom/doom_defend_center.py
+++ b/gym/envs/doom/doom_defend_center.py
@@ -28,12 +28,6 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
     Goal: 10 points
         Kill 11 monsters (you have 26 ammo)
 
-    Mode:
-        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
-        - 'normal' will run at roughly 35 fps (easier for human to watch)
-        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
-
     Ends when:
         - Player is dead
         - Timeout (60 seconds - 2100 frames)
@@ -43,6 +37,68 @@ class DoomDefendCenterEnv(doom_env.DoomEnv):
         actions[0] = 0       # ATTACK
         actions[14] = 1      # TURN_RIGHT
         actions[15] = 0      # TURN_LEFT
+
+    Configuration:
+        After creating the env, you can call env.configure() to configure some parameters.
+
+        - lock [e.g. env.configure(lock=multiprocessing_lock)]
+
+            VizDoom requires a multiprocessing lock when running across multiple processes, otherwise the vizdoom instance
+            might crash on launch
+
+            You can either:
+
+            1) [Preferred] Create a multiprocessing.Lock() and pass it as a parameter to the configure() method
+                [e.g. env.configure(lock=multiprocessing_lock)]
+
+            2) Create and close a Doom environment before running your multiprocessing routine, this will create
+                a singleton lock that will be cached in memory, and be used by all Doom environments afterwards
+                [e.g. env = gym.make('Doom-...'); env.close()]
+
+            3) Manually wrap calls to reset() and close() in a multiprocessing.Lock()
+
+    Wrappers:
+
+        You can use wrappers to further customize the environment
+
+            import gym
+            from gym.wrappers import doom
+            env = doom.WrapperTwo(doom.WrapperOne(gym.make('DoomDefendCenter-v0'))
+
+        - Observation space:
+
+            You can use the following wrappers to change the screen resolution
+
+            'Res160x120', 'Res200x125', 'Res200x150', 'Res256x144', 'Res256x160', 'Res256x192', 'Res320x180', 'Res320x200',
+            'Res320x240', 'Res320x256', 'Res400x225', 'Res400x250', 'Res400x300', 'Res512x288', 'Res512x320', 'Res512x384',
+            'Res640x360', 'Res640x400', 'Res640x480', 'Res800x450', 'Res800x500', 'Res800x600', 'Res1024x576', 'Res1024x640',
+            'Res1024x768', 'Res1280x720', 'Res1280x800', 'Res1280x960', 'Res1280x1024', '1400x787', 'Res1400x875',
+            'Res1400x1050', 'Res1600x900', 'Res1600x1000', 'Res1600x1200', 'Res1920x1080'
+
+        - Action space:
+
+            'DiscreteMinimal' - Discrete action space with NOOP and only the level's allowed actions
+            'Discrete7'       - Discrete action space with NOOP + 7 minimum actions required to complete all levels
+            'Discrete17'      - Discrete action space with NOOP + 17 most common actions
+            'DiscreteFull'    - Discrete action space with all available actions (Deltas will not work, since their range is restricted)
+
+            'BoxMinimal'      - Box action space with only the level's allowed actions
+            'Box7'            - Box action space with 7 minimum actions required to complete all levels
+            'Box17'           - Box action space with 17 most common actions
+            'BoxFull'         - Box action space with all available actions
+
+            Note: Discrete action spaces only allow one action at a time, Box action spaces support simultaneous actions
+
+        - Control:
+
+            'HumanPlayer' - Use this wrapper if you want to play the game yourself or look around a certain level
+                            (controls are Arrow Keys, '<', '>' and Ctrl)
+            'Skip1'       - Sends action and repeats it for 1 additional step   (~ 18 fps)
+            'Skip2'       - Sends action and repeats it for 2 additional steps  (~ 12 fps)
+            'Skip3'       - Sends action and repeats it for 3 additional steps  (~ 9 fps)
+            'Skip4'       - Sends action and repeats it for 4 additional steps  (~ 7 fps)
+            'Skip5'       - Sends action and repeats it for 5 additional steps  (~ 6 fps)
+
     -----------------------------------------------------
     """
     def __init__(self):

--- a/gym/envs/doom/doom_defend_line.py
+++ b/gym/envs/doom/doom_defend_line.py
@@ -28,12 +28,6 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
     Goal: 15 points
         Kill 16 monsters
 
-    Mode:
-        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
-        - 'normal' will run at roughly 35 fps (easier for human to watch)
-        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
-
     Ends when:
         - Player is dead
         - Timeout (60 seconds - 2100 frames)
@@ -43,6 +37,68 @@ class DoomDefendLineEnv(doom_env.DoomEnv):
         actions[0] = 0       # ATTACK
         actions[14] = 1      # TURN_RIGHT
         actions[15] = 0      # TURN_LEFT
+
+    Configuration:
+        After creating the env, you can call env.configure() to configure some parameters.
+
+        - lock [e.g. env.configure(lock=multiprocessing_lock)]
+
+            VizDoom requires a multiprocessing lock when running across multiple processes, otherwise the vizdoom instance
+            might crash on launch
+
+            You can either:
+
+            1) [Preferred] Create a multiprocessing.Lock() and pass it as a parameter to the configure() method
+                [e.g. env.configure(lock=multiprocessing_lock)]
+
+            2) Create and close a Doom environment before running your multiprocessing routine, this will create
+                a singleton lock that will be cached in memory, and be used by all Doom environments afterwards
+                [e.g. env = gym.make('Doom-...'); env.close()]
+
+            3) Manually wrap calls to reset() and close() in a multiprocessing.Lock()
+
+    Wrappers:
+
+        You can use wrappers to further customize the environment
+
+            import gym
+            from gym.wrappers import doom
+            env = doom.WrapperTwo(doom.WrapperOne(gym.make('DoomDefendLine-v0'))
+
+        - Observation space:
+
+            You can use the following wrappers to change the screen resolution
+
+            'Res160x120', 'Res200x125', 'Res200x150', 'Res256x144', 'Res256x160', 'Res256x192', 'Res320x180', 'Res320x200',
+            'Res320x240', 'Res320x256', 'Res400x225', 'Res400x250', 'Res400x300', 'Res512x288', 'Res512x320', 'Res512x384',
+            'Res640x360', 'Res640x400', 'Res640x480', 'Res800x450', 'Res800x500', 'Res800x600', 'Res1024x576', 'Res1024x640',
+            'Res1024x768', 'Res1280x720', 'Res1280x800', 'Res1280x960', 'Res1280x1024', '1400x787', 'Res1400x875',
+            'Res1400x1050', 'Res1600x900', 'Res1600x1000', 'Res1600x1200', 'Res1920x1080'
+
+        - Action space:
+
+            'DiscreteMinimal' - Discrete action space with NOOP and only the level's allowed actions
+            'Discrete7'       - Discrete action space with NOOP + 7 minimum actions required to complete all levels
+            'Discrete17'      - Discrete action space with NOOP + 17 most common actions
+            'DiscreteFull'    - Discrete action space with all available actions (Deltas will not work, since their range is restricted)
+
+            'BoxMinimal'      - Box action space with only the level's allowed actions
+            'Box7'            - Box action space with 7 minimum actions required to complete all levels
+            'Box17'           - Box action space with 17 most common actions
+            'BoxFull'         - Box action space with all available actions
+
+            Note: Discrete action spaces only allow one action at a time, Box action spaces support simultaneous actions
+
+        - Control:
+
+            'HumanPlayer' - Use this wrapper if you want to play the game yourself or look around a certain level
+                            (controls are Arrow Keys, '<', '>' and Ctrl)
+            'Skip1'       - Sends action and repeats it for 1 additional step   (~ 18 fps)
+            'Skip2'       - Sends action and repeats it for 2 additional steps  (~ 12 fps)
+            'Skip3'       - Sends action and repeats it for 3 additional steps  (~ 9 fps)
+            'Skip4'       - Sends action and repeats it for 4 additional steps  (~ 7 fps)
+            'Skip5'       - Sends action and repeats it for 5 additional steps  (~ 6 fps)
+
     -----------------------------------------------------
     """
     def __init__(self):

--- a/gym/envs/doom/doom_health_gathering.py
+++ b/gym/envs/doom/doom_health_gathering.py
@@ -25,12 +25,6 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
     Goal: 1000 points
         Stay alive long enough to reach 1,000 points (~ 30 secs)
 
-    Mode:
-        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
-        - 'normal' will run at roughly 35 fps (easier for human to watch)
-        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
-
     Ends when:
         - Player is dead
         - Timeout (60 seconds - 2,100 frames)
@@ -40,6 +34,68 @@ class DoomHealthGatheringEnv(doom_env.DoomEnv):
         actions[13] = 0      # MOVE_FORWARD
         actions[14] = 1      # TURN_RIGHT
         actions[15] = 0      # TURN_LEFT
+
+    Configuration:
+        After creating the env, you can call env.configure() to configure some parameters.
+
+        - lock [e.g. env.configure(lock=multiprocessing_lock)]
+
+            VizDoom requires a multiprocessing lock when running across multiple processes, otherwise the vizdoom instance
+            might crash on launch
+
+            You can either:
+
+            1) [Preferred] Create a multiprocessing.Lock() and pass it as a parameter to the configure() method
+                [e.g. env.configure(lock=multiprocessing_lock)]
+
+            2) Create and close a Doom environment before running your multiprocessing routine, this will create
+                a singleton lock that will be cached in memory, and be used by all Doom environments afterwards
+                [e.g. env = gym.make('Doom-...'); env.close()]
+
+            3) Manually wrap calls to reset() and close() in a multiprocessing.Lock()
+
+    Wrappers:
+
+        You can use wrappers to further customize the environment
+
+            import gym
+            from gym.wrappers import doom
+            env = doom.WrapperTwo(doom.WrapperOne(gym.make('DoomHealthGathering-v0'))
+
+        - Observation space:
+
+            You can use the following wrappers to change the screen resolution
+
+            'Res160x120', 'Res200x125', 'Res200x150', 'Res256x144', 'Res256x160', 'Res256x192', 'Res320x180', 'Res320x200',
+            'Res320x240', 'Res320x256', 'Res400x225', 'Res400x250', 'Res400x300', 'Res512x288', 'Res512x320', 'Res512x384',
+            'Res640x360', 'Res640x400', 'Res640x480', 'Res800x450', 'Res800x500', 'Res800x600', 'Res1024x576', 'Res1024x640',
+            'Res1024x768', 'Res1280x720', 'Res1280x800', 'Res1280x960', 'Res1280x1024', '1400x787', 'Res1400x875',
+            'Res1400x1050', 'Res1600x900', 'Res1600x1000', 'Res1600x1200', 'Res1920x1080'
+
+        - Action space:
+
+            'DiscreteMinimal' - Discrete action space with NOOP and only the level's allowed actions
+            'Discrete7'       - Discrete action space with NOOP + 7 minimum actions required to complete all levels
+            'Discrete17'      - Discrete action space with NOOP + 17 most common actions
+            'DiscreteFull'    - Discrete action space with all available actions (Deltas will not work, since their range is restricted)
+
+            'BoxMinimal'      - Box action space with only the level's allowed actions
+            'Box7'            - Box action space with 7 minimum actions required to complete all levels
+            'Box17'           - Box action space with 17 most common actions
+            'BoxFull'         - Box action space with all available actions
+
+            Note: Discrete action spaces only allow one action at a time, Box action spaces support simultaneous actions
+
+        - Control:
+
+            'HumanPlayer' - Use this wrapper if you want to play the game yourself or look around a certain level
+                            (controls are Arrow Keys, '<', '>' and Ctrl)
+            'Skip1'       - Sends action and repeats it for 1 additional step   (~ 18 fps)
+            'Skip2'       - Sends action and repeats it for 2 additional steps  (~ 12 fps)
+            'Skip3'       - Sends action and repeats it for 3 additional steps  (~ 9 fps)
+            'Skip4'       - Sends action and repeats it for 4 additional steps  (~ 7 fps)
+            'Skip5'       - Sends action and repeats it for 5 additional steps  (~ 6 fps)
+
     -----------------------------------------------------
     """
     def __init__(self):

--- a/gym/envs/doom/doom_my_way_home.py
+++ b/gym/envs/doom/doom_my_way_home.py
@@ -25,12 +25,6 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
     Goal: 0.50 point
         Find the vest
 
-    Mode:
-        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
-        - 'normal' will run at roughly 35 fps (easier for human to watch)
-        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
-
     Ends when:
         - Vest is found
         - Timeout (1 minutes - 2,100 frames)
@@ -40,6 +34,68 @@ class DoomMyWayHomeEnv(doom_env.DoomEnv):
         actions[13] = 0      # MOVE_FORWARD
         actions[14] = 1      # TURN_RIGHT
         actions[15] = 0      # TURN_LEFT
+
+    Configuration:
+        After creating the env, you can call env.configure() to configure some parameters.
+
+        - lock [e.g. env.configure(lock=multiprocessing_lock)]
+
+            VizDoom requires a multiprocessing lock when running across multiple processes, otherwise the vizdoom instance
+            might crash on launch
+
+            You can either:
+
+            1) [Preferred] Create a multiprocessing.Lock() and pass it as a parameter to the configure() method
+                [e.g. env.configure(lock=multiprocessing_lock)]
+
+            2) Create and close a Doom environment before running your multiprocessing routine, this will create
+                a singleton lock that will be cached in memory, and be used by all Doom environments afterwards
+                [e.g. env = gym.make('Doom-...'); env.close()]
+
+            3) Manually wrap calls to reset() and close() in a multiprocessing.Lock()
+
+    Wrappers:
+
+        You can use wrappers to further customize the environment
+
+            import gym
+            from gym.wrappers import doom
+            env = doom.WrapperTwo(doom.WrapperOne(gym.make('DoomMyWayHome-v0'))
+
+        - Observation space:
+
+            You can use the following wrappers to change the screen resolution
+
+            'Res160x120', 'Res200x125', 'Res200x150', 'Res256x144', 'Res256x160', 'Res256x192', 'Res320x180', 'Res320x200',
+            'Res320x240', 'Res320x256', 'Res400x225', 'Res400x250', 'Res400x300', 'Res512x288', 'Res512x320', 'Res512x384',
+            'Res640x360', 'Res640x400', 'Res640x480', 'Res800x450', 'Res800x500', 'Res800x600', 'Res1024x576', 'Res1024x640',
+            'Res1024x768', 'Res1280x720', 'Res1280x800', 'Res1280x960', 'Res1280x1024', '1400x787', 'Res1400x875',
+            'Res1400x1050', 'Res1600x900', 'Res1600x1000', 'Res1600x1200', 'Res1920x1080'
+
+        - Action space:
+
+            'DiscreteMinimal' - Discrete action space with NOOP and only the level's allowed actions
+            'Discrete7'       - Discrete action space with NOOP + 7 minimum actions required to complete all levels
+            'Discrete17'      - Discrete action space with NOOP + 17 most common actions
+            'DiscreteFull'    - Discrete action space with all available actions (Deltas will not work, since their range is restricted)
+
+            'BoxMinimal'      - Box action space with only the level's allowed actions
+            'Box7'            - Box action space with 7 minimum actions required to complete all levels
+            'Box17'           - Box action space with 17 most common actions
+            'BoxFull'         - Box action space with all available actions
+
+            Note: Discrete action spaces only allow one action at a time, Box action spaces support simultaneous actions
+
+        - Control:
+
+            'HumanPlayer' - Use this wrapper if you want to play the game yourself or look around a certain level
+                            (controls are Arrow Keys, '<', '>' and Ctrl)
+            'Skip1'       - Sends action and repeats it for 1 additional step   (~ 18 fps)
+            'Skip2'       - Sends action and repeats it for 2 additional steps  (~ 12 fps)
+            'Skip3'       - Sends action and repeats it for 3 additional steps  (~ 9 fps)
+            'Skip4'       - Sends action and repeats it for 4 additional steps  (~ 7 fps)
+            'Skip5'       - Sends action and repeats it for 5 additional steps  (~ 6 fps)
+
     -----------------------------------------------------
     """
     def __init__(self):

--- a/gym/envs/doom/doom_predict_position.py
+++ b/gym/envs/doom/doom_predict_position.py
@@ -29,12 +29,6 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
     Hint: Missile launcher takes longer to load. You must wait a good second after the game starts
         before trying to fire it.
 
-    Mode:
-        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
-        - 'normal' will run at roughly 35 fps (easier for human to watch)
-        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
-
     Ends when:
         - Monster is dead
         - Out of missile (you only have one)
@@ -45,6 +39,68 @@ class DoomPredictPositionEnv(doom_env.DoomEnv):
         actions[0] = 0       # ATTACK
         actions[14] = 1      # TURN_RIGHT
         actions[15] = 0      # TURN_LEFT
+
+    Configuration:
+        After creating the env, you can call env.configure() to configure some parameters.
+
+        - lock [e.g. env.configure(lock=multiprocessing_lock)]
+
+            VizDoom requires a multiprocessing lock when running across multiple processes, otherwise the vizdoom instance
+            might crash on launch
+
+            You can either:
+
+            1) [Preferred] Create a multiprocessing.Lock() and pass it as a parameter to the configure() method
+                [e.g. env.configure(lock=multiprocessing_lock)]
+
+            2) Create and close a Doom environment before running your multiprocessing routine, this will create
+                a singleton lock that will be cached in memory, and be used by all Doom environments afterwards
+                [e.g. env = gym.make('Doom-...'); env.close()]
+
+            3) Manually wrap calls to reset() and close() in a multiprocessing.Lock()
+
+    Wrappers:
+
+        You can use wrappers to further customize the environment
+
+            import gym
+            from gym.wrappers import doom
+            env = doom.WrapperTwo(doom.WrapperOne(gym.make('DoomPredictPosition-v0'))
+
+        - Observation space:
+
+            You can use the following wrappers to change the screen resolution
+
+            'Res160x120', 'Res200x125', 'Res200x150', 'Res256x144', 'Res256x160', 'Res256x192', 'Res320x180', 'Res320x200',
+            'Res320x240', 'Res320x256', 'Res400x225', 'Res400x250', 'Res400x300', 'Res512x288', 'Res512x320', 'Res512x384',
+            'Res640x360', 'Res640x400', 'Res640x480', 'Res800x450', 'Res800x500', 'Res800x600', 'Res1024x576', 'Res1024x640',
+            'Res1024x768', 'Res1280x720', 'Res1280x800', 'Res1280x960', 'Res1280x1024', '1400x787', 'Res1400x875',
+            'Res1400x1050', 'Res1600x900', 'Res1600x1000', 'Res1600x1200', 'Res1920x1080'
+
+        - Action space:
+
+            'DiscreteMinimal' - Discrete action space with NOOP and only the level's allowed actions
+            'Discrete7'       - Discrete action space with NOOP + 7 minimum actions required to complete all levels
+            'Discrete17'      - Discrete action space with NOOP + 17 most common actions
+            'DiscreteFull'    - Discrete action space with all available actions (Deltas will not work, since their range is restricted)
+
+            'BoxMinimal'      - Box action space with only the level's allowed actions
+            'Box7'            - Box action space with 7 minimum actions required to complete all levels
+            'Box17'           - Box action space with 17 most common actions
+            'BoxFull'         - Box action space with all available actions
+
+            Note: Discrete action spaces only allow one action at a time, Box action spaces support simultaneous actions
+
+        - Control:
+
+            'HumanPlayer' - Use this wrapper if you want to play the game yourself or look around a certain level
+                            (controls are Arrow Keys, '<', '>' and Ctrl)
+            'Skip1'       - Sends action and repeats it for 1 additional step   (~ 18 fps)
+            'Skip2'       - Sends action and repeats it for 2 additional steps  (~ 12 fps)
+            'Skip3'       - Sends action and repeats it for 3 additional steps  (~ 9 fps)
+            'Skip4'       - Sends action and repeats it for 4 additional steps  (~ 7 fps)
+            'Skip5'       - Sends action and repeats it for 5 additional steps  (~ 6 fps)
+
     -----------------------------------------------------
     """
     def __init__(self):

--- a/gym/envs/doom/doom_take_cover.py
+++ b/gym/envs/doom/doom_take_cover.py
@@ -22,12 +22,6 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
     Goal: 750 points
         Survive for ~ 20 seconds
 
-    Mode:
-        - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
-        - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
-        - 'normal' will run at roughly 35 fps (easier for human to watch)
-        - 'human' will let you play the game (keyboard only: Arrow Keys, '<', '>' and Ctrl)
-
     Ends when:
         - Player is dead (one or two fireballs should be enough to kill you)
         - Timeout (60 seconds - 2,100 frames)
@@ -36,6 +30,68 @@ class DoomTakeCoverEnv(doom_env.DoomEnv):
         actions = [0] * 43
         actions[10] = 0      # MOVE_RIGHT
         actions[11] = 1      # MOVE_LEFT
+
+    Configuration:
+        After creating the env, you can call env.configure() to configure some parameters.
+
+        - lock [e.g. env.configure(lock=multiprocessing_lock)]
+
+            VizDoom requires a multiprocessing lock when running across multiple processes, otherwise the vizdoom instance
+            might crash on launch
+
+            You can either:
+
+            1) [Preferred] Create a multiprocessing.Lock() and pass it as a parameter to the configure() method
+                [e.g. env.configure(lock=multiprocessing_lock)]
+
+            2) Create and close a Doom environment before running your multiprocessing routine, this will create
+                a singleton lock that will be cached in memory, and be used by all Doom environments afterwards
+                [e.g. env = gym.make('Doom-...'); env.close()]
+
+            3) Manually wrap calls to reset() and close() in a multiprocessing.Lock()
+
+    Wrappers:
+
+        You can use wrappers to further customize the environment
+
+            import gym
+            from gym.wrappers import doom
+            env = doom.WrapperTwo(doom.WrapperOne(gym.make('DoomTakeCover-v0'))
+
+        - Observation space:
+
+            You can use the following wrappers to change the screen resolution
+
+            'Res160x120', 'Res200x125', 'Res200x150', 'Res256x144', 'Res256x160', 'Res256x192', 'Res320x180', 'Res320x200',
+            'Res320x240', 'Res320x256', 'Res400x225', 'Res400x250', 'Res400x300', 'Res512x288', 'Res512x320', 'Res512x384',
+            'Res640x360', 'Res640x400', 'Res640x480', 'Res800x450', 'Res800x500', 'Res800x600', 'Res1024x576', 'Res1024x640',
+            'Res1024x768', 'Res1280x720', 'Res1280x800', 'Res1280x960', 'Res1280x1024', '1400x787', 'Res1400x875',
+            'Res1400x1050', 'Res1600x900', 'Res1600x1000', 'Res1600x1200', 'Res1920x1080'
+
+        - Action space:
+
+            'DiscreteMinimal' - Discrete action space with NOOP and only the level's allowed actions
+            'Discrete7'       - Discrete action space with NOOP + 7 minimum actions required to complete all levels
+            'Discrete17'      - Discrete action space with NOOP + 17 most common actions
+            'DiscreteFull'    - Discrete action space with all available actions (Deltas will not work, since their range is restricted)
+
+            'BoxMinimal'      - Box action space with only the level's allowed actions
+            'Box7'            - Box action space with 7 minimum actions required to complete all levels
+            'Box17'           - Box action space with 17 most common actions
+            'BoxFull'         - Box action space with all available actions
+
+            Note: Discrete action spaces only allow one action at a time, Box action spaces support simultaneous actions
+
+        - Control:
+
+            'HumanPlayer' - Use this wrapper if you want to play the game yourself or look around a certain level
+                            (controls are Arrow Keys, '<', '>' and Ctrl)
+            'Skip1'       - Sends action and repeats it for 1 additional step   (~ 18 fps)
+            'Skip2'       - Sends action and repeats it for 2 additional steps  (~ 12 fps)
+            'Skip3'       - Sends action and repeats it for 3 additional steps  (~ 9 fps)
+            'Skip4'       - Sends action and repeats it for 4 additional steps  (~ 7 fps)
+            'Skip5'       - Sends action and repeats it for 5 additional steps  (~ 6 fps)
+
     -----------------------------------------------------
     """
     def __init__(self):

--- a/gym/envs/doom/meta_doom.py
+++ b/gym/envs/doom/meta_doom.py
@@ -89,22 +89,6 @@ Changing Level:
 Allowed actions:
     - Each level has their own allowed actions, see each level for details
 
-Mode:
-    - env.mode can be 'fast', 'normal' or 'human' (e.g. env.mode = 'fast')
-    - 'fast' (default) will run as fast as possible (~75 fps) (best for simulation)
-    - 'normal' will run at roughly 35 fps (easier for human to watch)
-    - 'human' will let you play the game (keyboard: Arrow Keys, '<', '>' and Ctrl, mouse available for Doom Deathmatch)
-
-    e.g. to start in human mode:
-
-        import gym
-        env = gym.make('meta-Doom-v0')
-        env.mode='human'
-        env.reset()
-        num_episodes = 10
-        for i in range(num_episodes):
-            env.step([0] * 43)
-
 Actions:
     actions = [0] * 43
     actions[0] = 0       # ATTACK
@@ -112,5 +96,67 @@ Actions:
     [...]
     actions[42] = 0      # MOVE_UP_DOWN_DELTA
     A full list of possible actions is available in controls.md
+
+Configuration:
+    After creating the env, you can call env.configure() to configure some parameters.
+
+    - lock [e.g. env.configure(lock=multiprocessing_lock)]
+
+        VizDoom requires a multiprocessing lock when running across multiple processes, otherwise the vizdoom instance
+        might crash on launch
+
+        You can either:
+
+        1) [Preferred] Create a multiprocessing.Lock() and pass it as a parameter to the configure() method
+            [e.g. env.configure(lock=multiprocessing_lock)]
+
+        2) Create and close a Doom environment before running your multiprocessing routine, this will create
+            a singleton lock that will be cached in memory, and be used by all Doom environments afterwards
+            [e.g. env = gym.make('Doom-...'); env.close()]
+
+        3) Manually wrap calls to reset() and close() in a multiprocessing.Lock()
+
+Wrappers:
+
+    You can use wrappers to further customize the environment
+
+            import gym
+            from gym.wrappers import doom
+            env = doom.WrapperTwo(doom.WrapperOne(gym.make('meta-Doom-v0'))
+
+    - Observation space:
+
+        You can use the following wrappers to change the screen resolution
+
+        'Res160x120', 'Res200x125', 'Res200x150', 'Res256x144', 'Res256x160', 'Res256x192', 'Res320x180', 'Res320x200',
+        'Res320x240', 'Res320x256', 'Res400x225', 'Res400x250', 'Res400x300', 'Res512x288', 'Res512x320', 'Res512x384',
+        'Res640x360', 'Res640x400', 'Res640x480', 'Res800x450', 'Res800x500', 'Res800x600', 'Res1024x576', 'Res1024x640',
+        'Res1024x768', 'Res1280x720', 'Res1280x800', 'Res1280x960', 'Res1280x1024', '1400x787', 'Res1400x875',
+        'Res1400x1050', 'Res1600x900', 'Res1600x1000', 'Res1600x1200', 'Res1920x1080'
+
+    - Action space:
+
+        'DiscreteMinimal' - Discrete action space with NOOP and only the level's allowed actions
+        'Discrete7'       - Discrete action space with NOOP + 7 minimum actions required to complete all levels
+        'Discrete17'      - Discrete action space with NOOP + 17 most common actions
+        'DiscreteFull'    - Discrete action space with all available actions (Deltas will not work, since their range is restricted)
+
+        'BoxMinimal'      - Box action space with only the level's allowed actions
+        'Box7'            - Box action space with 7 minimum actions required to complete all levels
+        'Box17'           - Box action space with 17 most common actions
+        'BoxFull'         - Box action space with all available actions
+
+        Note: Discrete action spaces only allow one action at a time, Box action spaces support simultaneous actions
+
+    - Control:
+
+        'HumanPlayer' - Use this wrapper if you want to play the game yourself or look around a certain level
+                        (controls are Arrow Keys, '<', '>' and Ctrl)
+        'Skip1'       - Sends action and repeats it for 1 additional step   (~ 18 fps)
+        'Skip2'       - Sends action and repeats it for 2 additional steps  (~ 12 fps)
+        'Skip3'       - Sends action and repeats it for 3 additional steps  (~ 9 fps)
+        'Skip4'       - Sends action and repeats it for 4 additional steps  (~ 7 fps)
+        'Skip5'       - Sends action and repeats it for 5 additional steps  (~ 6 fps)
+
 -----------------------------------------------------
 """

--- a/gym/monitoring/monitor.py
+++ b/gym/monitoring/monitor.py
@@ -277,6 +277,7 @@ class Monitor(object):
     def _env_info(self):
         env_info = {
             'gym_version': version.VERSION,
+            'wrappers': self.env.wrappers,
         }
         if self.env.spec:
             env_info['env_id'] = self.env.spec.id
@@ -363,7 +364,7 @@ def collapse_env_infos(env_infos, training_dir):
         if first != other:
             raise error.Error('Found two unequal env_infos: {} and {}. This usually indicates that your training directory {} has commingled results from multiple runs.'.format(first, other, training_dir))
 
-    for key in ['env_id', 'gym_version']:
+    for key in ['env_id', 'gym_version', 'wrappers']:
         if key not in first:
-            raise error.Error("env_info {} from training directory {} is missing expected key {}. This is unexpected and likely indicates a bug in gym.".format(first, training_dir, key))
+            raise error.Error("env_info {} from training directory {} is missing expected key {}. This is unexpected and likely indicates a bug in gym or a deprecated training directory.".format(first, training_dir, key))
     return first

--- a/gym/scoreboard/api.py
+++ b/gym/scoreboard/api.py
@@ -21,7 +21,7 @@ def upload(training_dir, algorithm_id=None, writeup=None, api_key=None, ignore_o
 
     Args:
         training_dir (Optional[str]): A directory containing the results of a training run.
-        algorithm_id (Optional[str]): An algorithm id indicating the paricular version of the algorithm (including choices of parameters) you are running (visit https://gym.openai.com/algorithms to create an id)
+        algorithm_id (Optional[str]): An algorithm id indicating the particular version of the algorithm (including choices of parameters) you are running (visit https://gym.openai.com/algorithms to create an id)
         writeup (Optional[str]): A Gist URL (of the form https://gist.github.com/<user>/<id>) containing your writeup for this evaluation.
         api_key (Optional[str]): Your OpenAI API key. Can also be provided as an environment variable (OPENAI_GYM_API_KEY).
     """
@@ -54,6 +54,7 @@ def upload(training_dir, algorithm_id=None, writeup=None, api_key=None, ignore_o
         training_episode_batch=training_episode_batch_id,
         training_video=training_video_id,
         env=env_info['env_id'],
+        wrappers=env_info['wrappers'],
         algorithm={
             'id': algorithm_id,
         },

--- a/gym/wrappers/README.md
+++ b/gym/wrappers/README.md
@@ -1,0 +1,28 @@
+# Wrappers
+
+These are the wrappers to customize environments. Note that we may later
+restructure any of the files, but will keep the wrappers available
+at the relevant package's top-level. So for example, you should access
+`Res160x120` as follows:
+
+```
+# Will be supported in future releases
+from gym.wrappers import doom
+doom.Res160x120
+```
+
+## How to add new wrappers to Gym
+
+1. Write your wrapper in an existing collection or a new collection. All collections are subfolders of `/gym/wrappers'. The wrapper collection should be the same as the environment collection.
+2. Import your wrapper into the `__init__.py` file of the collection. This file will be located at `/gym/wrappers/my_collection/__init__.py`. Add `from gym.wrappers.my_collection.my_awesome_wrapper import MyWrapper` to this file.
+3. Write a good description of the utility of your wrapper using python docstring format (""" """ under the class definition)
+
+
+## Quick Tips
+
+- You can access the inner environment with `self._unwrapped`
+- You can access the previous layer using `self.env`
+- The variables `metadata`, `action_space`, `observation_space`, `reward_range`, and `spec` have been copied to `self` from the previous layer
+- If you do not want results from your wrapper to be uploadable to the scoreboard, set `self._uploadable = False`
+- Create a wrapped function for at least one of the following: `__init__(self, env)`, `_step`, `_reset`, `_render`, `_close`, `_configure`, or `_seed`
+- Your layered function should take its input from the previous layer (`self.env`) and/or the inner layer (`self._unwrapped`)

--- a/gym/wrappers/__init__.py
+++ b/gym/wrappers/__init__.py
@@ -1,0 +1,1 @@
+import gym.wrappers.doom

--- a/gym/wrappers/doom/__init__.py
+++ b/gym/wrappers/doom/__init__.py
@@ -1,0 +1,3 @@
+from gym.wrappers.doom.action_space import *
+from gym.wrappers.doom.control import *
+from gym.wrappers.doom.observation_space import *

--- a/gym/wrappers/doom/action_space.py
+++ b/gym/wrappers/doom/action_space.py
@@ -1,0 +1,181 @@
+import numpy as np
+import gym
+from gym import spaces
+
+# Constants
+NUM_ACTIONS = 43
+ALLOWED_ACTIONS = [
+    [0, 10, 11],                                # 0 - Basic
+    [0, 10, 11, 13, 14, 15],                    # 1 - Corridor
+    [0, 14, 15],                                # 2 - DefendCenter
+    [0, 14, 15],                                # 3 - DefendLine
+    [13, 14, 15],                               # 4 - HealthGathering
+    [13, 14, 15],                               # 5 - MyWayHome
+    [0, 14, 15],                                # 6 - PredictPosition
+    [10, 11],                                   # 7 - TakeCover
+    [x for x in range(NUM_ACTIONS) if x != 33], # 8 - Deathmatch
+]
+
+__all__ = [ 'DiscreteMinimal', 'Discrete7', 'Discrete17', 'DiscreteFull',
+            'BoxMinimal', 'Box7', 'Box17', 'BoxFull']
+
+# Helper functions
+
+class DiscreteToHighLow(object):
+    """ Acts as a filter between HighLow and Discrete (only one button can be pressed at a time) """
+    def __init__(self, high_low_space, allowed_actions=None):
+        assert isinstance(high_low_space, spaces.HighLow)
+        self.actions = allowed_actions if allowed_actions is not None else list(range(high_low_space.shape))
+        # +1 to take into account noop at beginning
+        self.mapping = {(i + 1): self.actions[i] for i in range(len(self.actions))}
+        self.n = high_low_space.shape
+        self.discrete_n = len(self.actions) + 1
+
+    def __call__(self, act):
+        action_list = [0] * self.n
+        if act in self.mapping:
+            action_list[self.mapping[act]] = 1
+        return action_list
+
+class BoxToHighLow(object):
+    """ Acts as a filter between HighLow and Box (values are value based on HighLow precision level) """
+    def __init__(self, high_low_space, allowed_actions=None):
+        assert isinstance(high_low_space, spaces.HighLow)
+        self.actions = allowed_actions if allowed_actions is not None else list(range(high_low_space.shape))
+        self.low = [high_low_space.matrix[i, 0] for i in self.actions]
+        self.high = [high_low_space.matrix[i, 1] for i in self.actions]
+        self.precision = [high_low_space.matrix[i, 2] for i in range(high_low_space.shape)]
+        self.box = spaces.Box(np.array(self.low), np.array(self.high))
+        self.n = high_low_space.shape
+
+    def __call__(self, box_array):
+        action_list = [0] * self.n
+        for ind, i in enumerate(self.actions):
+            action_list[i] = round(box_array[ind], self.precision[i])
+        return action_list
+
+# Wrappers
+
+class DiscreteMinimal(gym.Wrapper):
+    """
+        Converts HighLow action space to Discrete with NOOP and only the level's allowed actions
+        Discrete only supports one action at a given time
+
+        Basic:              NOOP, ATTACK, MOVE_RIGHT, MOVE_LEFT
+        Corridor:           NOOP, ATTACK, MOVE_RIGHT, MOVE_LEFT, MOVE_FORWARD, TURN_RIGHT, TURN_LEFT
+        DefendCenter        NOOP, ATTACK, TURN_RIGHT, TURN_LEFT
+        DefendLine:         NOOP, ATTACK, TURN_RIGHT, TURN_LEFT
+        HealthGathering:    NOOP, MOVE_FORWARD, TURN_RIGHT, TURN_LEFT
+        MyWayHome:          NOOP, MOVE_FORWARD, TURN_RIGHT, TURN_LEFT
+        PredictPosition:    NOOP, ATTACK, TURN_RIGHT, TURN_LEFT
+        TakeCover:          NOOP, MOVE_RIGHT, MOVE_LEFT
+        Deathmatch:         NOOP, ALL COMMANDS (Deltas are limited to [0,1] range and will not work properly)
+    """
+    def __init__(self, env):
+        allowed_actions = ALLOWED_ACTIONS[self._unwrapped.level]
+        self.action_filter = DiscreteToHighLow(self.action_space, allowed_actions)
+        self.action_space = spaces.Discrete(self.action_filter.discrete_n)
+    def _step(self, action):
+        return self.env._step(self.action_filter(action))
+
+class Discrete7(gym.Wrapper):
+    """
+        Converts HighLow action space to Discrete with the 8 minimum actions required to complete all levels
+        Actions are NOOP, ATTACK, MOVE_RIGHT, MOVE_LEFT, MOVE_FORWARD, TURN_RIGHT, TURN_LEFT, SELECT_NEXT_WEAPON
+        Discrete only supports one action at a given time
+    """
+    def __init__(self, env):
+        allowed_actions = [0, 10, 11, 13, 14, 15, 31]
+        self.action_filter = DiscreteToHighLow(self.action_space, allowed_actions)
+        self.action_space = spaces.Discrete(self.action_filter.discrete_n)
+    def _step(self, action):
+        return self.env._step(self.action_filter(action))
+
+class Discrete17(gym.Wrapper):
+    """
+        Converts HighLow action space to Discrete with the 18 most used actions
+        Actions are NOOP, ATTACK, JUMP, CROUCH, TURN180, RELOAD, SPEED, STRAFE, MOVE_RIGHT, MOVE_LEFT, MOVE_BACKWARD
+                    MOVE_FORWARD, TURN_RIGHT, TURN_LEFT, LOOK_UP, LOOK_DOWN, SELECT_NEXT_WEAPON, SELECT_PREV_WEAPON
+        Discrete only supports one action at a given time
+    """
+    def __init__(self, env):
+        allowed_actions = [0, 2, 3, 4, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 31, 32]
+        self.action_filter = DiscreteToHighLow(self.action_space, allowed_actions)
+        self.action_space = spaces.Discrete(self.action_filter.discrete_n)
+    def _step(self, action):
+        return self.env._step(self.action_filter(action))
+
+class DiscreteFull(gym.Wrapper):
+    """
+        Converts HighLow action space to Discrete with the all available actions
+        Discrete only supports one action at a given time
+    """
+    def __init__(self, env):
+        self.action_filter = DiscreteToHighLow(self.action_space)
+        self.action_space = spaces.Discrete(self.action_filter.discrete_n)
+    def _step(self, action):
+        return self.env._step(self.action_filter(action))
+
+class BoxMinimal(gym.Wrapper):
+    """
+        Converts HighLow action space to Box with only the level's allowed actions
+        Values are automatically rounded to the nearest integer
+        Box supports multiple simultaneous actions
+
+        Basic:              ATTACK, MOVE_RIGHT, MOVE_LEFT
+        Corridor:           ATTACK, MOVE_RIGHT, MOVE_LEFT, MOVE_FORWARD, TURN_RIGHT, TURN_LEFT
+        DefendCenter        ATTACK, TURN_RIGHT, TURN_LEFT
+        DefendLine:         ATTACK, TURN_RIGHT, TURN_LEFT
+        HealthGathering:    MOVE_FORWARD, TURN_RIGHT, TURN_LEFT
+        MyWayHome:          MOVE_FORWARD, TURN_RIGHT, TURN_LEFT
+        PredictPosition:    ATTACK, TURN_RIGHT, TURN_LEFT
+        TakeCover:          MOVE_RIGHT, MOVE_LEFT
+        Deathmatch:         ALL COMMANDS
+    """
+    def __init__(self, env):
+        allowed_actions = ALLOWED_ACTIONS[self._unwrapped.level]
+        self.action_filter = BoxToHighLow(self.action_space, allowed_actions)
+        self.action_space = self.action_filter.box
+    def _step(self, action):
+        return self.env._step(self.action_filter(action))
+
+class Box7(gym.Wrapper):
+    """
+        Converts HighLow action space to Box with the 8 minimum actions required to complete all levels
+        Values are automatically rounded to the nearest integer
+        Actions are NOOP, ATTACK, MOVE_RIGHT, MOVE_LEFT, MOVE_FORWARD, TURN_RIGHT, TURN_LEFT, SELECT_NEXT_WEAPON
+        Box supports multiple simultaneous actions
+    """
+    def __init__(self, env):
+        allowed_actions = [0, 10, 11, 13, 14, 15, 31]
+        self.action_filter = BoxToHighLow(self.action_space, allowed_actions)
+        self.action_space = self.action_filter.box
+    def _step(self, action):
+        return self.env._step(self.action_filter(action))
+
+class Box17(gym.Wrapper):
+    """
+        Converts HighLow action space to Box with the 18 most used actions
+        Values are automatically rounded to the nearest integer
+        Actions are NOOP, ATTACK, JUMP, CROUCH, TURN180, RELOAD, SPEED, STRAFE, MOVE_RIGHT, MOVE_LEFT, MOVE_BACKWARD
+                    MOVE_FORWARD, TURN_RIGHT, TURN_LEFT, LOOK_UP, LOOK_DOWN, SELECT_NEXT_WEAPON, SELECT_PREV_WEAPON
+        Box supports multiple simultaneous actions
+    """
+    def __init__(self, env):
+        allowed_actions = [0, 2, 3, 4, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 31, 32]
+        self.action_filter = BoxToHighLow(self.action_space, allowed_actions)
+        self.action_space = self.action_filter.box
+    def _step(self, action):
+        return self.env._step(self.action_filter(action))
+
+class BoxFull(gym.Wrapper):
+    """
+        Converts HighLow action space to Box with the all available actions
+        Values are automatically rounded to the nearest integer
+        Box supports multiple simultaneous actions
+    """
+    def __init__(self, env):
+        self.action_filter = BoxToHighLow(self.action_space)
+        self.action_space = self.action_filter.box
+    def _step(self, action):
+        return self.env._step(self.action_filter(action))

--- a/gym/wrappers/doom/control.py
+++ b/gym/wrappers/doom/control.py
@@ -1,0 +1,48 @@
+import gym
+
+__all__ = ['HumanPlayer', 'Skip1', 'Skip2', 'Skip3', 'Skip4', 'Skip5']
+
+# Helper functions
+
+def skip_n(wrapper, action, skip_steps):
+    done = False
+    rew_total = 0
+    current_step = 0
+    while current_step < (skip_steps + 1) and not done:
+        obs, rew, done, info = wrapper.env.step(action)
+        rew_total += rew
+        current_step += 1
+    return obs, rew_total, done, info
+
+# Wrappers
+
+class HumanPlayer(gym.Wrapper):
+    """ Allows a human to play the level """
+    def __init__(self, env):
+        self._uploadable = False
+        self._unwrapped._mode = 'human'
+
+class Skip1(gym.Wrapper):
+    """ Sends action, and repeats it for 1 additional step """
+    def _step(self, action):
+        return skip_n(self, action, 1)
+
+class Skip2(gym.Wrapper):
+    """ Sends action, and repeats it for 2 additional steps """
+    def _step(self, action):
+        return skip_n(self, action, 2)
+
+class Skip3(gym.Wrapper):
+    """ Sends action, and repeats it for 3 additional steps """
+    def _step(self, action):
+        return skip_n(self, action, 3)
+
+class Skip4(gym.Wrapper):
+    """ Sends action, and repeats it for 4 additional steps """
+    def _step(self, action):
+        return skip_n(self, action, 4)
+
+class Skip5(gym.Wrapper):
+    """ Sends action, and repeats it for 5 additional steps """
+    def _step(self, action):
+        return skip_n(self, action, 5)

--- a/gym/wrappers/doom/observation_space.py
+++ b/gym/wrappers/doom/observation_space.py
@@ -1,0 +1,303 @@
+import gym
+from gym import utils, spaces
+
+try:
+    from doom_py import ScreenResolution
+except ImportError as e:
+    raise gym.error.DependencyNotInstalled("{}. (HINT: you can install Doom dependencies " +
+                                           "with 'pip install gym[doom].)'".format(e))
+
+__all__ = ['Res160x120', 'Res200x125', 'Res200x150', 'Res256x144', 'Res256x160', 'Res256x192', 'Res320x180', 'Res320x200',
+            'Res320x240', 'Res320x256', 'Res400x225', 'Res400x250', 'Res400x300', 'Res512x288', 'Res512x320', 'Res512x384',
+            'Res640x360', 'Res640x400', 'Res640x480', 'Res800x450', 'Res800x500', 'Res800x600', 'Res1024x576', 'Res1024x640',
+            'Res1024x768', 'Res1280x720', 'Res1280x800', 'Res1280x960', 'Res1280x1024', 'Res1400x787', 'Res1400x875',
+            'Res1400x1050', 'Res1600x900', 'Res1600x1000', 'Res1600x1200', 'Res1920x1080']
+
+class Res160x120(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 160x120 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 160, 120, ScreenResolution.RES_160X120
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res200x125(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 200x125 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 200, 125, ScreenResolution.RES_200X125
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res200x150(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 200x150 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 200, 150, ScreenResolution.RES_200X150
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res256x144(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 256x144 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 256, 144, ScreenResolution.RES_256X144
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res256x160(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 256x160 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 256, 160, ScreenResolution.RES_256X160
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res256x192(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 256x192 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 256, 192, ScreenResolution.RES_256X192
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res320x180(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 320x180 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 320, 180, ScreenResolution.RES_320X180
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res320x200(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 320x200 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 320, 200, ScreenResolution.RES_320X200
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res320x240(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 320x240 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 320, 240, ScreenResolution.RES_320X240
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res320x256(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 320x256 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 320, 256, ScreenResolution.RES_320X256
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res400x225(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 400x225 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 400, 225, ScreenResolution.RES_400X225
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res400x250(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 400x250 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 400, 250, ScreenResolution.RES_400X250
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res400x300(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 400x300 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 400, 300, ScreenResolution.RES_400X300
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res512x288(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 512x288 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 512, 288, ScreenResolution.RES_512X288
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res512x320(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 512x320 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 512, 320, ScreenResolution.RES_512X320
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res512x384(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 512x384 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 512, 384, ScreenResolution.RES_512X384
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res640x360(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 640x360 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 640, 360, ScreenResolution.RES_640X360
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res640x400(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 640x400 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 640, 400, ScreenResolution.RES_640X400
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res640x480(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 640x480 """
+    def __init__(self, env):
+        self._uploadable = True
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 640, 480, ScreenResolution.RES_640X480
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res800x450(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 800x450 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 800, 450, ScreenResolution.RES_800X450
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res800x500(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 800x500 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 800, 500, ScreenResolution.RES_800X500
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res800x600(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 800x600 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 800, 600, ScreenResolution.RES_800X600
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1024x576(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1024x576 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1024, 576, ScreenResolution.RES_1024X576
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1024x640(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1024x640 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1024, 640, ScreenResolution.RES_1024X640
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1024x768(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1024x768 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1024, 768, ScreenResolution.RES_1024X768
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1280x720(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1280x720 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1280, 720, ScreenResolution.RES_1280X720
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1280x800(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1280x800 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1280, 800, ScreenResolution.RES_1280X800
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1280x960(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1280x960 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1280, 960, ScreenResolution.RES_1280X960
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1280x1024(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1280x1024 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1280, 1024, ScreenResolution.RES_1280X1024
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1400x787(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1400x747 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1400, 787, ScreenResolution.RES_1400X787
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1400x875(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1400x875 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1400, 875, ScreenResolution.RES_1400X875
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1400x1050(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1400x1050 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1400, 1050, ScreenResolution.RES_1400X1050
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1600x900(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1600x900 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1600, 900, ScreenResolution.RES_1600X900
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1600x1000(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1600x1000 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1600, 1000, ScreenResolution.RES_1600X1000
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1600x1200(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1600x1200 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1600, 1200, ScreenResolution.RES_1600X1200
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space
+
+class Res1920x1080(gym.Wrapper):
+    """ Changes observation space (screen resolution) to 1920x1080 """
+    def __init__(self, env):
+        unwrapped = self._unwrapped
+        self.screen_width, self.screen_height, unwrapped.screen_resolution = 1920, 1080, ScreenResolution.RES_1920X1080
+        unwrapped.observation_space = spaces.Box(low=0, high=255, shape=(self.screen_height, self.screen_width, 3))
+        self.observation_space = unwrapped.observation_space


### PR DESCRIPTION
Issue #257 - Doom envs create from threads leave behind running vizdoom
- Added lock param, required to run VizDoom across processes
- Added __enter__ and __exit__ on env.core, so envs can be created with a 'with' block, and without needing to call .close() explicitly.

e.g.
```python
with gym.make('DoomBasic-v0') as env:
    env.reset()
    done = False
    while not done:
        obs, rew, done, info = env.step(env.action_space.sample())
```

Issue #248 - Too large action spaces for most Doom environments
- Added screen_resolution and action_filter on configure() method to convert HighLow action space to Discrete

Submitting both fix together, since they both relate to modifying the configure() method