### PR TITLE
Added a termination condition for the Half Cheetah env when it is upside down.

### DIFF
--- a/gym/envs/mujoco/half_cheetah.py
+++ b/gym/envs/mujoco/half_cheetah.py
@@ -15,7 +15,10 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         reward_ctrl = - 0.1 * np.square(action).sum()
         reward_run = (xposafter - xposbefore)/self.dt
         reward = reward_ctrl + reward_run
-        done = False
+        if self.model.data.qpos[1,0] < -0.25:
+            done = True
+        else:
+            done = False
         return ob, reward, done, dict(reward_run = reward_run, reward_ctrl=reward_ctrl)
 
     def _get_obs(self):


### PR DESCRIPTION
Done condition in Half cheetah is always set to false. But I think it should be true when the agent goes upside down.