### PR TITLE
Add combinatorial enumeration to MultiDiscrete

### DIFF
--- a/gym/monitoring/video_recorder.py
+++ b/gym/monitoring/video_recorder.py
@@ -289,7 +289,10 @@ class ImageEncoder(object):
                      )
 
         logger.debug('Starting ffmpeg with "%s"', ' '.join(self.cmdline))
-        self.proc = subprocess.Popen(self.cmdline, stdin=subprocess.PIPE, preexec_fn=os.setsid)
+        if hasattr(os,'setsid'): #setsid not present on Windows
+            self.proc = subprocess.Popen(self.cmdline, stdin=subprocess.PIPE, preexec_fn=os.setsid)
+        else:
+            self.proc = subprocess.Popen(self.cmdline, stdin=subprocess.PIPE)
 
     def capture_frame(self, frame):
         if not isinstance(frame, (np.ndarray, np.generic)):

--- a/gym/spaces/tests/test_spaces.py
+++ b/gym/spaces/tests/test_spaces.py
@@ -3,7 +3,7 @@ import json # note: ujson fails this test due to float equality
 import numpy as np
 from nose2 import tools
 
-from gym.spaces import Tuple, Box, Discrete, MultiDiscrete
+from gym.spaces import Tuple, Box, Discrete, MultiDiscrete, DiscreteToMultiDiscrete
 
 @tools.params(Discrete(3),
               Tuple([Discrete(5), Discrete(10)]),
@@ -29,3 +29,16 @@ def test_roundtripping(space):
     s2p = space.to_jsonable([sample_2_prime])
     assert s1 == s1p, "Expected {} to equal {}".format(s1, s1p)
     assert s2 == s2p, "Expected {} to equal {}".format(s2, s2p)
+
+@tools.params(
+    ([[0, 1], [2, 3]], [(0, 2), (0, 3), (1, 2), (1, 3)]),
+    ([[0, 1], [2, 4]], [(0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4)]))
+def test_multidiscrete_enumerate_options(space, expected_options):
+    actual_options = list(MultiDiscrete(space).enumerate_options())
+    assert actual_options == expected_options
+
+@tools.params( ([1], 2), ([1, 2], 6), ([3, 4, 5], 120))
+def test_multidiscrete_to_discreet(high, expected_n):
+    space = MultiDiscrete([[0, i] for i in high])
+    wrapped = DiscreteToMultiDiscrete(space, 'all')
+    assert wrapped.n == expected_n


### PR DESCRIPTION
Hi everybody,

I added combinatorial enumeration to MultiDiscrete, which I assume is the typical use-case.

MultiDiscrete spaces model multiple discrete actions, such as multiple buttons on a keypad. I added the new function enumerate_options(), which enumerates all of the possible combinations of keypresses.

```
multi_discrete = MultiDiscrete([[0, 1], [2, 4]])
print(list(multi_discrete.enumerate_options()))

```

> [(0, 2), (0, 3), (0, 4), (1, 2), (1, 3), (1, 4)]

I also added a new configuration DiscreteToMultiDiscrete(multi_discrete, 'all'), which will enumerate and flatten all of the possible combinations.

```
wrapped = DiscreteToMultiDiscrete(multi_discrete, 'all')
samples = [wrapped.sample() for i in range(10)]
print(wrapped.n)
print(samples)
print([wrapped(sample) for sample in samples])
```

> 6
> [4, 0, 0, 4, 2, 1, 0, 1, 5, 1]
> [(1, 3), (0, 2), (0, 2), (1, 3), (0, 4), (0, 3), (0, 2), (0, 3), (1, 4), (0, 3)]
> 

This should make it easier to translate from lists of buttons to lists of actions.

Cheers,
Ben