### PR TITLE
Save and Restore Atari Environment State

### DIFF
--- a/gym/envs/atari/atari_env.py
+++ b/gym/envs/atari/atari_env.py
@@ -145,18 +145,34 @@ class AtariEnv(gym.Env, utils.EzPickle):
 
         return keys_to_action
 
-    # def save_state(self):
-    #     return self.ale.saveState()
+    def clone_state(self):
+        """Clone emulator state w/o system state. Restoring this state will
+        *not* give an identical environment. For complete cloning and restoring
+        of the full state, see `{clone,restore}_full_state()`."""
+        state_ref = self.ale.cloneState()
+        state = self.ale.encodeState(state_ref)
+        self.ale.deleteState(state_ref)
+        return state
 
-    # def load_state(self):
-    #     return self.ale.loadState()
+    def restore_state(self, state):
+        """Restore emulator state w/o system state."""
+        state_ref = self.ale.decodeState(state)
+        self.ale.restoreState(state)
+        self.ale.deleteState(state_ref)
 
-    # def clone_state(self):
-    #     return self.ale.cloneState()
+    def clone_full_state(self):
+        """Clone emulator state w/ system state including pseudorandomness.
+        Restoring this state will give an identical environment."""
+        state_ref = self.ale.cloneSystemState()
+        state = self.ale.encodeState(state_ref)
+        self.ale.deleteState(state_ref)
+        return state
 
-    # def restore_state(self, state):
-    #     return self.ale.restoreState(state)
-
+    def restore_full_state(self, state):
+        """Restore emulator state w/ system state including pseudorandomness."""
+        state_ref = self.ale.decodeState(state)
+        self.ale.restoreSystemState(state_ref)
+        self.ale.deleteState(state_ref)
 
 ACTION_MEANING = {
     0 : "NOOP",


### PR DESCRIPTION
Save (clone) and load (restore) the Atari emulator state for analysis, planning, or other experiments that require returning to identical states of the environment. This addresses #402 for Atari.

Note: the ALE distinguishes two kinds of environment states. The "state" captures memory but not further details of the "system state" that are necessary to determinism. `clone_full_state()` and `restore_full_state()` are necessary to save and load the state and system state (including pseudorandomness) for fully identical restoration of the environment.

Further note: a limitation of ALE is that on restore the screen is blank, and it's necessary to take a step in the emulator to draw to it. To properly restore a a time step t, one needs to both clone the system state at t-1 and save the action at t-1, and then restore the system state and take the action to arrive at time t.

See openai/atari-py#15 for the prerequisite changes to expose these methods through gym. This can be merged once atari-py has been updated, the new version is propagated to gym, and the environment version numbers are bumped to v4 since a few ROMs have slightly altered semantics in the latest ALE.