### PR TITLE
Unify action_space API

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -297,6 +297,18 @@ class Space(object):
         """
         raise NotImplementedError
 
+    @property
+    def actions(self):
+        """
+        Return iterable with all legal actions
+        for this space.
+
+        This allows general agents (not specifically written for gym)
+        to get the range of available actions by len(env.action_space.actions)
+        as well as indexing. Actions must therefore be a flattened iterable.
+        """
+        raise NotImplementedError
+
     def to_jsonable(self, sample_n):
         """Convert a batch of samples from this space to a JSONable data type."""
         # By default, assume identity is JSONable

--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -25,20 +25,31 @@ class Box(gym.Space):
             assert np.isscalar(low) and np.isscalar(high)
             self.low = low + np.zeros(shape)
             self.high = high + np.zeros(shape)
+
+        self._actions = xrange(low, high)
+
+    @property
+    def actions(self):
+        return self._actions
+
     def sample(self):
         return prng.np_random.uniform(low=self.low, high=self.high, size=self.low.shape)
+
     def contains(self, x):
         return x.shape == self.shape and (x >= self.low).all() and (x <= self.high).all()
 
     def to_jsonable(self, sample_n):
         return np.array(sample_n).tolist()
+
     def from_jsonable(self, sample_n):
         return [np.asarray(sample) for sample in sample_n]
 
     @property
     def shape(self):
         return self.low.shape
+
     def __repr__(self):
         return "Box" + str(self.shape)
+
     def __eq__(self, other):
         return np.allclose(self.low, other.low) and np.allclose(self.high, other.high)

--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import gym, time
+import gym
 from gym.spaces import prng
 
 class Discrete(gym.Space):
@@ -11,9 +11,17 @@ class Discrete(gym.Space):
     self.observation_space = spaces.Discrete(2)
     """
     def __init__(self, n):
+        # Keep n for backwards compatability
         self.n = n
+        self._actions = xrange(0, self.n)
+
+    @property
+    def actions(self):
+        return self._actions
+
     def sample(self):
         return prng.np_random.randint(self.n)
+
     def contains(self, x):
         if isinstance(x, int):
             as_int = x
@@ -22,7 +30,9 @@ class Discrete(gym.Space):
         else:
             return False
         return as_int >= 0 and as_int < self.n
+
     def __repr__(self):
         return "Discrete(%d)" % self.n
+
     def __eq__(self, other):
         return self.n == other.n

--- a/gym/spaces/multi_discrete.py
+++ b/gym/spaces/multi_discrete.py
@@ -31,19 +31,29 @@ class MultiDiscrete(gym.Space):
         self.high = np.array([x[1] for x in array_of_param_array])
         self.num_discrete_space = self.low.shape[0]
 
+        self._actions = [action for action_space in array_of_param_array for action in xrange(action_space[0],
+                                                                                              action_space[1])]
+
+    @property
+    def actions(self):
+        return self._actions
+
     def sample(self):
         """ Returns a array with one sample from each discrete action space """
         # For each row: round(random .* (max - min) + min, 0)
         random_array = prng.np_random.rand(self.num_discrete_space)
         return [int(x) for x in np.rint(np.multiply((self.high - self.low), random_array) + self.low)]
+
     def contains(self, x):
         return len(x) == self.num_discrete_space and (np.array(x) >= self.low).all() and (np.array(x) <= self.high).all()
 
     @property
     def shape(self):
         return self.num_discrete_space
+
     def __repr__(self):
         return "MultiDiscrete" + str(self.num_discrete_space)
+
     def __eq__(self, other):
         return np.array_equal(self.low, other.low) and np.array_equal(self.high, other.high)
 
@@ -113,7 +123,7 @@ class DiscreteToMultiDiscrete(Discrete):
 
         # Config 1
         if options is None:
-            self.n = self.num_discrete_space + 1                # +1 for NOOP at beginning
+            self.n = self.num_discrete_space + 1  # +1 for NOOP at beginning
             self.mapping = {i: [0] * self.num_discrete_space for i in range(self.n)}
             for i in range(self.num_discrete_space):
                 self.mapping[i + 1][i] = self.multi_discrete.high[i]
@@ -121,7 +131,7 @@ class DiscreteToMultiDiscrete(Discrete):
         # Config 2
         elif isinstance(options, list):
             assert len(options) <= self.num_discrete_space
-            self.n = len(options) + 1                          # +1 for NOOP at beginning
+            self.n = len(options) + 1  # +1 for NOOP at beginning
             self.mapping = {i: [0] * self.num_discrete_space for i in range(self.n)}
             for i, disc_num in enumerate(options):
                 assert disc_num < self.num_discrete_space

--- a/gym/spaces/tuple_space.py
+++ b/gym/spaces/tuple_space.py
@@ -10,6 +10,12 @@ class Tuple(Space):
     def __init__(self, spaces):
         self.spaces = spaces
 
+        self._actions = [action for space in self.spaces for action in space.actions]
+
+    @property
+    def actions(self):
+        return self._actions
+
     def sample(self):
         return tuple([space.sample() for space in self.spaces])
 
@@ -17,7 +23,7 @@ class Tuple(Space):
         if isinstance(x, list):
             x = tuple(x)  # Promote list to tuple for contains check
         return isinstance(x, tuple) and len(x) == len(self.spaces) and all(
-            space.contains(part) for (space,part) in zip(self.spaces,x))
+            space.contains(part) for (space, part) in zip(self.spaces, x))
 
     def __repr__(self):
         return "Tuple(" + ", ". join([str(s) for s in self.spaces]) + ")"


### PR DESCRIPTION
To be able to better decouple general agents from the gym, make the
action_space API more unified so that any action space can be queried
by:

Get max number of valid actions:
    len(env.action_space.actions)
Indexing of any environments action_space:
    action = env.action_space.actions[index]

This means that any action_space needs to be flattened and somewhat
assumes a discrete action_space, and translates poorly for mouse-based
action_spaces.
Also in the long run, perhaps sample() et.al should instead be drawn from this flattened
action_space and could simplify some of the action_spaces.

Signed-off-by: Jesper Derehag <jderehag@hotmail.com>