### PR TITLE
replace self.spec by getattr(self, 'spec', None) in core Env object

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -202,7 +202,7 @@ class Env(object):
         self.close()
 
     def __str__(self):
-        if self.spec is not None:
+        if getattr(self, 'spec', None) is not None:
             return '<{}<{}>>'.format(type(self).__name__, self.spec.id)
         else:
             return '<{} instance>'.format(type(self).__name__)


### PR DESCRIPTION
Accessing missing object attribute raises an exception that's not catched. For example

```
Traceback (most recent call last):
  File "policy_evaluation.py", line 5, in <module>
    print(env)
  File "/Users/QV/code-project/learn/sutton/venv/lib/python3.5/site-packages/gym/core.py", line 205, in __str__
    if self.spec is not None:
AttributeError: 'BlackjackEnv' object has no attribute 'spec'
```