### PR TITLE
Wrapper metadata typo

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -316,10 +316,9 @@ class Wrapper(Env):
 
     def __init__(self, env=None):
         self.env = env
-        # Merge with the base metadata
-        metadata = self.metadata
-        self.metadata = self.env.metadata.copy()
-        self.metadata.update(metadata)
+        # Copy metadata from base class to this object instance, override with env.metadata
+        self.metadata = self.metadata.copy()
+        self.metadata.update(self.env.metadata)
 
         self.action_space = self.env.action_space
         self.observation_space = self.env.observation_space


### PR DESCRIPTION
Good idea, the wrappers. Started to use, found a bug, here's a fix and a sample to test:

```python
import gym
from gym.wrappers import SkipWrapper

every_two_frame = SkipWrapper(2)
env = gym.make("FrozenLake-v0")
env = every_two_frame(env)
obs = env.reset()
for _ in range(1000):
  env.render()
  action = env.action_space.sample()
  obs, reward, done, info = env.step(action)
```

(doesn't work with master, works after this PR)
