### PR TITLE
Optional monitor wrapper.

### DIFF
--- a/examples/agents/cem.py
+++ b/examples/agents/cem.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import gym
+from gym.wrappers import Monitored
 import logging
 import numpy as np
 try:
@@ -65,7 +66,7 @@ if __name__ == '__main__':
     # directory, but can't contain previous monitor results. You can
     # also dump to a tempdir if you'd like: tempfile.mkdtemp().
     outdir = '/tmp/cem-agent-results'
-    env.monitor.start(outdir, force=True)
+    env = Monitored(env, outdir, force=True)
 
     # Prepare snapshotting
     # ----------------------------------------
@@ -94,7 +95,7 @@ if __name__ == '__main__':
     # environment.
     writefile('info.json', json.dumps(info))
 
-    env.monitor.close()
+    env.close()
 
     logger.info("Successfully ran cross-entropy method. Now trying to upload results to the scoreboard. If it breaks, you can always just try re-uploading the same results.")
     gym.upload(outdir)

--- a/examples/agents/random_agent.py
+++ b/examples/agents/random_agent.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import gym
+from gym.wrappers import Monitored
 
 # The world's simplest agent!
 class RandomAgent(object):
@@ -40,7 +41,7 @@ if __name__ == '__main__':
     # like: tempfile.mkdtemp().
     outdir = '/tmp/random-agent-results'
     env.seed(0)
-    env.monitor.start(outdir, force=True)
+    env = Monitored(env, outdir, force=True)
 
     # This declaration must go *after* the monitor call, since the
     # monitor's seeding creates a new action_space instance with the
@@ -63,7 +64,7 @@ if __name__ == '__main__':
             # Video is not recorded every episode, see capped_cubic_video_schedule for details.
 
     # Dump result info to disk
-    env.monitor.close()
+    env.close()
 
     # Upload to the scoreboard. We could also do this from another
     # process if we wanted.

--- a/examples/scripts/benchmark_runner
+++ b/examples/scripts/benchmark_runner
@@ -12,6 +12,7 @@ import os
 import sys
 
 import gym
+from gym.wrappers import Monitored
 # In modules, use `logger = logging.getLogger(__name__)`
 logger = logging.getLogger()
 
@@ -44,7 +45,7 @@ def main():
         env = gym.make(task.env_id)
         for trial in range(task.trials):
             training_dir_name = "{}/{}-{}".format(args.training_dir, task.env_id, trial)
-            env.monitor.start(training_dir_name)
+            env = Monitored(env, training_dir_name)
             env.reset()
             for _ in range(task.max_timesteps):
                 o, r, done, _ = env.step(env.action_space.sample())

--- a/examples/utilities/live_plot.py
+++ b/examples/utilities/live_plot.py
@@ -1,4 +1,5 @@
 import gym
+from gym.wrappers import Monitored
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -42,7 +43,7 @@ if __name__ == '__main__':
     env = gym.make('CartPole-v0')
     outdir = '/tmp/random-agent-results'
     env.seed(0)
-    env.monitor.start(outdir, force=True)
+    env = Monitored(env, outdir, force=True)
 
     # You may optionally include a LivePlot so that you can see
     # how your agent is performing.  Use plotter.plot() to update

--- a/gym/__init__.py
+++ b/gym/__init__.py
@@ -43,7 +43,7 @@ del logger_setup
 
 sanity_check_dependencies()
 
-from gym.core import Env, Space, Wrapper, ObservationWrapper, ActionWrapper, RewardWrapper, Monitored
+from gym.core import Env, Space, Wrapper, ObservationWrapper, ActionWrapper, RewardWrapper
 from gym.benchmarks import benchmark_spec
 from gym.envs import make, spec
 from gym.scoreboard.api import upload

--- a/gym/__init__.py
+++ b/gym/__init__.py
@@ -43,7 +43,7 @@ del logger_setup
 
 sanity_check_dependencies()
 
-from gym.core import Env, Space, Wrapper, ObservationWrapper, ActionWrapper, RewardWrapper
+from gym.core import Env, Space, Wrapper, ObservationWrapper, ActionWrapper, RewardWrapper, Monitored
 from gym.benchmarks import benchmark_spec
 from gym.envs import make, spec
 from gym.scoreboard.api import upload

