### PR TITLE
Pass along kwargs in reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ tutorial/*.html
 # PyCharm project files
 .idea
 vizdoom.ini
+
+# vim
+.ropeproject
+tags
+*.swo

--- a/gym/core.py
+++ b/gym/core.py
@@ -110,9 +110,12 @@ class Env(object):
         observation, reward, done, info = self._step(action)
         return observation, reward, done, info
 
-    def reset(self):
+    def reset(self, **kwargs):
         """Resets the state of the environment and returns an initial
         observation. Will call 'configure()' if not already called.
+
+        Args:
+            kwargs: forward episode-specific config to the environment.
 
         Returns: observation (object): the initial observation of the
             space. (Initial reward is assumed to be 0.)
@@ -120,7 +123,7 @@ class Env(object):
         if self.metadata.get('configure.required') and not self._configured:
             logger.warning("Called reset on %s before configuring. Configuring automatically with default arguments", self)
             self.configure()
-        observation = self._reset()
+        observation = self._reset(**kwargs)
         return observation
 
     def render(self, mode='human', close=False):
@@ -332,8 +335,8 @@ class Wrapper(Env):
     def _step(self, action):
         return self.env.step(action)
 
-    def _reset(self):
-        return self.env.reset()
+    def _reset(self, **kwargs):
+        return self.env.reset(**kwargs)
 
     def _render(self, mode='human', close=False):
         if self.env is None:

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -1,7 +1,6 @@
 from gym.envs.registration import registry, register, make, spec
 
-# Algorithmic
-# ----------------------------------------
+# Algorithmic # ----------------------------------------
 
 register(
     id='Copy-v0',

--- a/gym/wrappers/frame_skipping.py
+++ b/gym/wrappers/frame_skipping.py
@@ -28,8 +28,8 @@ def SkipWrapper(repeat_count):
             info['skip.stepcount'] = self.stepcount
             return obs, total_reward, done, info
 
-        def _reset(self):
+        def _reset(self, **kwargs):
             self.stepcount = 0
-            return self.env.reset()
+            return self.env.reset(**kwargs)
 
     return SkipWrapper

--- a/gym/wrappers/monitoring.py
+++ b/gym/wrappers/monitoring.py
@@ -23,9 +23,9 @@ class _Monitor(Wrapper):
 
         return observation, reward, done, info
 
-    def _reset(self):
+    def _reset(self, **kwargs):
         self._monitor._before_reset()
-        observation = self.env.reset()
+        observation = self.env.reset(**kwargs)
         self._monitor._after_reset(observation)
 
         return observation

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -46,7 +46,7 @@ class TimeLimit(Wrapper):
 
         return observation, reward, done, info
 
-    def _reset(self):
+    def _reset(self, **kwargs):
         self._episode_started_at = time.time()
         self._elapsed_steps = 0
-        return self.env.reset()
+        return self.env.reset(**kwargs)


### PR DESCRIPTION
TL;DR extend reset to be `reset(**kwargs)` so we can have reset the environment to a given configuration.

See PR: https://github.com/openai/universe/pull/122

@joschu 
