### PR TITLE
Fix Taxi-v1 for Python 3

### DIFF
--- a/gym/envs/tests/rollout_py3.json
+++ b/gym/envs/tests/rollout_py3.json
@@ -483,7 +483,7 @@
     "dones": "ecfbe8578a5aac6442d7b65f2e4bd4f6d70e5cdc76c1d6868ee031460c7477b9",
     "rewards": "36cef7344bd1692a0ecf95ae868270fe39c57686a8076abfe58bd11a6f255bb9",
     "actions": "7364c36f0f18ebecf3d6086b3e09a8944af50d3f40f25c2efb338bc42cc7255a",
-    "observations": "76237ddcbaa694880c46f98785741585698121ad214892f22570cca8bbf7f127"
+    "observations": "cbf716b5409407e877006bfdd0705889ce324ff0b7883e70984401b62c15322c"
   },
   "YarsRevenge-ram-v0": {
     "dones": "ecfbe8578a5aac6442d7b65f2e4bd4f6d70e5cdc76c1d6868ee031460c7477b9",

--- a/gym/envs/toy_text/taxi.py
+++ b/gym/envs/toy_text/taxi.py
@@ -62,9 +62,9 @@ class TaxiEnv(discrete.DiscreteEnv):
                                 newrow = min(row+1, maxR)
                             elif a==1:
                                 newrow = max(row-1, 0)
-                            if a==2 and self.desc[1+row,2*col+2]==":":
+                            if a==2 and self.desc[1+row,2*col+2]==b":":
                                 newcol = min(col+1, maxC)
-                            elif a==3 and self.desc[1+row,2*col]==":":
+                            elif a==3 and self.desc[1+row,2*col]==b":":
                                 newcol = max(col-1, 0)
                             elif a==4: # pickup
                                 if (passidx < 4 and taxiloc == locs[passidx]):


### PR DESCRIPTION
This fixes the East and West actions in Taxi-v1 for Python 3.

I haven't bumped the version because v1 is now essentially broken in Python 3 anyway.