### PR TITLE
Docker - Minor fix for pull requests

### DIFF
--- a/bin/docker_entrypoint
+++ b/bin/docker_entrypoint
@@ -6,7 +6,7 @@ set -e
 
 path=$(cd $(dirname "$0") && pwd)
 
-[ -z ${MUJOCO_KEY_BUNDLE+x} ] || ( mkdir -p ~/.mujoco && curl https://openai-public.s3-us-west-2.amazonaws.com/mujoco/$MUJOCO_KEY_BUNDLE.tar.gz | tar xz -C ~/.mujoco )
+[ -z "${MUJOCO_KEY_BUNDLE}" ] || ( mkdir -p ~/.mujoco && curl https://openai-public.s3-us-west-2.amazonaws.com/mujoco/$MUJOCO_KEY_BUNDLE.tar.gz | tar xz -C ~/.mujoco )
 
 # Set up display; otherwise rendering will fail
 rm -f /tmp/.X12-lock

--- a/test.dockerfile
+++ b/test.dockerfile
@@ -26,10 +26,10 @@ RUN apt-get update \
 
 WORKDIR /usr/local/gym
 RUN mkdir -p gym && touch gym/__init__.py
-COPY ./gym/version.py ./gym
-COPY ./requirements.txt .
-COPY ./setup.py .
-COPY ./tox.ini .
+COPY ./gym/version.py ./gym/
+COPY ./requirements.txt ./
+COPY ./setup.py ./
+COPY ./tox.ini ./
 
 RUN pip install tox
 # Install the relevant dependencies. Keep printing so Travis knows we're alive.


### PR DESCRIPTION
- MUJOCO_KEY_BUNDLE is an empty string in pull requests, rather than being unset.
- Split py27 and py34 to avoid hitting the 50 mins timeout, and for easier debugging.
- COPY takes a trailing slash as per documentation
```
If <dest> does not end with a trailing slash, it will be considered a regular file and the contents of <src> will be written at <dest>.
```