### PR TITLE
rfc: allow optionally assigning names to box dimensions and discrete values

### DIFF
--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -99,7 +99,9 @@ class LunarLander(gym.Env):
             self.action_space = spaces.Box(-1, +1, (2,))
         else:
             # Nop, fire left engine, main engine, right engine
-            self.action_space = spaces.Discrete(4)
+            self.action_space = spaces.Categorical(
+                ['NO_OP', 'LEFT_ENGINE', 'MAIN_ENGINE', 'RIGHT_ENGINE']
+            )
 
         self._reset()
 

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -64,7 +64,7 @@ class CartPoleEnv(gym.Env):
         assert self.action_space.contains(action), "%r (%s) invalid"%(action, type(action))
         state = self.state
         x, x_dot, theta, theta_dot = state
-        force = self.force_mag if action==self.action_space.LEFT else -self.force_mag
+        force = self.force_mag if action==self.action_space.RIGHT else -self.force_mag
         costheta = math.cos(theta)
         sintheta = math.sin(theta)
         temp = (force + self.polemass_length * theta_dot * theta_dot * sintheta) / self.total_mass

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -39,8 +39,10 @@ class CartPoleEnv(gym.Env):
             self.theta_threshold_radians * 2,
             np.finfo(np.float32).max])
 
-        self.action_space = spaces.Discrete(2)
-        self.observation_space = spaces.Box(-high, high)
+        self.action_space = spaces.Categorical(['LEFT', 'RIGHT'])
+        self.observation_space = spaces.Box(-high, high, named=
+            ['x', 'x_dot', 'theta', 'theta_dot']
+        )
 
         self._seed()
         self.reset()
@@ -62,7 +64,7 @@ class CartPoleEnv(gym.Env):
         assert self.action_space.contains(action), "%r (%s) invalid"%(action, type(action))
         state = self.state
         x, x_dot, theta, theta_dot = state
-        force = self.force_mag if action==1 else -self.force_mag
+        force = self.force_mag if action==self.action_space.LEFT else -self.force_mag
         costheta = math.cos(theta)
         sintheta = math.sin(theta)
         temp = (force + self.polemass_length * theta_dot * theta_dot * sintheta) / self.total_mass

--- a/gym/spaces/__init__.py
+++ b/gym/spaces/__init__.py
@@ -1,7 +1,7 @@
 from gym.spaces.box import Box
-from gym.spaces.discrete import Discrete
+from gym.spaces.discrete import Discrete, Categorical
 from gym.spaces.multi_discrete import MultiDiscrete, DiscreteToMultiDiscrete, BoxToMultiDiscrete
 from gym.spaces.prng import seed
 from gym.spaces.tuple_space import Tuple
 
-__all__ = ["Box", "Discrete", "MultiDiscrete", "DiscreteToMultiDiscrete", "BoxToMultiDiscrete", "Tuple"]
+__all__ = ["Box", "Discrete", "MultiDiscrete", "DiscreteToMultiDiscrete", "BoxToMultiDiscrete", "Tuple", "Categorical"]

--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -11,7 +11,7 @@ class Box(gym.Space):
     Example usage:
     self.action_space = spaces.Box(low=-10, high=10, shape=(1,))
     """
-    def __init__(self, low, high, shape=None):
+    def __init__(self, low, high, shape=None, named=None):
         """
         Two kinds of valid input:
             Box(-1.0, 1.0, (3,4)) # low and high are scalars, and shape is provided
@@ -25,6 +25,10 @@ class Box(gym.Space):
             assert np.isscalar(low) and np.isscalar(high)
             self.low = low + np.zeros(shape)
             self.high = high + np.zeros(shape)
+        if named:
+            # Probably not a good idea to do this for high-dimensional spaces
+            assert self.shape == (len(named),)
+        self.named_dimensions = named
     def sample(self):
         return prng.np_random.uniform(low=self.low, high=self.high, size=self.low.shape)
     def contains(self, x):
@@ -39,6 +43,15 @@ class Box(gym.Space):
     def shape(self):
         return self.low.shape
     def __repr__(self):
