### PR TITLE
Scale height reported by state to viewport height rather than width

### DIFF
--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -280,7 +280,7 @@ class LunarLander(gym.Env):
         vel = self.lander.linearVelocity
         state = [
             (pos.x - VIEWPORT_W/SCALE/2) / (VIEWPORT_W/SCALE/2),
-            (pos.y - (self.helipad_y+LEG_DOWN/SCALE)) / (VIEWPORT_W/SCALE/2),
+            (pos.y - (self.helipad_y+LEG_DOWN/SCALE)) / (VIEWPORT_H/SCALE),
             vel.x*(VIEWPORT_W/SCALE/2)/FPS,
             vel.y*(VIEWPORT_H/SCALE/2)/FPS,
             self.lander.angle,


### PR DESCRIPTION
The scaling in the reported state looks off to me.  It shouldn't matter to the solution, since it's just scaling by a different constant, but seems like the vertical velocity and height should be in compatible scales.
