### PR TITLE
Add license for Mujoco models

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+# gym
+
 The MIT License
 
 Copyright (c) 2016 OpenAI (http://openai.com)
@@ -19,3 +21,14 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+# Mujoco models
+This work is derived from [MuJuCo models](http://www.mujoco.org/forum/index.php?resources/) used under the following license:
+> This file is part of MuJoCo.     
+> Copyright 2009-2015 Roboti LLC.	
+> 	Mujoco		:: Advanced physics simulation engine
+> 	Source		: www.roboti.us
+>		Version		: 1.31
+>		Released 	: 23Apr16
+>	  Author		:: Vikash Kumar
+> 	Contacts 	: kumar@roboti.us


### PR DESCRIPTION
@vikashplus brought up that we have removed the header block on top of the Mujoco XMLs. This brings them back in the LICENSE. @gdb does that seem reasonable?