-        return "Box" + str(self.shape)
+        # Don't try to show high/low/name for each dimension of high-dimensional spaces
+        if len(self.shape) > 1 or self.shape[0] > 10:
+            return "Box" + str(self.shape)
+        range_strs = ["{:.2g}..{:.2g}".format(self.low[i], self.high[i]) for i in range(self.shape[0])]
+        if self.named_dimensions:
+            dimen_strs = ["{}: {}".format(self.named_dimensions[i], range_strs[i])
+                for i in range(self.shape[0])]
+        else:
+            dimen_strs = range_strs
+        return "Box({{{}}})".format(", ".join(dimen_strs))
     def __eq__(self, other):
         return np.allclose(self.low, other.low) and np.allclose(self.high, other.high)

--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -23,6 +23,24 @@ class Discrete(gym.Space):
             return False
         return as_int >= 0 and as_int < self.n
     def __repr__(self):
-        return "Discrete(%d)" % self.n
+        return "Discrete({})".format(self.n)
     def __eq__(self, other):
         return self.n == other.n
+
+class Categorical(Discrete):
+    """A discrete space with named elements. Element indices are made available
+    as attributes (as long as they're legal Python names). e.g.
+    >>> shapes = Categorical(['circle', 'triangle', 'rectangle'])
+    >>> shapes.circle
+    0
+    """
+    def __init__(self, named_members):
+        self.n = len(named_members)
+        self.named_members = list(named_members)
+    def __repr__(self):
+        return "Categorical({!r})".format(self.named_members)
+    def __getattr__(self, attr):
+        try:
+            return self.named_members.index(attr)
+        except IndexError:
+            raise AttributeError("{} has no attribute {}".format(self, attr))

--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -37,10 +37,11 @@ class Categorical(Discrete):
     def __init__(self, named_members):
         self.n = len(named_members)
         self.named_members = list(named_members)
+        for i, named_member in enumerate(named_members):
+            if hasattr(self, named_member):
+                raise ValueError("Element name {} collides with existing attribute.")
+            else:
+                setattr(self, named_member, i)
+
     def __repr__(self):
         return "Categorical({!r})".format(self.named_members)
-    def __getattr__(self, attr):
-        try:
-            return self.named_members.index(attr)
-        except IndexError:
-            raise AttributeError("{} has no attribute {}".format(self, attr))

--- a/gym/spaces/tests/test_spaces.py
+++ b/gym/spaces/tests/test_spaces.py
@@ -3,7 +3,7 @@ import json # note: ujson fails this test due to float equality
 import numpy as np
 from nose2 import tools
 
-from gym.spaces import Tuple, Box, Discrete, MultiDiscrete
+from gym.spaces import Tuple, Box, Discrete, MultiDiscrete, Categorical
 
 @tools.params(Discrete(3),
               Tuple([Discrete(5), Discrete(10)]),
@@ -29,3 +29,15 @@ def test_roundtripping(space):
     s2p = space.to_jsonable([sample_2_prime])
     assert s1 == s1p, "Expected {} to equal {}".format(s1, s1p)
     assert s2 == s2p, "Expected {} to equal {}".format(s2, s2p)
+
+def test_categoricals():
+    shapes = Categorical(['circle', 'triangle', 'square'])
+    assert shapes.n == 3
+    assert shapes.circle == 0 and shapes.triangle == 1 and shapes.square == 2
+
+    # 'contains' is the name of a method.
+    try:
+        synonyms = Categorical(['holds', 'encompasses', 'contains'])
+        assert False, "exception should have been raised"
+    except ValueError:
+        pass


### PR DESCRIPTION
Before (CartPole):

```python
>>> env.action_space
Discrete(2)
>>> env.observation_space
Box(4,)
```
After:

```python
>>> env.action_space
Categorical(['LEFT', 'RIGHT'])
>>> env.observation_space
Box({x: -4.8..4.8, x_dot: -3.4e+38..3.4e+38, theta: -0.42..0.42, theta_dot: -3.4e+38..3.4e+38})
```

I only re-did CartPole as an example. If this looks agreeable, I'm happy to go through and start changing others as well.

I think the Categorical option is a definite improvement. The box changes feel a little more kludgy. Maybe `repr` should just show the names of dimensions (if present), but not try to fit in their ranges?

Currently, this only affects `repr` output and, in the case of the `Categorical` class, adds some convenience attributes to use in place of magic numbers (e.g. `self.action_space.RIGHT` instead of `1`).