### PR TITLE
fix issue #100 with new Box2D-kengz dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from version import VERSION
 extras = {
   'atari': ['atari_py>=0.0.21', 'Pillow', 'PyOpenGL'],
   'board_game' : ['pachi-py>=0.0.19'],
-  'box2d': ['box2d-py'],
+  'box2d': ['Box2D-kengz'],
   'classic_control': ['PyOpenGL'],
   'mujoco': ['mujoco_py>=0.4.3', 'imageio'],
   'parameter_tuning': ['keras', 'theano'],


### PR DESCRIPTION
This fixes #100 **Box2d won't find some RAND_LIMIT_swigconstant**

The issue has proven a hurdle for users who wants to get started on the gym, or for developers who builds projects with gym as the dependency since a clean install will have the broken 2d environments.

Steps:
- clone the Box2D repo, release a fixed version to PyPi as `Box2D-kengz` at version 2.3.3 (since the author seems inactive). The fork is [here](https://github.com/kengz/pybox2d).
- update gym's dependency in `setup.py` to point to this package
- test the installation with LunarLander-v2 environment on direct install of gym from my fork. Issue resolved.