### PR TITLE
Add support for Adventure, Atari game by W. Robinett

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -269,7 +269,7 @@ register(
 # ----------------------------------------
 
 # # print ', '.join(["'{}'".format(name.split('.')[0]) for name in atari_py.list_games()])
-for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix', 'asteroids', 'atlantis',
+for game in ['adventure', 'air_raid', 'alien', 'amidar', 'assault', 'asterix', 'asteroids', 'atlantis',
     'bank_heist', 'battle_zone', 'beam_rider', 'berzerk', 'bowling', 'boxing', 'breakout', 'carnival',
     'centipede', 'chopper_command', 'crazy_climber', 'demon_attack', 'double_dunk',
     'elevator_action', 'enduro', 'fishing_derby', 'freeway', 'frostbite', 'gopher', 'gravitar',


### PR DESCRIPTION
This adds support for [Adventure](https://en.wikipedia.org/wiki/Adventure_(Atari_2600)), which is now supported in https://pypi.python.org/pypi/atari-py/0.0.21. See also https://github.com/openai/atari-py/pull/9

It has very sparse rewards; -1 for getting "eaten" by a dragon, +1 for bringing the chalice to the golden castle. Both states end the episode.

Semi-skilled player finishing level 1: https://www.youtube.com/watch?v=I6-zN_eaRd8

"Classic game implementation post-mortem" from GDC: https://www.youtube.com/watch?v=yINb5Huh0C4


Just adding this should allow it to be used within gym locally.

I didn't add Adventure to the scoreboard (gym/scoreboard/__init__.py) because I haven't tested that yet.

I didn't know what to put in https://github.com/openai/gym/envs/tests/rollout.json, so I didn't.

Both will probably be needed to entirely support Adventure in Gym (and I guess Universe).