### PR TITLE
Fix acrobot doc

### DIFF
--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -24,12 +24,12 @@ class AcrobotEnv(core.Env):
     collide when they have the same angle.
     **STATE:**
     The state consists of the sin() and cos() of the two rotational joint
-    angles and the joint velocities :
+    angles and the joint angular velocities :
     [cos(theta1) sin(theta1) cos(theta2) sin(theta2) thetaDot1 thetaDot2].
     For the first link, an angle of 0 corresponds to the link pointing downwards.
     The angle of the second link is relative to the angle of the first link.
     An angle of 0 corresponds to having the same angle between the two links.
-    A state of [1, 0, 1, 0, ..., ...] means that both links point downards.
+    A state of [1, 0, 1, 0, ..., ...] means that both links point downwards.
     **ACTIONS:**
     The action is either applying +1, 0 or -1 torque on the joint between
     the two pendulum links.

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -23,9 +23,13 @@ class AcrobotEnv(core.Env):
     Both links can swing freely and can pass by each other, i.e., they don't
     collide when they have the same angle.
     **STATE:**
-    The state consists of the two rotational joint angles and their velocities
-    [theta1 theta2 thetaDot1 thetaDot2]. An angle of 0 corresponds to corresponds
-    to the respective link pointing downwards (angles are in world coordinates).
+    The state consists of the sin() and cos() of the two rotational joint
+    angles and the joint velocities :
+    [cos(theta1) sin(theta1) cos(theta2) sin(theta2) thetaDot1 thetaDot2].
+    For the first link, an angle of 0 corresponds to the link pointing downwards.
+    The angle of the second link is relative to the angle of the first link.
+    An angle of 0 corresponds to having the same angle between the two links.
+    A state of [1, 0, 1, 0, ..., ...] means that both links point downards.
     **ACTIONS:**
     The action is either applying +1, 0 or -1 torque on the joint between
     the two pendulum links.


### PR DESCRIPTION
* The docstring of the Acrobot env advertises a 4-valued state when the observation returned is actually 6-valued.
* The docstring specifies that both angles are in world coordinates but the angle of the second link is relative to the angle of the first link

Both these mistakes are fixed in this PR.