### PR TITLE
remove configure, simplify core.py

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -4,7 +4,7 @@ logger = logging.getLogger(__name__)
 import numpy as np
 
 from gym import error
-from gym.utils import closer, reraise
+from gym.utils import closer
 
 env_closer = closer.Closer()
 
@@ -21,7 +21,6 @@ class Env(object):
         reset
         render
         close
-        configure
         seed
 
     When implementing an environment, override the following methods
@@ -31,7 +30,6 @@ class Env(object):
         _reset
         _render
         _close
-        _configure
         _seed
 
     And set the following attributes:
@@ -53,8 +51,7 @@ class Env(object):
         env = super(Env, cls).__new__(cls)
         env._env_closer_id = env_closer.register(env)
         env._closed = False
-        env._configured = False
-        env._unwrapped = None
+        env._configured = False # TODO: remove
 
         # Will be automatically set when creating an environment via 'make'
         env.spec = None
@@ -68,9 +65,6 @@ class Env(object):
     def _close(self):
         pass
 
-    def _configure(self):
-        pass
-
     # Set these in ALL subclasses
     action_space = None
     observation_space = None
@@ -78,10 +72,7 @@ class Env(object):
     # Override in ALL subclasses
     def _step(self, action): raise NotImplementedError
     def _reset(self): raise NotImplementedError
-    def _render(self, mode='human', close=False):
-        if close:
-            return
-        raise NotImplementedError
+    def _render(self, mode='human', close=False): raise NotImplementedError
     def _seed(self, seed=None): return []
 
     # Do not override
@@ -107,21 +98,15 @@ class Env(object):
             done (boolean): whether the episode has ended, in which case further step() calls will return undefined results
             info (dict): contains auxiliary diagnostic information (helpful for debugging, and sometimes learning)
         """
-        observation, reward, done, info = self._step(action)
-        return observation, reward, done, info
+        return self._step(action)
 
     def reset(self):
-        """Resets the state of the environment and returns an initial
-        observation. Will call 'configure()' if not already called.
+        """Resets the state of the environment and returns an initial observation.
 
         Returns: observation (object): the initial observation of the
-            space. (Initial reward is assumed to be 0.)
+            space.
         """
-        if self.metadata.get('configure.required') and not self._configured:
-            logger.warning("Called reset on %s before configuring. Configuring automatically with default arguments", self)
-            self.configure()
-        observation = self._reset()
-        return observation
+        return self._reset()
 
     def render(self, mode='human', close=False):
         """Renders the environment.
@@ -161,16 +146,12 @@ class Env(object):
                 else:
                     super(MyEnv, self).render(mode=mode) # just raise an exception
         """
-        if close:
-            return self._render(close=close)
-
-        # This code can be useful for calling super() in a subclass.
+        if close: return        
         modes = self.metadata.get('render.modes', [])
         if len(modes) == 0:
             raise error.UnsupportedMode('{} does not support rendering (requested mode: {})'.format(self, mode))
         elif mode not in modes:
             raise error.UnsupportedMode('Unsupported rendering mode: {}. (Supported modes for {}: {})'.format(mode, self, modes))
-
         return self._render(mode=mode, close=close)
 
     def close(self):
@@ -179,9 +160,7 @@ class Env(object):
         Environments will automatically close() themselves when
         garbage collected or when the program exits.
         """
-        # _closed will be missing if this instance is still
-        # initializing.
-        if not hasattr(self, '_closed') or self._closed:
+        if self._closed:
             return
 
         if self._owns_render:
@@ -210,43 +189,14 @@ class Env(object):
         """
         return self._seed(seed)
 
-    def configure(self, *args, **kwargs):
-        """Provides runtime configuration to the environment.
-
-        This configuration should consist of data that tells your
-        environment how to run (such as an address of a remote server,
-        or path to your ImageNet data). It should not affect the
-        semantics of the environment.
-        """
-        self._configured = True
-
-        try:
-            self._configure(*args, **kwargs)
-        except TypeError as e:
-            # It can be confusing if you have the wrong environment
-            # and try calling with unsupported arguments, since your
-            # stack trace will only show core.py.
-            if self.spec:
-                reraise(suffix='(for {})'.format(self.spec.id))
-            else:
-                raise
-
     @property
     def unwrapped(self):
         """Completely unwrap this env.
 
-        Notes:
-            EXPERIMENTAL: may be removed in a later version of Gym
-
-            This is a dynamic property in order to avoid refcycles.
-
         Returns:
             gym.Env: The base non-wrapped gym.Env instance
         """
-        if self._unwrapped is not None:
-            return self._unwrapped
-        else:
-            return self
+        return self
 
     def __del__(self):
         self.close()
@@ -288,46 +238,37 @@ class Space(object):
 class Wrapper(Env):
     # Clear metadata so by default we don't override any keys.
     metadata = {}
-
     _owns_render = False
-
     # Make sure self.env is always defined, even if things break
     # early.
     env = None
 
-    def __init__(self, env=None):
+    def __init__(self, env):
         self.env = env
         # Merge with the base metadata
         metadata = self.metadata
         self.metadata = self.env.metadata.copy()
