### PR TITLE
Removing dot files with no cd

### DIFF
--- a/test.dockerfile
+++ b/test.dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && easy_install pip
 
-WORKDIR /usr/local/gym
+WORKDIR /usr/local/gym/
 RUN mkdir -p gym && touch gym/__init__.py
 COPY ./gym/version.py ./gym/
 COPY ./requirements.txt ./
@@ -35,9 +35,9 @@ RUN pip install tox
 # Install the relevant dependencies. Keep printing so Travis knows we're alive.
 RUN ["bash", "-c", "( while true; do echo '.'; sleep 60; done ) & tox --notest"]
 
-# Finally, clean cached code and upload our actual code!
-RUN mv .tox /tmp/.tox && cd .. & rm -rf gym && mkdir gym && cd gym && mv /tmp/.tox .tox
-COPY . /usr/local/gym
+# Finally, clean cached code (including dot files) and upload our actual code!
+RUN mv .tox /tmp/.tox && rm -rf .??* * && mv /tmp/.tox .tox
+COPY . /usr/local/gym/
 
 ENTRYPOINT ["/usr/local/gym/bin/docker_entrypoint"]
 CMD ["tox"]


### PR DESCRIPTION
This should work. Added missing trailing slashes from PR 264.

My test case:
```
Sending build context to Docker daemon 2.048 kB
Step 1 : FROM ubuntu:14.04
 ---> ff6011336327

Step 2 : WORKDIR /root/
 ---> Running in e9fdce1fd470
 ---> bdc7b58ee3c3
Removing intermediate container e9fdce1fd470

Step 3 : RUN mkdir -p .tox && mkdir -p .tox2 && touch .tox/a.txt && touch .tox2/b.txt && mkdir -p /tmp && touch abc.txt && mkdir -p c && touch c/c.txt
 ---> Running in 60a49ffa62b9
 ---> d9b8779eeabf
Removing intermediate container 60a49ffa62b9

Step 4 : RUN ls -lhA
 ---> Running in 91dc7db77d6a
total 20K
-rw-r--r-- 1 root root 3.1K Feb 20  2014 .bashrc
-rw-r--r-- 1 root root  140 Feb 20  2014 .profile
drwxr-xr-x 2 root root 4.0K Aug 13 20:41 .tox
drwxr-xr-x 2 root root 4.0K Aug 13 20:41 .tox2
-rw-r--r-- 1 root root    0 Aug 13 20:41 abc.txt
drwxr-xr-x 2 root root 4.0K Aug 13 20:41 c
 ---> f5908ce0c168
Removing intermediate container 91dc7db77d6a

Step 5 : RUN mv .tox /tmp/.tox && rm -rf .??* * && mv /tmp/.tox .tox
 ---> Running in 80a659b1ee3d
 ---> f5b8ce5b9595
Removing intermediate container 80a659b1ee3d

Step 6 : RUN ls -lhA
 ---> Running in 7b8d73063616
total 4.0K
drwxr-xr-x 2 root root 4.0K Aug 13 20:41 .tox
 ---> 990db3fcb17b
Removing intermediate container 7b8d73063616

Step 7 : CMD /bin/bash
 ---> Running in 88ccaac92af0
 ---> e5ee241cdc0d
Removing intermediate container 88ccaac92af0
Successfully built e5ee241cdc0d
```
