### PR TITLE
Unbreak random_agent

### DIFF
--- a/examples/agents/random_agent.py
+++ b/examples/agents/random_agent.py
@@ -48,14 +48,12 @@ if __name__ == '__main__':
     agent = RandomAgent(env.action_space)
 
     episode_count = 100
-    max_steps = 200
     reward = 0
     done = False
 
     for i in range(episode_count):
         ob = env.reset()
-
-        for j in range(max_steps):
+        while True:
             action = agent.act(ob, reward, done)
             ob, reward, done, _ = env.step(action)
             if done:


### PR DESCRIPTION
The semantics of `env.reset()` have changed. It's no longer possible
to reset an environment until it's done.

Notably, this commit changes the behavior of random_agent. It used
to have a limit on number of actions per episode. If we wanted
that now, we'd have to close the environment and recreate it
on each episode, which may be slow.