### PR TITLE
get rid of deprecation warning for env.spec.timestep_limit

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -78,15 +78,11 @@ class EnvSpec(object):
 
     @property
     def timestep_limit(self):
-        logger.warn("DEPRECATION WARNING: env.spec.timestep_limit has been deprecated. Replace your call to `env.spec.timestep_limit` with `env.spec.tags.get('wrapper_config.TimeLimit.max_episode_steps')`. This change was made 12/28/2016 and is included in version 0.7.0")
         return self.tags.get('wrapper_config.TimeLimit.max_episode_steps')
 
     @timestep_limit.setter
     def timestep_limit(self, timestep_limit):
-        if timestep_limit is not None:
-            logger.warn(
-                "DEPRECATION WARNING: env.spec.timestep_limit has been deprecated. Replace any calls to `register(timestep_limit=200)` with `register(tags={'wrapper_config.TimeLimit.max_episode_steps': 200)}`, . This change was made 12/28/2016 and is included in gym version 0.7.0. If you are getting many of these warnings, you may need to update universe past version 0.21.1")
-            self.tags['wrapper_config.TimeLimit.max_episode_steps'] = timestep_limit
+        self.tags['wrapper_config.TimeLimit.max_episode_steps'] = timestep_limit
 
 class EnvRegistry(object):
     """Register an env by ID. IDs remain stable over time and are


### PR DESCRIPTION
proposed syntax seems too verbose for something so common