### PR TITLE
Implementations of bandits and tabular MDPs for rl^2

### DIFF
--- a/gym/benchmarks/__init__.py
+++ b/gym/benchmarks/__init__.py
@@ -568,3 +568,45 @@ register_benchmark(
          'reward_ceiling': 1000.0,
         },
     ])
+
+bandit_tasks = []
+for n_arms in [5, 10, 50]:
+    for n_episodes in [10, 100, 500]:
+        bandit_tasks.append({
+            'env_id': 'BernoulliBandit-{k}.arms-{n}.episodes-v0'.format(k=n_arms, n=n_episodes),
+            'trials': 1,
+            'max_timesteps': 10 ** 9,
+            'reward_floor': 0,
+            'reward_ceiling': n_episodes,
+        })
+
+register_benchmark(
+    id='BernoulliBandit-v0',
+    name='BernoulliBandit',
+    description='Multi-armed Bernoulli bandits',
+    scorer=scoring.ClipTo01ThenAverage(num_episodes=1000),
+    tasks=bandit_tasks
+)
+
+tabular_mdp_tasks = []
+for n_states in [10]:
+    for n_actions in [5]:
+        for episode_length in [10]:
+            for n_episodes in [10, 25, 50, 75, 100]:
+                tabular_mdp_tasks.append({
+                    'env_id': 'RandomTabularMDP-{s}.states-{a}.actions-{t}.timesteps-{n}.episodes-v0'.format(
+                        s=n_states, a=n_actions, t=episode_length, n=n_episodes,
+                    ),
+                    'trials': 1,
+                    'max_timesteps': 10 ** 9,
+                    'reward_floor': 0,
+                    'reward_ceiling': episode_length * n_episodes * 2,
+                })
+
+register_benchmark(
+    id='RandomTabularMDP-v0',
+    name='RandomTabularMDP',
+    description='Random tabular MDPs',
+    scorer=scoring.ClipTo01ThenAverage(num_episodes=1000),
+    tasks=tabular_mdp_tasks
+)

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -461,3 +461,33 @@ register(
     entry_point='gym.envs.safety:OffSwitchCartpoleProbEnv',
     timestep_limit=200,
 )
+
+
+# RL^2
+# ----------------------------------------
+
+# Bandits
+
+for n_arms in [5, 10, 50]:
+    for n_episodes in [10, 100, 500, 1000]:
+        register(
+            id='BernoulliBandit-{k}.arms-{n}.episodes-v0'.format(k=n_arms, n=n_episodes),
+            entry_point='gym.envs.rl2:BernoulliBanditEnv',
+            kwargs={'n_arms': n_arms, 'n_episodes': n_episodes},
+            timestep_limit=n_episodes,
+        )
+
+# Tabular MDPs
+
+for n_states in [10]:
+    for n_actions in [5]:
+        for episode_length in [10]:
+            for n_episodes in [10, 25, 50, 75, 100, 200, 400]:
+                register(
+                    id='RandomTabularMDP-{s}.states-{a}.actions-{t}.timesteps-{n}.episodes-v0'.format(
+                        s=n_states, a=n_actions, t=episode_length, n=n_episodes),
+                    entry_point='gym.envs.rl2:RandomTabularMDPEnv',
+                    kwargs={'n_states': n_states, 'n_actions': n_actions, 'episode_length': episode_length,
+                            'n_episodes': n_episodes},
+                    timestep_limit=n_episodes * episode_length,
+                )

--- a/gym/envs/rl2/__init__.py
+++ b/gym/envs/rl2/__init__.py
@@ -1,0 +1,2 @@
+from gym.envs.rl2.bernoulli_bandit import BernoulliBanditEnv
+from gym.envs.rl2.random_tabular_mdp import RandomTabularMDPEnv

