### PR TITLE
Allow envs to be registered on the scoreboard but not in gym core

### DIFF
--- a/gym/scoreboard/registration.py
+++ b/gym/scoreboard/registration.py
@@ -38,19 +38,20 @@ class Registry(object):
             self.groups[group]['envs'].append(id)
 
     def finalize(self, strict=False):
-        # Extract all IDs we know about
-        registered_ids = set(env_id for group in self.groups.values() for env_id in group['envs'])
-        # Extract all IDs gym knows about
-        all_ids = set(spec.id for spec in gym.envs.registry.all() if spec._entry_point and not spec._local_only)
+        # Extract all IDs the scoreboard knows about
+        scoreboard_ids = set(env_id for group in self.groups.values() for env_id in group['envs'])
+        # Extract all IDs gym core knows about, which does not include
+        # any external packages
+        gym_core_ids = set(spec.id for spec in gym.envs.registry.all() if spec._entry_point and not spec._local_only)
 
-        missing = all_ids - registered_ids
-        extra = registered_ids - all_ids
+        missing = gym_core_ids - scoreboard_ids
+        # Note: it is not an error if the scoreboard contains envs that are
+        # not registered in gym core, because some scoreboard envs may come from
+        # external packages
 
         message = []
         if missing:
             message.append('Scoreboard did not register all envs: {}'.format(missing))
-        if extra:
-            message.append('Scoreboard registered non-existent or deprecated envs: {}'.format(extra))
 
         if len(message) > 0:
             message = ' '.join(message)


### PR DESCRIPTION
In order to enable user-contributed environments to be listed on the scoreboard, but not packaged with gym core or included in the gym.make() registry, the "finalize" test in gym.scoreboard.registration needs to become more lenient. We still ensure that all gym core envs are in the scoreboard, but we now permit envs to exist in the scoreboard registry that are not in gym core.