--- a/gym/benchmarks/tests/test_benchmark.py
+++ b/gym/benchmarks/tests/test_benchmark.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import gym
-from gym import monitoring
+from gym import monitoring, Monitored
 from gym.monitoring.tests import helpers
 
 from gym.benchmarks import registration, scoring
@@ -21,7 +21,7 @@ def test():
             }])
 
     with helpers.tempdir() as temp:
-        env = gym.make('CartPole-v0')
+        env = Monitored(gym.make('CartPole-v0'))
         env.seed(0)
         env.monitor.start(temp, video_callable=False)
 

--- a/gym/benchmarks/tests/test_benchmark.py
+++ b/gym/benchmarks/tests/test_benchmark.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 import gym
-from gym import monitoring, Monitored
+from gym import monitoring
+from gym.wrappers import Monitored
 from gym.monitoring.tests import helpers
 
 from gym.benchmarks import registration, scoring
@@ -21,10 +22,8 @@ def test():
             }])
 
     with helpers.tempdir() as temp:
-        env = Monitored(gym.make('CartPole-v0'))
+        env = Monitored(gym.make('CartPole-v0'), temp, video_callable=False)
         env.seed(0)
-        env.monitor.start(temp, video_callable=False)
-
         env.monitor.configure(mode='evaluation')
         rollout(env)
 

--- a/gym/core.py
+++ b/gym/core.py
@@ -88,20 +88,6 @@ class Env(object):
     # Do not override
     _owns_render = True
 
-    @property
-    def monitor(self):
-        """Lazily creates a monitor instance.
-
-        We do this lazily rather than at environment creation time
-        since when the monitor closes, we need remove the existing
-        monitor but also make it easy to start a new one. We could
-        still just forcibly create a new monitor instance on old
-        monitor close, but that seems less clean.
-        """
-        if not hasattr(self, '_monitor'):
-            self._monitor = monitoring.Monitor(self)
-        return self._monitor
-
     def step(self, action):
         """Run one timestep of the environment's dynamics. When end of
         episode is reached, you are responsible for calling `reset()`
@@ -118,11 +104,7 @@ class Env(object):
             done (boolean): whether the episode has ended, in which case further step() calls will return undefined results
             info (dict): contains auxiliary diagnostic information (helpful for debugging, and sometimes learning)
         """
