### PR TITLE
Allow Discrete spaces to be iterable

### DIFF
--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -22,6 +22,13 @@ class Discrete(gym.Space):
         else:
             return False
         return as_int >= 0 and as_int < self.n
+    def __len__(self):
+        return self.n
+    def __iter__(self):
+        i = 0
+        while i < self.n:
+            yield i
+            i += 1
     def __repr__(self):
         return "Discrete(%d)" % self.n
     def __eq__(self, other):

--- a/gym/spaces/tests/test_discrete.py
+++ b/gym/spaces/tests/test_discrete.py
@@ -1,0 +1,6 @@
+from gym.spaces import Discrete
+
+def test_is_iterable():
+    space = Discrete(5)
+    assert len(space) == 5
+    assert list(space) == [0, 1, 2, 3, 4]


### PR DESCRIPTION
Allows discrete spaces to be iterable, so the following can be accomplished:

```python
for action in env.action_space:
    print action
```