### PR TITLE
Add universal 'dim' interface to all spaces.

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -307,6 +307,10 @@ class Space(object):
         # By default, assume identity is JSONable
         return sample_n
 
+    @property
+    def dim(self):
+        raise NotImplementedError
+
 class Wrapper(Env):
     _owns_render = False
 

--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -38,6 +38,9 @@ class Box(gym.Space):
     @property
     def shape(self):
         return self.low.shape
+    @property
+    def dim(self):
+        return len(self.low)
     def __repr__(self):
         return "Box" + str(self.shape)
     def __eq__(self, other):

--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -26,3 +26,8 @@ class Discrete(gym.Space):
         return "Discrete(%d)" % self.n
     def __eq__(self, other):
         return self.n == other.n
+
+    @property
+    def dim(self):
+        return self.n
+ 

--- a/gym/spaces/multi_discrete.py
+++ b/gym/spaces/multi_discrete.py
@@ -42,6 +42,9 @@ class MultiDiscrete(gym.Space):
     @property
     def shape(self):
         return self.num_discrete_space
+    @property
+    def dim(self):
+        return np.sum(self.high - self.low)
     def __repr__(self):
         return "MultiDiscrete" + str(self.num_discrete_space)
     def __eq__(self, other):
@@ -146,6 +149,10 @@ class DiscreteToMultiDiscrete(Discrete):
     def __call__(self, discrete_action):
         return self.mapping[discrete_action]
 
+    @property
+    def dim(self):
+        return self.multi_discrete.dim
+ 
 
 class BoxToMultiDiscrete(Box):
     """
@@ -210,3 +217,8 @@ class BoxToMultiDiscrete(Box):
         for i in self.mapping:
             multi_discrete_action[self.mapping[i]] = int(round(box_action[i], 0))
         return multi_discrete_action
+
+    @property
+    def dim(self):
+        return self.multi_discrete.dim
+ 

--- a/gym/spaces/tuple_space.py
+++ b/gym/spaces/tuple_space.py
@@ -29,3 +29,7 @@ class Tuple(Space):
 
     def from_jsonable(self, sample_n):
         return zip(*[space.from_jsonable(sample_n[i]) for i, space in enumerate(self.spaces)])
+
+    @property
+    def dim(self):
+        return sum([space.dim for space in self.spaces])


### PR DESCRIPTION
Exposing the state dimension will allow more generality in designing algorithms. For example, the parameters of a linear model will share the same dimension as the state space. Without this change, algorithms have to manually configure for each different state space.