-        self.monitor._before_step(action)
-        observation, reward, done, info = self._step(action)
-
-        done = self.monitor._after_step(observation, reward, done, info)
-        return observation, reward, done, info
+        return self._step(action)
 
     def reset(self):
         """Resets the state of the environment and returns an initial
@@ -136,9 +118,7 @@ class Env(object):
         elif not self._configured:
             self.configure()
 
-        self.monitor._before_reset()
         observation = self._reset()
-        self.monitor._after_reset(observation)
         return observation
 
     def render(self, mode='human', close=False):
@@ -202,9 +182,7 @@ class Env(object):
         if not hasattr(self, '_closed') or self._closed:
             return
 
-        # Automatically close the monitor and any render window.
-        if hasattr(self, '_monitor'):
-            self.monitor.close()
+        # Automatically close any render window.
         if self._owns_render:
             self.render(close=True)
 
@@ -370,6 +348,42 @@ class Wrapper(Env):
         if self.env is not None:
             self.env.spec = spec
         self._spec = spec
+
+class Monitored(Wrapper):
+    def __init__(self, env=None, monitor=None):
+        if monitor is not None:
+            self._monitor = monitor
+        super(Monitored, self).__init__(env)
+
+    @property
+    def monitor(self):
+        """
+        We do this lazily rather than at environment creation time
+        since when the monitor closes, we need remove the existing
+        monitor but also make it easy to start a new one. We could
+        still just forcibly create a new monitor instance on old
+        monitor close, but that seems less clean.
+        """
+        if not hasattr(self, '_monitor'):
+            self._monitor = monitoring.Monitor(self)
+        return self._monitor
+
+    def _step(self, action):
+        self.monitor._before_step(action)
+        observation, reward, done, info = self.env.step(action)
+        done = self.monitor._after_step(observation, reward, done, info)
+        return observation, reward, done, info
+
+    def _reset(self):
+        self.monitor._before_reset()
+        observation = self.env.reset()
+        self.monitor._after_reset(observation)
+        return observation
+
+    def _close(self):
+        if hasattr(self, '_monitor'):
+            self.monitor.close()
+        self.env.close()
 
 class ObservationWrapper(Wrapper):
     def _reset(self):

--- a/gym/core.py
+++ b/gym/core.py
@@ -350,23 +350,9 @@ class Wrapper(Env):
         self._spec = spec
 
 class Monitored(Wrapper):
-    def __init__(self, env=None, monitor=None):
-        if monitor is not None:
-            self._monitor = monitor
+    def __init__(self, monitor, env=None):
+        self._monitor = monitor
         super(Monitored, self).__init__(env)
-
-    @property
-    def monitor(self):
-        """
-        We do this lazily rather than at environment creation time
-        since when the monitor closes, we need remove the existing
-        monitor but also make it easy to start a new one. We could
-        still just forcibly create a new monitor instance on old
-        monitor close, but that seems less clean.
-        """
-        if not hasattr(self, '_monitor'):
-            self._monitor = monitoring.Monitor(self)
-        return self._monitor
 
     def _step(self, action):
         self.monitor._before_step(action)

--- a/gym/core.py
+++ b/gym/core.py
@@ -349,27 +349,6 @@ class Wrapper(Env):
             self.env.spec = spec
         self._spec = spec
 
-class Monitored(Wrapper):
-    def __init__(self, monitor, env=None):
-        self._monitor = monitor
-        super(Monitored, self).__init__(env)
-
-    def _step(self, action):
-        self.monitor._before_step(action)
-        observation, reward, done, info = self.env.step(action)
-        done = self.monitor._after_step(observation, reward, done, info)
-        return observation, reward, done, info
-
-    def _reset(self):
-        self.monitor._before_reset()
-        observation = self.env.reset()
-        self.monitor._after_reset(observation)
-        return observation
-
-    def _close(self):
-        if hasattr(self, '_monitor'):
-            self.monitor.close()
-        self.env.close()
 
 class ObservationWrapper(Wrapper):
     def _reset(self):

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -9,6 +9,7 @@ from gym import spaces
 from gym.envs.box2d.car_dynamics import Car
 from gym.envs.classic_control import rendering
 from gym.utils import colorize, seeding
+from gym.wrappers import Monitored
 
 import pyglet
 from pyglet.gl import *
@@ -474,7 +475,7 @@ if __name__=="__main__":
     env.render()
     record_video = False
     if record_video:
-        env.monitor.start('/tmp/video-test', force=True)
+        env = Monitored(env, '/tmp/video-test', force=True)
     env.viewer.window.on_key_press = key_press
     env.viewer.window.on_key_release = key_release
     while True:
@@ -495,4 +496,4 @@ if __name__=="__main__":
             if not record_video: # Faster, but you can as well call env.render() every time to play full window.
                 env.render()
             if done or restart: break
-    env.monitor.close()
+    env.close()

--- a/gym/envs/safety/semisuper.py
+++ b/gym/envs/safety/semisuper.py
@@ -15,12 +15,12 @@ import gym
 class SemisuperEnv(gym.Env):
     def step(self, action):
         assert self.action_space.contains(action)
-        self.monitor._before_step(action)
+        #self.monitor._before_step(action)
 
         observation, true_reward, done, info = self._step(action)
         assert self.observation_space.contains(observation)
 
-        done = self.monitor._after_step(observation, true_reward, done, info)
+        #done = self.monitor._after_step(observation, true_reward, done, info)
 
         perceived_reward = self._distort_reward(true_reward)
         return observation, perceived_reward, done, info

--- a/gym/monitoring/monitor.py
+++ b/gym/monitoring/monitor.py
@@ -53,18 +53,24 @@ def _open_monitors():
 class Monitor(object):
     """A configurable monitor for your training runs.
 
-    Every env has an attached monitor, which you can access as
-    'env.monitor'. Simple usage is just to call 'monitor.start(dir)'
-    to begin monitoring and 'monitor.close()' when training is
-    complete. This will record stats and will periodically record a video.
+    Simple usage is just to use the Monitored wrapper, e.g.
+    
+    >>> env = Monitored(gym.make('CartPole-v0'), '/tmp/cartpole')
+    >>> env.reset()
+    >>> env.step(...)
+    >>> env.close() # calls env.monitor.close()
+
+    This will record stats and periodically record a video.
 
     For finer-grained control over how often videos are collected, use the
