### PR TITLE
Fix Taxi (upgrade -> v2)

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -168,7 +168,7 @@ register(
     id='Taxi-v2',
     entry_point='gym.envs.toy_text.taxi:TaxiEnv',
     tags={'wrapper_config.TimeLimit.max_episode_steps': 200},
-    reward_threshold=9.7, # optimum = 10.2
+    reward_threshold=8, # optimum = 8.46
 )
 
 register(

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -165,7 +165,7 @@ register(
 )
 
 register(
-    id='Taxi-v1',
+    id='Taxi-v2',
     entry_point='gym.envs.toy_text.taxi:TaxiEnv',
     tags={'wrapper_config.TimeLimit.max_episode_steps': 200},
     reward_threshold=9.7, # optimum = 10.2

--- a/gym/envs/tests/rollout.json
+++ b/gym/envs/tests/rollout.json
@@ -3740,7 +3740,7 @@
   "Taxi-v2": {
     "actions": "7364c36f0f18ebecf3d6086b3e09a8944af50d3f40f25c2efb338bc42cc7255a",
     "dones": "ecfbe8578a5aac6442d7b65f2e4bd4f6d70e5cdc76c1d6868ee031460c7477b9",
-    "observations": "cbf716b5409407e877006bfdd0705889ce324ff0b7883e70984401b62c15322c",
+    "observations": "4a9b043754645cd675313e42a2fd8c41a7644b1720465a9567c728b57dde8320",
     "rewards": "36cef7344bd1692a0ecf95ae868270fe39c57686a8076abfe58bd11a6f255bb9"
   },
   "Tennis-ram-v0": {

--- a/gym/envs/tests/rollout.json
+++ b/gym/envs/tests/rollout.json
@@ -3737,7 +3737,7 @@
     "observations": "dc6a89cebe2307516a293b41439499bc899adeca63abddd0ebd36b042355bafb",
     "rewards": "04db9812be236ea437cbda6cea214bba8c79760fb57a66176704503576f6f390"
   },
-  "Taxi-v1": {
+  "Taxi-v2": {
     "actions": "7364c36f0f18ebecf3d6086b3e09a8944af50d3f40f25c2efb338bc42cc7255a",
     "dones": "ecfbe8578a5aac6442d7b65f2e4bd4f6d70e5cdc76c1d6868ee031460c7477b9",
     "observations": "cbf716b5409407e877006bfdd0705889ce324ff0b7883e70984401b62c15322c",

--- a/gym/envs/toy_text/taxi.py
+++ b/gym/envs/toy_text/taxi.py
@@ -48,10 +48,10 @@ class TaxiEnv(discrete.DiscreteEnv):
             for col in range(5):
                 for passidx in range(5):
                     for destidx in range(4):
+                        state = self.encode(row, col, passidx, destidx)
                         if passidx < 4 and passidx != destidx:
                             isd[state] += 1
                         for a in range(nA):
-                            state = self.encode(row, col, passidx, destidx)
                             # defaults
                             newrow, newcol, newpassidx = row, col, passidx
                             reward = -1

--- a/gym/scoreboard/__init__.py
+++ b/gym/scoreboard/__init__.py
@@ -610,7 +610,7 @@ add_task(
 )
 
 add_task(
-    id='Taxi-v1',
+    id='Taxi-v2',
     group='toy_text',
     summary='As a taxi driver, you need to pick up and drop off passengers as fast as possible.',
     description="""


### PR DESCRIPTION
This fixes the initial state distribution of Taxi such that it no longer produces a start location equal to the goal location (issue #72). At the moment the distribution is not what's expected.

The new reward threshold was calculated using policy iteration.