### PR TITLE
Fix error when running min on empty list

### DIFF
--- a/gym/monitoring/monitor.py
+++ b/gym/monitoring/monitor.py
@@ -360,7 +360,7 @@ def merge_stats_files(stats_files):
     timestamps = np.array(timestamps)[idxs].tolist()
     episode_lengths = np.array(episode_lengths)[idxs].tolist()
     episode_rewards = np.array(episode_rewards)[idxs].tolist()
-    initial_reset_timestamp = min(initial_reset_timestamps)
+    initial_reset_timestamp = min(initial_reset_timestamps) if len(initial_reset_timestamps) > 0 else []
     return timestamps, episode_lengths, episode_rewards, initial_reset_timestamp
 
 def collapse_env_infos(env_infos, training_dir):

--- a/gym/monitoring/monitor.py
+++ b/gym/monitoring/monitor.py
@@ -360,7 +360,12 @@ def merge_stats_files(stats_files):
     timestamps = np.array(timestamps)[idxs].tolist()
     episode_lengths = np.array(episode_lengths)[idxs].tolist()
     episode_rewards = np.array(episode_rewards)[idxs].tolist()
-    initial_reset_timestamp = min(initial_reset_timestamps) if len(initial_reset_timestamps) > 0 else []
+    
+    if len(initial_reset_timestamps) > 0:
+        initial_reset_timestamp = min(initial_reset_timestamps)
+    else:
+        initial_reset_timestamp = 0
+        
     return timestamps, episode_lengths, episode_rewards, initial_reset_timestamp
 
 def collapse_env_infos(env_infos, training_dir):


### PR DESCRIPTION
Running min on an empty list (which occurs on first episode from `if len(content['timestamps'])==0: continue`) causes it to throw an error