### PR TITLE
Remove duplicate PyOpenGL declaration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ deps =
     PyOpenGL
     pachi-py>=0.0.19
     box2d-py
-    PyOpenGL
     doom_py>=0.0.11
     mujoco_py>=0.4.3
     keras
@@ -40,7 +39,6 @@ deps =
     PyOpenGL
     pachi-py>=0.0.19
     box2d-py
-    PyOpenGL
     doom_py>=0.0.11
     mujoco_py>=0.4.3
     keras


### PR DESCRIPTION
Currently in `tox.ini`, `PyOpenGL` is declared twice per python version. 