### PR TITLE
Redirect stderr to avoid avconv version spam

### DIFF
--- a/gym/monitoring/video_recorder.py
+++ b/gym/monitoring/video_recorder.py
@@ -258,7 +258,12 @@ class ImageEncoder(object):
 
     @property
     def version_info(self):
-        return {'backend':self.backend,'version':str(subprocess.check_output([self.backend, '-version'])),'cmdline':self.cmdline}
+        return {
+            'backend':self.backend,
+            'version':str(subprocess.check_output([self.backend, '-version'],
+                                                  stderr=subprocess.STDOUT)),
+            'cmdline':self.cmdline
+        }
 
     def start(self):
         self.cmdline = (self.backend,


### PR DESCRIPTION
In addition to what it prints to stdout, `avconv -version` outputs a long-ish version string to stderr. As a result, 90% of Travis build logs are composed of that string. I've also seen it in the wild when running monitors.