### PR TITLE
Monitor wrapper

### DIFF
--- a/gym/__init__.py
+++ b/gym/__init__.py
@@ -43,7 +43,7 @@ del logger_setup
 
 sanity_check_dependencies()
 
-from gym.core import Env, Space, Wrapper, ObservationWrapper, ActionWrapper, RewardWrapper
+from gym.core import Env, Space, Wrapper, ObservationWrapper, ActionWrapper, RewardWrapper, MonitorWrapper
 from gym.benchmarks import benchmark_spec
 from gym.envs import make, spec
 from gym.scoreboard.api import upload

--- a/gym/core.py
+++ b/gym/core.py
@@ -87,19 +87,12 @@ class Env(object):
 
     # Do not override
     _owns_render = True
-    
+
     @property
     def monitor(self):
-        """
-        We do this lazily rather than at environment creation time
-        since when the monitor closes, we need remove the existing
-        monitor but also make it easy to start a new one. We could
-        still just forcibly create a new monitor instance on old
-        monitor close, but that seems less clean.
-        """
-        if not hasattr(self, '_monitor'):
-            self._monitor = monitoring.Monitor(self)
-        return self._monitor
+        raise NotImplemented("Use the MonitorWrapper wrapper if you need a " +
+            "monitor. (You get this for free if you instantiate using gym.make())")
+    
 
     def step(self, action):
         """Run one timestep of the environment's dynamics. When end of
@@ -363,6 +356,18 @@ class Wrapper(Env):
         self._spec = spec
 
 class MonitorWrapper(Wrapper):
+    @property
+    def monitor(self):
+        """
+        We do this lazily rather than at environment creation time
+        since when the monitor closes, we need remove the existing
+        monitor but also make it easy to start a new one. We could
+        still just forcibly create a new monitor instance on old
+        monitor close, but that seems less clean.
+        """
+        if not hasattr(self, '_monitor'):
+            self._monitor = monitoring.Monitor(self)
+        return self._monitor
 
     def _step(self, action):
         self.monitor._before_step(action)

--- a/gym/core.py
+++ b/gym/core.py
@@ -87,6 +87,19 @@ class Env(object):
 
     # Do not override
     _owns_render = True
+    
+    @property
+    def monitor(self):
+        """
+        We do this lazily rather than at environment creation time
+        since when the monitor closes, we need remove the existing
+        monitor but also make it easy to start a new one. We could
+        still just forcibly create a new monitor instance on old
+        monitor close, but that seems less clean.
+        """
+        if not hasattr(self, '_monitor'):
+            self._monitor = monitoring.Monitor(self)
+        return self._monitor
 
     def step(self, action):
         """Run one timestep of the environment's dynamics. When end of
@@ -350,19 +363,6 @@ class Wrapper(Env):
         self._spec = spec
 
 class MonitorWrapper(Wrapper):
-    """Adds a lazy-loaded monitor"""
-    @property
-    def monitor(self):
-        """
-        We do this lazily rather than at environment creation time
-        since when the monitor closes, we need remove the existing
-        monitor but also make it easy to start a new one. We could
-        still just forcibly create a new monitor instance on old
-        monitor close, but that seems less clean.
-        """
-        if not hasattr(self, '_monitor'):
-            self._monitor = monitoring.Monitor(self)
-        return self._monitor
 
     def _step(self, action):
         self.monitor._before_step(action)

--- a/gym/core.py
+++ b/gym/core.py
@@ -88,20 +88,6 @@ class Env(object):
     # Do not override
     _owns_render = True
 
-    @property
-    def monitor(self):
-        """Lazily creates a monitor instance.
-
-        We do this lazily rather than at environment creation time
-        since when the monitor closes, we need remove the existing
-        monitor but also make it easy to start a new one. We could
-        still just forcibly create a new monitor instance on old
-        monitor close, but that seems less clean.
-        """
-        if not hasattr(self, '_monitor'):
-            self._monitor = monitoring.Monitor(self)
-        return self._monitor
-
     def step(self, action):
         """Run one timestep of the environment's dynamics. When end of
         episode is reached, you are responsible for calling `reset()`
@@ -118,11 +104,7 @@ class Env(object):
             done (boolean): whether the episode has ended, in which case further step() calls will return undefined results
             info (dict): contains auxiliary diagnostic information (helpful for debugging, and sometimes learning)
         """
