### PR TITLE
Synchronize dependencies in requirements.txt and setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ numpy>=1.10.4
 requests>=2.0
 six
 pyglet>=1.2.0
-scipy==0.17.1


### PR DESCRIPTION
Synchronize dependencies in requirements.txt and setup.py.

I changed scipy to a greater-than requirement instead of equality. Please let me know if there is something broken in later versions of scipy. I also added scipy to setup.py. I removed theano because it is a dependency of keras.

https://github.com/openai/gym/issues/449

Cheers,
Ben

