### PR TITLE
Utilities for observation spaces

### DIFF
--- a/gym/utils/space_utils.py
+++ b/gym/utils/space_utils.py
@@ -1,0 +1,90 @@
+from gym.spaces import Tuple, Box, Discrete
+import itertools
+import numpy as np
+
+
+def flatten_spaces(space):
+    """
+    Flatten a tree of Tuple spaces into a list of simple spaces.
+    :param space: A space that may be a Tuple
+    :return: a list of spaces
+    """
+    if isinstance(space, Tuple):
+        return list(itertools.chain.from_iterable(flatten_spaces(s) for s in space.spaces))
+    else:
+        return [space]
+
+
+def space_shapes(space_list):
+    """
+    Return shapes of a list of Discrete and Box spaces
+    :param space_list: list of spaces
+    :return: list of shape tuples
+    """
+    shapes = []
+    for space in space_list:
+        if isinstance(space, Discrete):
+            shapes.append((space.n,))
+        elif isinstance(space, Box):
+            shapes.append(space.shape)
+        else:
+            raise NotImplementedError("Only Discrete and Box input spaces currently supported")
+    return shapes
+
+
+def one_hot(label, nb_classes):
+    """
+    Convert label and number of classes to one-hot representation
+    :param label: class label
+    :param nb_classes: number of classes
+    :return: vector of length nb_classes, 1 at position label, 0 everywhere else.
+    """
+    ret = np.zeros((nb_classes,))
+    ret[label] = 1
+    return ret
+
+
+def flatten_input(observation, observation_space):
+    """
+    Given observation and observation space, return list of numpy arrays of same shape as space_shapes.
+    * Tuple spaces are flattened into a list
+    * Box spaces are wrapped as numpy arrays and shaped to match the space.shape
+    * Discrete spaces are one-hot encoded as numpy arrays
+    :param observation: input observation, typically tuples of arrays
+    :param observation_space: space describing the input observations
+    :return: list of numpy arrays
+    """
+    if isinstance(observation_space, Tuple):
+        return list(
+            itertools.chain.from_iterable(flatten_input(o, s) for o, s in zip(observation, observation_space.spaces)))
+    elif isinstance(observation_space, Discrete):
+        return [one_hot(observation, observation_space.n)]
+    elif isinstance(observation_space, Box):
+        return [np.array(observation).reshape(observation_space.shape)]
+    else:
+        raise NotImplementedError(
+            "Only Discrete and Box input spaces currently supported, found: {}".format(type(observation_space)))
+
+
+def concatenated_input_dim(observation_space):
+    """
+    Calculate the total number of dimensions of an input space
+    * Tuple spaces are unrolled
+    * Boxe spaces are flattened
+    * Discrete spaces are one-hot encoded
+    :param observation_space: space describing the input observation
+    :return: number of dimensions
+    """
+    shapes = space_shapes(flatten_spaces(observation_space))
+    return np.sum(np.prod(shape) for shape in shapes)
+
+
+def concatenated_input(observation, observation_space):
+    """
+    Convert Discrete spaces to one-hot encodings and flatten all inputs into a single numpy array.
+    :param observation: input observation
+    :param observation_space: space describing the input observation
+    :return: single dimensional numpy array concatenating all input
+    """
+    observations = flatten_input(observation, observation_space)
+    return np.hstack(obs.reshape((-1)) for obs in observations)

--- a/gym/utils/tests/test_space_utils.py
+++ b/gym/utils/tests/test_space_utils.py
@@ -1,0 +1,30 @@
+from nose2 import tools
+import numpy as np
+from gym.spaces import Discrete, Tuple, Box
+from gym.utils.space_utils import concatenated_input_dim, flatten_input, flatten_spaces
+from gym.utils.space_utils import space_shapes, concatenated_input
+
+
+@tools.params((Discrete(3), [(3,)]),
+              (Tuple([Discrete(5), Discrete(10)]), [(5,), (10,)]))
+def test_space_shapes(space, expected_shapes):
+    actual_shapes = space_shapes(flatten_spaces(space))
+    assert actual_shapes == expected_shapes
+
+
+@tools.params((Discrete(5), 3, [np.array([0, 0, 0, 1, 0])]),
+              (Tuple([Box(-10, 10, (2, 3)), Discrete(4)]), ([[2, 3, 4], [1, 2, 3]], 2),
+               [[[2, 3, 4], [1, 2, 3]], [0, 0, 1, 0]]))
+def test_flatten_input(space, observation, expected_input):
+    actual_input = flatten_input(observation, space)
+    for actual, expected in zip(actual_input, expected_input):
+        np.testing.assert_array_equal(actual, expected)
+
+
+@tools.params((Discrete(5), 3, 5),
+              (Tuple([Box(-10, 10, (2, 3)), Discrete(4)]), ([[2, 3, 4], [1, 2, 3]], 2), 10))
+def test_concatenated_input(space, observation, expected_shape):
+    actual_shape_dim = concatenated_input_dim(space)
+    assert (actual_shape_dim == expected_shape)
+    flat_input = concatenated_input(observation, space)
+    assert (flat_input.shape[0] == expected_shape)


### PR DESCRIPTION
Hello everybody,

These are generic utilities for converting observations and observation spaces into feature vectors. Using these utilities, an agent should be able to support any combination of Tuple, Box and Discrete observation spaces. The goal is to easily write generic agents without knowing the specifics of the observation space.

At the extreme, you can flatten the input entirely regardless of its structure.

Typical use case:
```
# flatten Tuple and Box spaces and one-hot encode Discrete spaces
# model input shape calculated by concatenated_input_dim
input_layer = Input(shape=(concatenated_input_dim(space),))
# 1-D numpy feature vector calculated by concatenated_input
input_features = concatenated_input(observation, space)
```

If you want more control, you can use `space_shapes` and `flatten_input` to one-hot encode input and convert a tree into a list, but not flatten the inputs.

Cheers,
Ben