### PR TITLE
Disable ALE's underlying repeat_action_probability

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -275,13 +275,13 @@ for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix', 'asteroids', '
         register(
             id='{}-v0'.format(name),
             entry_point='gym.envs.atari:AtariEnv',
-            kwargs={'game': game, 'obs_type': obs_type},
+            kwargs={'game': game, 'obs_type': obs_type, 'repeat_action_probability': 0.25},
             timestep_limit=10000,
             nondeterministic=nondeterministic,
         )
 
         register(
-            id='{}-v1'.format(name),
+            id='{}-v2'.format(name),
             entry_point='gym.envs.atari:AtariEnv',
             kwargs={'game': game, 'obs_type': obs_type},
             timestep_limit=100000,
@@ -296,16 +296,7 @@ for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix', 'asteroids', '
 
         register(
             # Use a deterministic frame skip.
-            id='{}Deterministic-v0'.format(name),
-            entry_point='gym.envs.atari:AtariEnv',
-            kwargs={'game': game, 'obs_type': obs_type, 'frameskip': frameskip},
-            timestep_limit=10000,
-            nondeterministic=nondeterministic,
-        )
-
-        register(
-            # Use a deterministic frame skip.
-            id='{}Deterministic-v1'.format(name),
+            id='{}Deterministic-v2'.format(name),
             entry_point='gym.envs.atari:AtariEnv',
             kwargs={'game': game, 'obs_type': obs_type, 'frameskip': frameskip},
             timestep_limit=100000,
@@ -315,18 +306,10 @@ for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix', 'asteroids', '
         # No frameskip. (Atari has no entropy source, so these are
         # deterministic environments.)
         register(
-            id='{}NoFrameskip-v0'.format(name),
+            id='{}NoFrameskip-v2'.format(name),
             entry_point='gym.envs.atari:AtariEnv',
             kwargs={'game': game, 'obs_type': obs_type, 'frameskip': 1}, # A frameskip of 1 means we get every frame
-            timestep_limit=40000,
-            nondeterministic=nondeterministic,
-        )
-
-        register(
-            id='{}NoFrameskip-v1'.format(name),
-            entry_point='gym.envs.atari:AtariEnv',
-            kwargs={'game': game, 'obs_type': obs_type, 'frameskip': 1}, # A frameskip of 1 means we get every frame
-            timestep_limit=400000,
+            timestep_limit=frameskip * 100000,
             nondeterministic=nondeterministic,
         )
 

--- a/gym/envs/atari/atari_env.py
+++ b/gym/envs/atari/atari_env.py
@@ -48,7 +48,7 @@ class AtariEnv(gym.Env, utils.EzPickle):
         # Tune (or disable) ALE's action repeat:
         # https://github.com/openai/gym/issues/349
         assert isinstance(repeat_action_probability, (float, int)), "Invalid repeat_action_probability: {!r}".format(repeat_action_probability)
-        self.ale.setFloat('repeat_action_probability', repeat_action_probability)
+        self.ale.setFloat('repeat_action_probability'.encode('utf-8'), repeat_action_probability)
 
         (screen_width,screen_height) = self.ale.getScreenDims()
         if self._obs_type == 'ram':

--- a/gym/envs/atari/atari_env.py
+++ b/gym/envs/atari/atari_env.py
@@ -47,6 +47,7 @@ class AtariEnv(gym.Env, utils.EzPickle):
 
         # Tune (or disable) ALE's action repeat:
         # https://github.com/openai/gym/issues/349
+        assert isinstance(repeat_action_probability, (float, int)), "Invalid repeat_action_probability: {!r}".format(repeat_action_probability)
         self.ale.setFloat('repeat_action_probability', repeat_action_probability)
 
         (screen_width,screen_height) = self.ale.getScreenDims()

--- a/gym/envs/atari/atari_env.py
+++ b/gym/envs/atari/atari_env.py
@@ -22,7 +22,7 @@ def to_ram(ale):
 class AtariEnv(gym.Env, utils.EzPickle):
     metadata = {'render.modes': ['human', 'rgb_array']}
 
-    def __init__(self, game='pong', obs_type='ram', frameskip=(2, 5)):
+    def __init__(self, game='pong', obs_type='ram', frameskip=(2, 5), repeat_action_probability=0.):
         """Frameskip should be either a tuple (indicating a random range to
         choose from, with the top value exclude), or an int."""
 
@@ -44,6 +44,10 @@ class AtariEnv(gym.Env, utils.EzPickle):
 
         self._action_set = self.ale.getMinimalActionSet()
         self.action_space = spaces.Discrete(len(self._action_set))
+
+        # Tune (or disable) ALE's action repeat:
+        # https://github.com/openai/gym/issues/349
+        self.ale.setFloat('repeat_action_probability', repeat_action_probability)
 
         (screen_width,screen_height) = self.ale.getScreenDims()
         if self._obs_type == 'ram':


### PR DESCRIPTION
Thanks @erictzeng (cf https://github.com/openai/gym/issues/349)

Verified that these are in fact different (it's a bit hard to tell by hand):

```
import gym, numpy as np
a = gym.make('Pong-v2')
b = gym.make('Pong-v0') # switch to v2 to ensure determinism

a.seed(0)
b.seed(0)

a_all = []
def step_a(action):
    ob, _, _, _ = a.step(action)
    a_all.append(ob)

b_all = []
def step_b(action):
    ob, _, _, _ = b.step(action)
    b_all.append(ob)

np.random.seed(0)
for i in range(1000):
    x = np.random.randint(2, 4)
    step_a(x)
    step_b(x)
    # a.render()
    # b.render()
print [i for i, (ao, bo) in enumerate(zip(a_all, b_all)) if not np.all(ao == bo)]
```