--- a/gym/envs/rl2/bernoulli_bandit.py
+++ b/gym/envs/rl2/bernoulli_bandit.py
@@ -1,0 +1,101 @@
+from gym.utils import seeding, colorize
+from gym import core, spaces
+
+from six import StringIO
+import sys
+
+BIG = 100000000
+
+
+class BernoulliBanditEnv(core.Env):
+    """
+    An implementation of the classical multi-armed bandit task. Each arm has a Bernoulli reward distribution,
+    where the mean parameter is sampled from Uniform(0, 1).
+    """
+
+    metadata = {'render.modes': ['human', 'ansi']}
+
+    def __init__(self, n_arms, n_episodes):
+        """
+        n_arms: Number of arms.
+        n_episodes: Number of episodes. For bandits, each episode only lasts one time step. So this is simply the
+        number of pulls allowed.
+        """
+
+        self.n_arms = n_arms
+        self.n_episodes = n_episodes
+        self.observation_space = spaces.Tuple([
+            # State: just a placeholder for bandits
+            spaces.Discrete(1),
+            # Previous action
+            spaces.Discrete(n_arms),
+            # Previous reward
+            spaces.Box(low=-BIG, high=BIG, shape=(1,)),
+            # Previous termination flag
+            # Since a bandit task always terminates after one time step, the termination flag is always on
+            spaces.Box(low=0, high=1, shape=(1,)),
+        ])
+        self.action_space = spaces.Discrete(n_arms)
+        # Mean parameter for each arm's reward, which follows a Bernoulli distribution
+        self._arm_means = None
+        self._episode_cnt = None
+        self._last_action = None
+        self._last_reward = None
+        self._last_terminal = None
+        self._total_reward = None
+        self._seed()
+        self.reset()
+
+    def _seed(self, seed=None):
+        self.np_random, seed = seeding.np_random(seed)
+        return [seed]
+
+    def _reset(self):
+        self._arm_means = self.np_random.uniform(low=0, high=1, size=(self.n_arms,))
+        self._episode_cnt = 0
+        # Default value
+        self._last_action = 0
+        self._last_reward = 0
+        self._last_terminal = 1
+        self._total_reward = 0
+        return self._get_obs()
+
+    def _get_obs(self):
+        return 0, self._last_action, self._last_reward, self._last_terminal
+
+    def _step(self, action):
+        assert self.action_space.contains(action)
+        reward = self.np_random.binomial(n=1, p=self._arm_means[action])
+        self._last_action = action
+        self._last_reward = reward
+        self._last_terminal = 1
+        self._episode_cnt += 1
+        self._total_reward += reward
+        done = self._episode_cnt >= self.n_episodes
+        obs = self._get_obs()
+        return obs, reward, done, {}
+
+    def _render(self, mode='human', close=False):
+        """
+        Renders the bandit environment in ASCII style. Closely resembles the rendering implementation of algorithmic
+        tasks.
+        """
+        if close:
+            # Nothing interesting to close
+            return
+
+        outfile = StringIO() if mode == 'ansi' else sys.stdout
+        outfile.write('#Episode: {}\n'.format(self._episode_cnt))
+        outfile.write('Total reward so far: {}\n'.format(self._total_reward))
+        outfile.write('Action:')
+        for idx, mean in enumerate(self._arm_means):
+            if idx == self._last_action:
+                if self._last_reward == 1:
+                    outfile.write(' ' + colorize('%.2f' % mean, 'green', highlight=True))
+                else:
+                    outfile.write(' ' + colorize('%.2f' % mean, 'red', highlight=True))
+            else:
+                outfile.write(' ' + '%.2f' % mean)
+        outfile.write('\n')
+
+        return outfile