-        self.metadata.update(metadata)
+        self.metadata.update(metadata)        
 
         self.action_space = self.env.action_space
         self.observation_space = self.env.observation_space
         self.reward_range = self.env.reward_range
-        self._spec = self.env.spec
-        self._unwrapped = self.env.unwrapped
-
-        self._update_wrapper_stack()
-        if env and env._configured:
-            logger.warning("Attempted to wrap env %s after .configure() was called.", env)
-
-    def _update_wrapper_stack(self):
-        """
-        Keep a list of all the wrappers that have been appended to the stack.
-        """
-        self._wrapper_stack = getattr(self.env, '_wrapper_stack', [])
-        self._check_for_duplicate_wrappers()
-        self._wrapper_stack.append(self)
-
-    def _check_for_duplicate_wrappers(self):
-        """Raise an error if there are duplicate wrappers. Can be overwritten by subclasses"""
-        if self.class_name() in [wrapper.class_name() for wrapper in self._wrapper_stack]:
-            raise error.DoubleWrapperError("Attempted to double wrap with Wrapper: {}".format(self.class_name()))
+        self.spec = self.env.spec
+        self._ensure_no_double_wrap()
 
     @classmethod
     def class_name(cls):
         return cls.__name__
+
+    def _ensure_no_double_wrap(self):
+        env = self.env
+        while True:
+            if isinstance(env, Wrapper): 
+                if env.class_name() == self.class_name():
+                    raise error.DoubleWrapperError("Attempted to double wrap with Wrapper: {}".format(self.__class__.__name__))
+                env = env.env
+            else:
+                break
 
     def _step(self, action):
         return self.env.step(action)
@@ -336,17 +277,10 @@ class Wrapper(Env):
         return self.env.reset()
 
     def _render(self, mode='human', close=False):
-        if self.env is None:
-            return
         return self.env.render(mode, close)
 
     def _close(self):
-        if self.env is None:
-            return
         return self.env.close()
-
-    def _configure(self, *args, **kwargs):
-        return self.env.configure(*args, **kwargs)
 
     def _seed(self, seed=None):
         return self.env.seed(seed)
@@ -358,17 +292,8 @@ class Wrapper(Env):
         return str(self)
 
     @property
-    def spec(self):
-        if self._spec is None:
-            self._spec = self.env.spec
-        return self._spec
-
-    @spec.setter
-    def spec(self, spec):
-        # Won't have an env attr while in the __new__ from gym.Env
-        if self.env is not None:
-            self.env.spec = spec
-        self._spec = spec
+    def unwrapped(self):
+        return self.env.unwrapped
 
 class ObservationWrapper(Wrapper):
     def _reset(self):

--- a/gym/core.py
+++ b/gym/core.py
@@ -51,7 +51,6 @@ class Env(object):
         env = super(Env, cls).__new__(cls)
         env._env_closer_id = env_closer.register(env)
         env._closed = False
-        env._configured = False # TODO: remove
 
         # Will be automatically set when creating an environment via 'make'
         env.spec = None
@@ -248,7 +247,7 @@ class Wrapper(Env):
         # Merge with the base metadata
         metadata = self.metadata
         self.metadata = self.env.metadata.copy()
-        self.metadata.update(metadata)        
+        self.metadata.update(metadata)
 
         self.action_space = self.env.action_space
         self.observation_space = self.env.observation_space

--- a/gym/monitoring/tests/test_monitor.py
+++ b/gym/monitoring/tests/test_monitor.py
@@ -35,10 +35,7 @@ def test_write_upon_reset_true():
     with helpers.tempdir() as temp:
         env = gym.make('CartPole-v0')
 
-        # TODO: Fix Cartpole to not configure itself automatically
-        # assert not env._configured
         env = Monitor(env, directory=temp, video_callable=False, write_upon_reset=True)
-        env.configure()
         env.reset()
 
         files = glob.glob(os.path.join(temp, '*'))

--- a/gym/wrappers/tests/test_wrappers.py
+++ b/gym/wrappers/tests/test_wrappers.py
@@ -14,31 +14,6 @@ def test_skip():
     obs = env.reset()
     env.render()
 
-def test_configured():
-    env = gym.make("FrozenLake-v0")
-    env.configure()
-
-    # Make sure all layers of wrapping are configured
-    assert env._configured
-    assert env.env._configured
-    env.close()
-
-# TODO: Fix Cartpole issue and raise WrapAfterConfigureError correctly
-# def test_double_configured():
-#     env = gym.make("FrozenLake-v0")
-#     every_two_frame = SkipWrapper(2)
-#     env = every_two_frame(env)
-#
-#     env.configure()
-#     try:
-#         env = wrappers.TimeLimit(env)
-#     except error.WrapAfterConfigureError:
-#         pass
-#     else:
-#         assert False
-#
-#     env.close()
-
 def test_no_double_wrapping():
     temp = tempfile.mkdtemp()
     try:


### PR DESCRIPTION
Made some simplifications to core.py.
I'd like to move all of the configure() logic into the Universe Env, but I can't get any of the Universe tests to pass on my machine.