### PR TITLE
Add Dict space for access by keys

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -241,6 +241,16 @@ class Space(object):
         # By default, assume identity is JSONable
         return sample_n
 
+    def to_one_jsonable(self, sample):
+        """Convert a sample from this space to a JSONable data type."""
+        # By default, assume identity is JSONable
+        return sample
+
+    def from_one_jsonable(self, sample):
+        """Convert a JSONable data type to a sample from this space."""
+        # By default, assume identity is JSONable
+        return sample
+
 class Wrapper(Env):
     # Clear metadata so by default we don't override any keys.
     metadata = {}

--- a/gym/spaces/__init__.py
+++ b/gym/spaces/__init__.py
@@ -4,5 +4,6 @@ from gym.spaces.multi_discrete import MultiDiscrete
 from gym.spaces.multi_binary import MultiBinary
 from gym.spaces.prng import seed
 from gym.spaces.tuple_space import Tuple
+from gym.spaces.dict_space import Dict
 
-__all__ = ["Box", "Discrete", "MultiDiscrete", "MultiBinary", "Tuple"]
+__all__ = ["Box", "Discrete", "MultiDiscrete", "MultiBinary", "Tuple", "Dict"]

--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -35,6 +35,11 @@ class Box(gym.Space):
     def from_jsonable(self, sample_n):
         return [np.asarray(sample) for sample in sample_n]
 
+    def to_one_jsonable(self, sample):
+        return sample.tolist()
+    def from_one_jsonable(self, sample):
+        return np.asarray(sample)
+
     @property
     def shape(self):
         return self.low.shape

--- a/gym/spaces/dict_space.py
+++ b/gym/spaces/dict_space.py
@@ -1,0 +1,95 @@
+from gym import Space
+import numpy as np
+from collections import OrderedDict
+
+class Dict(Space):
+    """
+    A ordered dict of simpler spaces
+
+    Example usage:
+    s = Dict(('b', Discrete(2)), ('a', Box(0,1,2)))
+    s.sample()
+    -> OrderedDict([('b', 0), ('a', array([ 0.59284462,  0.84426575]))])
+    """
+    def __init__(self, *spaces):
+        """
+        spaces(OrderedDict or pairs of key and Space): an OrderedDict or ordered (key, Space)
+        """
+        if spaces is ():
+            self.spaces = OrderedDict()
+        elif isinstance(spaces[0], OrderedDict):
+            assert isinstance(spaces[0], Space)
+            self.spaces = spaces[0]
+        elif all(isinstance(x, (list, tuple)) for x in spaces):
+            self.spaces = OrderedDict(spaces)
+        else:
+            assert false
+
+    def sample(self):
+        """
+        random sample of the space
+        return: OrderedDict of sampled data
+        """
+        return OrderedDict([(key, space.sample()) for key, space in self.spaces.items()])
+
+    def contains(self, x):
+        '''x(OrderedDict): OrderedDict of data'''
+        assert isinstance(x, OrderedDict)
+        return isinstance(x, OrderedDict) and all(
+            self.spaces[key].contains(x[key]) for key in self.spaces.keys())
+
+    def __repr__(self):
+        return "Dict(" + ", ".join([str(x) for x in self.spaces]) + ")"
+
+    def to_jsonable(self, sample_n):
+        '''
+        convert the list of sample data to jsonable object
+        sample_n(list): List of sample data
+        return JSONable object
+        '''
+        return [OrderedDict(
+            [(key, space.to_one_jsonable(sample[key])) for key, space in self.spaces.items()]) for sample in sample_n]
+
+    def from_jsonable(self, sample_n):
+        '''
+        convert the jsonable object to the list of sample data
+        sample_n(list): JSONable representation of sample data
+        return List of sample data(OrderedDict)
+        '''
+        return [OrderedDict(
+            [(key, space.from_one_jsonable(sample[key])) for key, space in self.spaces.items()]) for sample in sample_n]
+
+    def to_one_jsonable(self, sample):
+        '''
+        convert a sample data to jsonable object
+        sample(object): a sample of data
+        return JSONable object
+        '''
+        return OrderedDict([(key, space.to_one_jsonable(sample[key])) for key, space in self.spaces.items()])
+
+    def __getitem__(self, key):
+        return self.spaces[key]
+
+    def __setitem__(self, key, value):
+        '''
+        Setter of Dict space. Note the assignment order is reserved.
+        d = Dict()
+        d['b'] = Discrete(3)
+        d['a'] = Box(0,1,2)
+        d.keys() --> ['b', 'a']
+        '''
+        assert isinstance(value, Space)
+        self.spaces[key] = value
+
+    def __iter__(self):
+        for key, value in self.spaces.items():
+            yield key, value
+
+    def keys(self):
+        return self.spaces.keys()
+
+    def values(self):
+        return self.spaces.values()
+
+    def items(self):
+        return self.spaces.items()

--- a/gym/spaces/tests/test_dict.py
+++ b/gym/spaces/tests/test_dict.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pytest
+from gym.spaces import Tuple, Box, Discrete, Dict
+from collections import OrderedDict
+
+def test_dict_space():
+    space = Dict(
+        ('d1', Discrete(2)),
+        ('b1', Box(0,1,1)),
+        ('t1', Tuple([Discrete(3), Box(0,1,2)])))
+    assert list(space.keys()) == ['d1', 'b1', 't1']
+    assert all([isinstance(x, y) for x, y in zip(space.values(), [Discrete, Box, Tuple])])
+    sample = space.sample()
+    assert isinstance(sample, OrderedDict)
+    assert space.contains(sample)
+    sample['b1'][0] = 1.1
+    assert not space.contains(sample)
+    

--- a/gym/spaces/tuple_space.py
+++ b/gym/spaces/tuple_space.py
@@ -29,3 +29,9 @@ class Tuple(Space):
 
     def from_jsonable(self, sample_n):
         return zip(*[space.from_jsonable(sample_n[i]) for i, space in enumerate(self.spaces)])
+
+    def to_one_jsonable(self, sample):
+        return [space.to_one_jsonable(sample[i]) for i, space in enumerate(self.spaces)]
+
+    def from_one_jsonable(self, sample):
+        return [space.from_one_jsonable(sample[i]) for i, space in enumerate(self.spaces)]


### PR DESCRIPTION
This Dict space defines a dict-like Space. It should be useful to bridge gym to other system. I need to modify the other space a bit to create JSON representation recursively.

Example:
```
> d=Dict(('button_a', Discrete(2)), ('axes', Box(0,1,2)))
> s=d.sample()
> s
OrderedDict([('button_a', 1), ('axes', array([ 0.38438171,  0.29753461]))])
> d.contains(s)
True			  
> s['button_a']
1
> s['axes']
array([ 0.38438171,  0.29753461])
> np.concatenate([x if isinstance(x,np.ndarray) else np.array([x]) for x in s.values()])
array([ 1.        ,  0.38438171,  0.29753461])
```
I use OrderedDict to preserve the order of elements. So we need to add 'object_pairs_hook=OrderedDict' argments for json.load function when use this Dict space.

- add dict_space.py
- add to_one_jsonable() and from_one_jsonable() for other space,
  need for recursive representation
- add test case in test_spaces.py
- add test for Dict in test_dict.py