--- a/gym/envs/rl2/random_tabular_mdp.py
+++ b/gym/envs/rl2/random_tabular_mdp.py
@@ -1,0 +1,121 @@
+from gym.utils import seeding, colorize
+from gym import core, spaces
+
+from six import StringIO
+import sys
+import numpy as np
+
+BIG = 100000000
+
+
+class RandomTabularMDPEnv(core.Env):
+    """
+    A tabular MDP with a fixed state / action space, where the rewards and transition probabilities are initialized
+    randomly.
+    The rewards follow a normal distribution with unit variance. The mean parameters themselves are initialized from
+    i.i.d. Normal(1, 1).
+    The transition probabilities are initialized from a flat Dirichlet prior, which put equal probability mass over
+    the entire probability simplex.
+    These distributions are commonly used as the prior distribution in Bayesian methods. Hence, they give such
+    Bayesian methods the maximal advantage.
+    """
+
+    metadata = {'render.modes': ['human', 'ansi']}
+
+    def __init__(self, n_states, n_actions, n_episodes, episode_length):
+        """
+        n_states: Number of states.
+        n_actions: Number of actions.
+        n_episodes: Number of episodes allowed to interact with a given MDP.
+        episode_length: Length of each episode for the sampled MDP.
+        """
+
+        self.n_states = n_states
+        self.n_actions = n_actions
+        self.n_episodes = n_episodes
+        self.episode_length = episode_length
+
+        self.observation_space = spaces.Tuple([
+            # Current state
+            spaces.Discrete(n_states),
+            # Previous action
+            spaces.Discrete(n_actions),
+            # Previous reward
+            spaces.Box(low=-BIG, high=BIG, shape=(1,)),
+            # Previous termination flag
+            spaces.Box(low=0, high=1, shape=(1,)),
+        ])
+        self.action_space = spaces.Discrete(n_actions)
+
+        # Transition probability matrix
+        self._P = None
+        # Reward parameter
+        self._R = None
+        # Mean parameter for each arm's reward, which follows a Bernoulli distribution
+        self._episode_cnt = None
+        self._episode_t = None
+        self._last_action = None
+        self._last_reward = None
+        self._last_terminal = None
+        self._total_reward = None
+        self._seed()
+        self.reset()
+
+    def _seed(self, seed=None):
+        self.np_random, seed = seeding.np_random(seed)
+        return [seed]
+
+    def _reset(self):
+        self._R = self.np_random.normal(loc=1, scale=1, size=(self.n_states, self.n_actions))
+        self._P = self.np_random.dirichlet(alpha=np.ones(self.n_states), size=(self.n_states, self.n_actions))
+        self._episode_cnt = 0
+        self._episode_t = 0
+        self._current_state = 0
+        # default value
+        self._last_action = 0
+        self._last_reward = 0
+        self._last_terminal = 1
+        self._total_reward = 0
+        return self._get_obs()
+
+    def _get_obs(self):
+        return self._current_state, self._last_action, self._last_reward, self._last_terminal
+
+    def _step(self, action):
+        assert self.action_space.contains(action)
+        p = self._P[self._current_state, action]
+        next_state = np.where(self.np_random.multinomial(n=1, pvals=p))[0][0]
+        reward = np.random.normal(loc=self._R[self._current_state, action], scale=1.)
+        self._last_action = action
+        self._last_reward = reward
+        self._last_terminal = 0
+        self._episode_t += 1
+        self._current_state = next_state
+        if self._episode_t >= self.episode_length:
+            # reset episode
+            self._episode_t = 0
+            self._episode_cnt += 1
+            self._current_state = 0
+            self._last_terminal = 1
+        self._total_reward += reward
+        done = self._episode_cnt >= self.n_episodes
+        obs = self._get_obs()
+        return obs, reward, done, {}
+
+    def _render(self, mode='human', close=False):
+        """
+        Renders the bandit environment in ASCII style. Closely resembles the rendering implementation of algorithmic
+        tasks.
+        """
+        if close:
+            # Nothing interesting to close
+            return
+
+        outfile = StringIO() if mode == 'ansi' else sys.stdout
+        outfile.write('#Episode: {}\n'.format(self._episode_cnt))
+        outfile.write('T within episode: {}\n'.format(self._episode_t))
+        outfile.write('Total reward so far: {}\n'.format(self._total_reward))
+        outfile.write('Current State: {}\n'.format(self._current_state))
+        outfile.write('Action: {}\n'.format(self._last_action))
+
+        return outfile

