### PR TITLE
Force integer conversion in blackjack env comparison function

### DIFF
--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -3,7 +3,7 @@ from gym import spaces
 from gym.utils import seeding
 
 def cmp(a, b):
-    return (a > b) - (a < b)
+    return int((a > b)) - int((a < b))
 
 # 1 = Ace, 2-10 = Number cards, Jack/Queen/King = 10
 deck = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10]


### PR DESCRIPTION
Bug in the Blackjack environment: The hand comparison function returns a boolean, which is converted into a 0/1 reward, but the rewards should be -1, 0 or +1. For example, always picking the "stick" action results in never losing a game with a -1 reward.

Numpy also gives a warning: 

```
DeprecationWarning: numpy boolean subtract, the `-` operator, is deprecated.
```