-        self.monitor._before_step(action)
-        observation, reward, done, info = self._step(action)
-
-        done = self.monitor._after_step(observation, reward, done, info)
-        return observation, reward, done, info
+        return self._step(action)
 
     def reset(self):
         """Resets the state of the environment and returns an initial
@@ -136,9 +118,7 @@ class Env(object):
         elif not self._configured:
             self.configure()
 
-        self.monitor._before_reset()
         observation = self._reset()
-        self.monitor._after_reset(observation)
         return observation
 
     def render(self, mode='human', close=False):
@@ -202,9 +182,7 @@ class Env(object):
         if not hasattr(self, '_closed') or self._closed:
             return
 
-        # Automatically close the monitor and any render window.
-        if hasattr(self, '_monitor'):
-            self.monitor.close()
+        # Automatically close any render window.
         if self._owns_render:
             self.render(close=True)
 
@@ -370,6 +348,38 @@ class Wrapper(Env):
         if self.env is not None:
             self.env.spec = spec
         self._spec = spec
+
+class MonitorWrapper(Wrapper):
+    """Adds a lazy-loaded monitor"""
+    @property
+    def monitor(self):
+        """
+        We do this lazily rather than at environment creation time
+        since when the monitor closes, we need remove the existing
+        monitor but also make it easy to start a new one. We could
+        still just forcibly create a new monitor instance on old
+        monitor close, but that seems less clean.
+        """
+        if not hasattr(self, '_monitor'):
+            self._monitor = monitoring.Monitor(self)
+        return self._monitor
+
+    def _step(self, action):
+        self.monitor._before_step(action)
+        observation, reward, done, info = self.env.step(action)
+        done = self.monitor._after_step(observation, reward, done, info)
+        return observation, reward, done, info
+
+    def _reset(self):
+        self.monitor._before_reset()
+        observation = self.env.reset()
+        self.monitor._after_reset(observation)
+        return observation
+
+    def _close(self):
+        if hasattr(self, '_monitor'):
+            self.monitor.close()
+        self.env.close()
 
 class ObservationWrapper(Wrapper):
     def _reset(self):

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -69,7 +69,10 @@ class EnvSpec(object):
             raise error.Error('Attempting to make deprecated env {}. (HINT: is there a newer registered version of this env?)'.format(self.id))
 
         cls = load(self._entry_point)
-        env = MonitorWrapper(cls(**self._kwargs))
+        env = cls(**self._kwargs)
+        # hack
+        if not env.metadata.get('runtime.vectorized'):
+            env = MonitorWrapper(env)
 
         # Make the enviroment aware of which spec it came from.
         env.spec = self

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -4,6 +4,7 @@ import re
 import sys
 
 from gym import error
+from gym.core import MonitorWrapper
 
 logger = logging.getLogger(__name__)
 # This format is true today, but it's *not* an official spec.
@@ -68,7 +69,7 @@ class EnvSpec(object):
             raise error.Error('Attempting to make deprecated env {}. (HINT: is there a newer registered version of this env?)'.format(self.id))
 
         cls = load(self._entry_point)
-        env = cls(**self._kwargs)
+        env = MonitorWrapper(cls(**self._kwargs))
 
         # Make the enviroment aware of which spec it came from.
         env.spec = self

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -70,8 +70,8 @@ class EnvSpec(object):
 
         cls = load(self._entry_point)
         env = cls(**self._kwargs)
-        # hack
-        if not env.metadata.get('runtime.vectorized'):
+        # (Some envs aren't compatible with MonitorWrapper.)
+        if getattr(env, 'monitor_wrapper_friendly', True):
             env = MonitorWrapper(env)
 
         # Make the enviroment aware of which spec it came from.

--- a/gym/envs/safety/semisuper.py
+++ b/gym/envs/safety/semisuper.py
@@ -15,6 +15,7 @@ import gym
 class SemisuperEnv(gym.Env):
     def step(self, action):
         assert self.action_space.contains(action)
+        # TODO: is this right? Should already be done in parent class. 
         self.monitor._before_step(action)
 
         observation, true_reward, done, info = self._step(action)

--- a/gym/envs/safety/semisuper.py
+++ b/gym/envs/safety/semisuper.py
@@ -15,13 +15,9 @@ import gym
 class SemisuperEnv(gym.Env):
     def step(self, action):
         assert self.action_space.contains(action)
-        # TODO: is this right? Should already be done in parent class. 
-        self.monitor._before_step(action)
 
         observation, true_reward, done, info = self._step(action)
         assert self.observation_space.contains(observation)
-
-        done = self.monitor._after_step(observation, true_reward, done, info)
 
         perceived_reward = self._distort_reward(true_reward)
         return observation, perceived_reward, done, info

--- a/gym/envs/tests/test_registration.py
+++ b/gym/envs/tests/test_registration.py
@@ -6,7 +6,6 @@ from gym.envs.classic_control import cartpole
 def test_make():
     env = envs.make('CartPole-v0')
     assert env.spec.id == 'CartPole-v0'
-    assert isinstance(env, cartpole.CartPoleEnv)
 
 def test_make_deprecated():
     try:

--- a/gym/monitoring/monitor.py
+++ b/gym/monitoring/monitor.py
@@ -58,6 +58,10 @@ class Monitor(object):
     to begin monitoring and 'monitor.close()' when training is
     complete. This will record stats and will periodically record a video.
 
+    *(If you call en environment's constructor directly rather than using
+    make(), you will not be able to interact with the monitor. See
+    gym.core.MonitorWrapper.)
+
     For finer-grained control over how often videos are collected, use the
     video_callable argument, e.g.
     'monitor.start(video_callable=lambda count: count % 100 == 0)'

--- a/gym/monitoring/tests/test_monitor.py
+++ b/gym/monitoring/tests/test_monitor.py
@@ -48,7 +48,7 @@ def test_write_upon_reset_true():
 
 def test_close_monitor():
     with helpers.tempdir() as temp:
-        env = FakeEnv()
+        env = gym.core.MonitorWrapper(FakeEnv())
         env.monitor.start(temp)
         env.monitor.close()
 


### PR DESCRIPTION
Extracts monitor logic from Env base class and adds it to a wrapper.

My overall impression is that this is a net loss in terms of clarity and robustness :(

Some alternative approaches:

- Make Wrapper's `__getattr__` fall through to `getattr(self.env, foo_attr)`. This would remove the need for the hacky check in `make()` to avoid breaking universe envs. The reason that check is necessary is that wrapping in gym.Wrapper hides the env's attributes (like `env.n`). This would also avoid having to copy attributes like `action_space`, `reward_range`, etc. in Wrapper's constructor.
- Contain the change to just `core.py`. Move the monitor logic to a wrapper, but export that wrapper under the name 'Env'. 

(These also seem kind of bad in their own ways.)