--- a/gym/envs/rl2/tests/test_rl2.py
+++ b/gym/envs/rl2/tests/test_rl2.py
@@ -1,0 +1,150 @@
+from gym.benchmarks import registration
+from gym.monitoring.tests import helpers
+from gym.envs import rl2
+from gym import monitoring
+import gym
+
+import numpy as np
+
+
+def test_bandits():
+    env = rl2.BernoulliBanditEnv(n_arms=5, n_episodes=10)
+    env.seed(0)
+    obs = env.reset()
+    assert isinstance(obs, tuple)
+    assert len(obs) == 4
+    assert obs[-1] == 1
+    # run it twice to make sure behavior is consistent
+    for _ in range(2):
+        path = random_rollout(env, n_steps=10)
+        assert path["dones"][-1]
+        assert not np.any(path["dones"][:-1])
+        raw_obs, last_actions, last_rewards, last_dones = [list(x) for x in zip(*path["observations"])]
+        # test that prev actions and actions taken agree
+        np.testing.assert_array_equal(
+            last_actions[1:],
+            path["actions"][:-1]
+        )
+        # test that prev rewards and rewards taken agree
+        np.testing.assert_array_equal(
+            last_rewards[1:],
+            path["rewards"][:-1]
+        )
+        # test that it always terminates
+        assert np.all(last_dones)
+
+
+def test_random_tabular_mdps():
+    env = rl2.RandomTabularMDPEnv(n_states=10, n_actions=5, n_episodes=10, episode_length=10)
+    env.seed(0)
+    obs = env.reset()
+    assert isinstance(obs, tuple)
+    assert len(obs) == 4
+    assert obs[-1] == 1
+    # run it twice to make sure behavior is consistent
+    for _ in range(2):
+        path = random_rollout(env, n_steps=100)
+        assert path["dones"][-1]
+        assert not np.any(path["dones"][:-1])
+        raw_obs, last_actions, last_rewards, last_dones = [list(x) for x in zip(*path["observations"])]
+        # test that prev actions and actions taken agree
+        np.testing.assert_array_equal(
+            last_actions[1:],
+            path["actions"][:-1]
+        )
+        # test that prev rewards and rewards taken agree
+        np.testing.assert_array_equal(
+            last_rewards[1:],
+            path["rewards"][:-1]
+        )
+        last_dones = np.asarray(last_dones)
+        # test that it terminates on the right times
+        assert np.all(last_dones[::10])
+        last_dones[::10] = 0
+        assert not np.any(last_dones)
+        # test that it always starts episodes on state 0
+        assert np.all(np.asarray(raw_obs[::10]) == 0)
+
+
+def test_benchmarks():
+    # benchmark = registration.Benchmark(
+    #     id='MyBenchmark-v0',
+    #     scorer=scoring.ClipTo01ThenAverage(),
+    #     tasks=[
+    #         {'env_id': 'CartPole-v0',
+    #          'trials': 1,
+    #          'max_timesteps': 5
+    #         },
+    #         {'env_id': 'CartPole-v0',
+    #          'trials': 1,
+    #          'max_timesteps': 100,
+    #         }])
+
+    for benchmark_id in ['BernoulliBandit-v0', 'RandomTabularMDP-v0']:
+
+        benchmark = registration.benchmark_spec(benchmark_id)
+
+        for env_id in benchmark.env_ids:
+
+            with helpers.tempdir() as temp:
+                env = gym.make(env_id)
+                env.seed(0)
+                env.monitor.start(temp, video_callable=False)
+
+                env.monitor.configure(mode='evaluation')
+                rollout(env)
+
+                env.monitor.configure(mode='training')
+                for i in range(2):
+                    rollout(env)
+
+                env.monitor.configure(mode='evaluation')
+                rollout(env, good=True)
+
+                env.monitor.close()
+                results = monitoring.load_results(temp)
+                evaluation_score = benchmark.score_evaluation(env_id, results['data_sources'],
+                                                              results['initial_reset_timestamps'], results['episode_lengths'],
+                                                              results['episode_rewards'], results['episode_types'],
+                                                              results['timestamps'])
+                benchmark_score = benchmark.score_benchmark({
+                    env_id: evaluation_score['scores'],
+                })
+
+                # import ipdb; ipdb.set_trace()
+                #
+                # assert np.all(np.isclose(evaluation_score['scores'],
+                #                          [0.00089999999999999998, 0.0054000000000000003])), "evaluation_score={}".format(
+                #     evaluation_score)
+                # assert np.isclose(benchmark_score, 0.00315), "benchmark_score={}".format(benchmark_score)
+
+
+def rollout(env, good=False):
+    env.reset()
+
+    action = 0
+    d = False
+    while not d:
+        if good:
+            action = 1 - action
+        o, r, d, i = env.step(action)
+
+
+def random_rollout(env, n_steps):
+    observations = []
+    actions = []
+    rewards = []
+    dones = []
+    obs = env.reset()
+    for _ in range(n_steps):
+        action = env.action_space.sample()
+        next_obs, reward, done, _ = env.step(action)
+        observations.append(obs)
+        actions.append(action)
+        rewards.append(reward)
+        dones.append(done)
+        obs = next_obs
+    return dict(observations=observations, actions=actions, rewards=rewards, dones=dones)
+
+test_benchmarks()
+