-    video_callable argument, e.g.
-    'monitor.start(video_callable=lambda count: count % 100 == 0)'
-    to record every 100 episodes. ('count' is how many episodes have completed)
+    video_callable argument, e.g. to record every 100 episodes:
 
-    Depending on the environment, video can slow down execution. You
-    can also use 'monitor.configure(video_callable=lambda count: False)' to disable
+    >>> env = Monitored(env, tmpdir, video_callable=lambda count: count % 100 == 0)
+
+    ('count' is how many episodes have completed)
+
+    Depending on the environment, video can slow down execution. You can also 
+    use 'monitor.configure(video_callable=lambda count: False)' to disable
     video.
 
     Monitor supports multiple threads and multiple processes writing
@@ -73,9 +79,6 @@ class Monitor(object):
 
     Args:
         env (gym.Env): The environment instance to monitor.
-
-    Attributes:
-        id (Optional[str]): The ID of the monitored environment
     """
 
     def __init__(self, env):

--- a/gym/monitoring/tests/test_monitor.py
+++ b/gym/monitoring/tests/test_monitor.py
@@ -4,6 +4,7 @@ import os
 import gym
 from gym import error, spaces
 from gym import monitoring
+from gym import Monitored
 from gym.monitoring import monitor
 from gym.monitoring.tests import helpers
 
@@ -13,7 +14,7 @@ class FakeEnv(gym.Env):
 
 def test_monitor_filename():
     with helpers.tempdir() as temp:
-        env = gym.make('CartPole-v0')
+        env = Monitored(gym.make('CartPole-v0'))
         env.monitor.start(temp)
         env.monitor.close()
 
@@ -22,7 +23,7 @@ def test_monitor_filename():
 
 def test_write_upon_reset_false():
     with helpers.tempdir() as temp:
-        env = gym.make('CartPole-v0')
+        env = Monitored(gym.make('CartPole-v0'))
         env.monitor.start(temp, video_callable=False, write_upon_reset=False)
         env.reset()
 
@@ -35,7 +36,7 @@ def test_write_upon_reset_false():
 
 def test_write_upon_reset_true():
     with helpers.tempdir() as temp:
-        env = gym.make('CartPole-v0')
+        env = Monitored(gym.make('CartPole-v0'))
         env.monitor.start(temp, video_callable=False, write_upon_reset=True)
         env.reset()
 
@@ -48,7 +49,7 @@ def test_write_upon_reset_true():
 
 def test_close_monitor():
     with helpers.tempdir() as temp:
-        env = FakeEnv()
+        env = Monitored(FakeEnv())
         env.monitor.start(temp)
         env.monitor.close()
 
@@ -57,7 +58,7 @@ def test_close_monitor():
 
 def test_video_callable_true_not_allowed():
     with helpers.tempdir() as temp:
-        env = gym.make('CartPole-v0')
+        env = Monitored(gym.make('CartPole-v0'))
         try:
             env.monitor.start(temp, video_callable=True)
         except error.Error:
@@ -67,7 +68,7 @@ def test_video_callable_true_not_allowed():
 
 def test_video_callable_false_does_not_record():
     with helpers.tempdir() as temp:
-        env = gym.make('CartPole-v0')
+        env = Monitored(gym.make('CartPole-v0'))
         env.monitor.start(temp, video_callable=False)
         env.reset()
         env.monitor.close()
@@ -76,7 +77,7 @@ def test_video_callable_false_does_not_record():
 
 def test_video_callable_records_videos():
     with helpers.tempdir() as temp:
-        env = gym.make('CartPole-v0')
+        env = Monitored(gym.make('CartPole-v0'))
         env.monitor.start(temp)
         env.reset()
         env.monitor.close()
@@ -85,7 +86,7 @@ def test_video_callable_records_videos():
 
 def test_env_reuse():
     with helpers.tempdir() as temp:
-        env = gym.make('CartPole-v0')
+        env = Monitored(gym.make('CartPole-v0'))
         env.monitor.start(temp)
         env.monitor.close()
 
@@ -118,7 +119,7 @@ gym.envs.register(
 )
 def test_env_reuse():
     with helpers.tempdir() as temp:
-        env = gym.make('Autoreset-v0')
+        env = Monitored(gym.make('Autoreset-v0'))
         env.monitor.start(temp)
 
         env.reset()
@@ -142,7 +143,7 @@ def test_no_monitor_reset_unless_done():
 
     with helpers.tempdir() as temp:
         # Make sure we can reset as we please without monitor
-        env = gym.make('CartPole-v0')
+        env = Monitored(gym.make('CartPole-v0'))
         env.reset()
         env.step(env.action_space.sample())
         env.step(env.action_space.sample())
@@ -175,7 +176,7 @@ def test_no_monitor_reset_unless_done():
 
 def test_only_complete_episodes_written():
     with helpers.tempdir() as temp:
-        env = gym.make('CartPole-v0')
+        env = Monitored(gym.make('CartPole-v0'))
 
         env.monitor.start(temp, video_callable=False)
         env.reset()

--- a/gym/monitoring/tests/test_monitor.py
+++ b/gym/monitoring/tests/test_monitor.py
@@ -14,9 +14,11 @@ class FakeEnv(gym.Env):
 
 def test_monitor_filename():
     with helpers.tempdir() as temp:
-        env = Monitored(gym.make('CartPole-v0'))
-        env.monitor.start(temp)
-        env.monitor.close()
+        env = gym.make('Cartpole-v0')
+        monitor = monitoring.Monitor(env)
+        env = Monitored(env, monitor)
+        monitor.start(temp)
+        monitor.close()
 
         manifests = glob.glob(os.path.join(temp, '*.manifest.*'))
         assert len(manifests) == 1

--- a/gym/monitoring/tests/test_monitor_envs.py
+++ b/gym/monitoring/tests/test_monitor_envs.py
@@ -6,6 +6,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from gym import envs
+from gym import Monitored
 from gym.monitoring.tests import helpers
 
 specs = [spec for spec in sorted(envs.registry.all(), key=lambda x: x.id) if spec._entry_point is not None]
@@ -25,7 +26,7 @@ def test_renderable_after_monitor_close(spec):
         return
 
     with helpers.tempdir() as temp:
-        env = spec.make()
+        env = Monitored(spec.make())
         # Skip un-renderable envs
         if 'human' not in env.metadata.get('render.modes', []):
             return

--- a/gym/monitoring/tests/test_monitor_envs.py
+++ b/gym/monitoring/tests/test_monitor_envs.py
@@ -6,7 +6,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from gym import envs
-from gym import Monitored
+from gym.wrappers import Monitored
 from gym.monitoring.tests import helpers
 
 specs = [spec for spec in sorted(envs.registry.all(), key=lambda x: x.id) if spec._entry_point is not None]
@@ -26,12 +26,11 @@ def test_renderable_after_monitor_close(spec):
         return
 
     with helpers.tempdir() as temp:
-        env = Monitored(spec.make())
+        env = Monitored(spec.make(), temp)
         # Skip un-renderable envs
         if 'human' not in env.metadata.get('render.modes', []):
             return
 
-        env.monitor.start(temp)
         env.reset()
         env.monitor.close()
 

--- a/gym/scoreboard/api.py
+++ b/gym/scoreboard/api.py
@@ -114,7 +114,7 @@ def _upload(training_dir, algorithm_id=None, writeup=None, benchmark_run_id=None
         elif training_video_id is not None:
             logger.info('[%s] Creating evaluation object from %s with training video', env_id, training_dir)
         else:
-            raise error.Error("[%s] You didn't have any recorded training data in {}. Once you've used 'env.monitor.start(training_dir)' to start recording, you need to actually run some rollouts. Please join the community chat on https://gym.openai.com if you have any issues.".format(env_id, training_dir))
+            raise error.Error("[%s] You didn't have any recorded training data in {}. Once you've done 'env = wrappers.Monitored(env, training_dir)' to start recording, you need to actually run some rollouts. Please join the community chat on https://gym.openai.com if you have any issues.".format(env_id, training_dir))
 
     evaluation = resource.Evaluation.create(
         training_episode_batch=training_episode_batch_id,
@@ -137,7 +137,7 @@ def upload_training_data(training_dir, api_key=None):
     if not results:
         raise error.Error('''Could not find any manifest files in {}.
 
-(HINT: this usually means you did not yet close() your env.monitor and have not yet exited the process. You should call 'env.monitor.start(training_dir)' at the start of training and 'env.monitor.close()' at the end, or exit the process.)'''.format(training_dir))
+(HINT: this usually means you did not yet close() your env.monitor and have not yet exited the process. You should wrap your env with wrappers.Monitored() at the start of training and call 'env.close()' at the end, or exit the process.)'''.format(training_dir))
 
     manifests = results['manifests']
     env_info = results['env_info']

--- a/gym/wrappers/__init__.py
+++ b/gym/wrappers/__init__.py
@@ -1,1 +1,2 @@
 from gym.wrappers.frame_skipping import SkipWrapper
+from gym.wrappers.monitoring import Monitored

--- a/gym/wrappers/monitoring.py
+++ b/gym/wrappers/monitoring.py
@@ -13,9 +13,13 @@ class Monitored(Wrapper):
         """Monitor is started immediately when this wrapper is created, using
         the provided args. See monitoring.Monitor.start for documentation of 
         start parameters."""
-        self.monitor = monitoring.Monitor(env)
+        self.monitor = self._monitor_factory(env)
         super(Monitored, self).__init__(env)
         self.monitor.start(*start_args, **start_kwargs)
+
+    def _monitor_factory(self, env):
+        # Subclasses can override this to wrap with different kinds of monitors.
+        return monitoring.Monitor(env)
 
     def _step(self, action):
         self.monitor._before_step(action)

--- a/gym/wrappers/monitoring.py
+++ b/gym/wrappers/monitoring.py
@@ -1,0 +1,27 @@
+from gym import monitoring
+from gym import Wrapper
+
+class Monitored(Wrapper):
+    def __init__(self, env, *start_args, **start_kwargs):
+        """Monitor is started immediately when this wrapper is created, using
+        the provided args. See monitoring.Monitor.start for documentation of 
+        start parameters."""
+        self.monitor = monitoring.Monitor(env)
+        super(Monitored, self).__init__(env)
+        self.monitor.start(*start_args, **start_kwargs)
+
+    def _step(self, action):
+        self.monitor._before_step(action)
+        observation, reward, done, info = self.env.step(action)
+        done = self.monitor._after_step(observation, reward, done, info)
+        return observation, reward, done, info
+
+    def _reset(self):
+        self.monitor._before_reset()
+        observation = self.env.reset()
+        self.monitor._after_reset(observation)
+        return observation
+
+    def _close(self):
+        self.monitor.close()
+        self.env.close()

--- a/gym/wrappers/monitoring.py
+++ b/gym/wrappers/monitoring.py
@@ -2,6 +2,13 @@ from gym import monitoring
 from gym import Wrapper
 
 class Monitored(Wrapper):
+    """Attaches a monitor to the wrapped environment that records stats and
+    video. When this wrapper is created, it creates a monitor and calls start()
+    on it. Calling close() on the wrapper env will also close() the monitor.
+
+    For finer-grained control, the monitor can be interacted with directly using
+    the 'monitor' attribute.
+    """
     def __init__(self, env, *start_args, **start_kwargs):
         """Monitor is started immediately when this wrapper is created, using
         the provided args. See monitoring.Monitor.start for documentation of 


### PR DESCRIPTION
Sequel to [#422](https://github.com/openai/gym/pull/422). 

There would need to be some non-trivial corresponding changes to universe before this is mergeable, but I thought I'd float this here first to see if it's on track.

I have some concerns:

- this is a pretty significant breaking API change (not in the sense of being a huge departure, but it affects a common operation, so it'll break a lot of people's code).
- it's not really clear how to fix the issue this introduces in SemiSuperEnv. It's true that you could recover the same behaviour by writing a separate Monitor wrapper. But how does the user know they're supposed to import `SemiSuperMonitored` rather than using the regular `Monitored` wrapper?
- without knowing how wrappers are implemented, would you guess that `Monitored(SpamWrapper(env))` enables monitoring, but `SpamWrapper(Monitored(env))` doesn't?