### PR TITLE
Fix video recording on Windows - skip setsid if attribute not present

### DIFF
--- a/gym/monitoring/video_recorder.py
+++ b/gym/monitoring/video_recorder.py
@@ -289,7 +289,10 @@ class ImageEncoder(object):
                      )
 
         logger.debug('Starting ffmpeg with "%s"', ' '.join(self.cmdline))
-        self.proc = subprocess.Popen(self.cmdline, stdin=subprocess.PIPE, preexec_fn=os.setsid)
+        if hasattr(os,'setsid'): #setsid not present on Windows
+            self.proc = subprocess.Popen(self.cmdline, stdin=subprocess.PIPE, preexec_fn=os.setsid)
+        else:
+            self.proc = subprocess.Popen(self.cmdline, stdin=subprocess.PIPE)
 
     def capture_frame(self, frame):
         if not isinstance(frame, (np.ndarray, np.generic)):


### PR DESCRIPTION
Conditionally reference os.setsid if that attribute is present. setsid is not an attribute of os on Windows. 

With this change, it looks like video recording is working correctly on Windows. Without the change, I get an error about setsid not being an attribute of os. I'm running Anaconda python 2.7.

Shouldn't affect mac and linux users.

Cheers,
Ben