--- a/gym/envs/rl2/tests/test_rl2.py
+++ b/gym/envs/rl2/tests/test_rl2.py
@@ -67,19 +67,6 @@ def test_random_tabular_mdps():
 
 
 def test_benchmarks():
-    # benchmark = registration.Benchmark(
-    #     id='MyBenchmark-v0',
-    #     scorer=scoring.ClipTo01ThenAverage(),
-    #     tasks=[
-    #         {'env_id': 'CartPole-v0',
-    #          'trials': 1,
-    #          'max_timesteps': 5
-    #         },
-    #         {'env_id': 'CartPole-v0',
-    #          'trials': 1,
-    #          'max_timesteps': 100,
-    #         }])
-
     for benchmark_id in ['BernoulliBandit-v0', 'RandomTabularMDP-v0']:
 
         benchmark = registration.benchmark_spec(benchmark_id)
@@ -104,19 +91,13 @@ def test_benchmarks():
                 env.monitor.close()
                 results = monitoring.load_results(temp)
                 evaluation_score = benchmark.score_evaluation(env_id, results['data_sources'],
-                                                              results['initial_reset_timestamps'], results['episode_lengths'],
+                                                              results['initial_reset_timestamps'],
+                                                              results['episode_lengths'],
                                                               results['episode_rewards'], results['episode_types'],
                                                               results['timestamps'])
-                benchmark_score = benchmark.score_benchmark({
+                benchmark.score_benchmark({
                     env_id: evaluation_score['scores'],
                 })
-
-                # import ipdb; ipdb.set_trace()
-                #
-                # assert np.all(np.isclose(evaluation_score['scores'],
-                #                          [0.00089999999999999998, 0.0054000000000000003])), "evaluation_score={}".format(
-                #     evaluation_score)
-                # assert np.isclose(benchmark_score, 0.00315), "benchmark_score={}".format(benchmark_score)
 
 
 def rollout(env, good=False):
@@ -146,5 +127,5 @@ def random_rollout(env, n_steps):
         obs = next_obs
     return dict(observations=observations, actions=actions, rewards=rewards, dones=dones)
 
-test_benchmarks()
 
+test_benchmarks()


### PR DESCRIPTION
Implements the bandits and random tabular MDP tasks, as used in the following paper:

Duan, Y., Schulman, J., Chen, X., Bartlett, P. L., Sutskever, I., & Abbeel, P. (2016). [RL^2: Fast Reinforcement Learning via Slow Reinforcement Learning](https://arxiv.org/pdf/1611.02779v2.pdf). arXiv preprint arXiv:1611.02779.

Also registered benchmarks for them separately.

Rebased and fixed conflicts to match the latest master.