### PR TITLE
Improve compatibility handling in reraise module

### DIFF
--- a/gym/utils/reraise.py
+++ b/gym/utils/reraise.py
@@ -1,5 +1,5 @@
 import sys
-from six import reraise as reraise_impl
+from six import reraise as reraise_impl, PY3
 
 def reraise(prefix=None, suffix=None):
     old_exc_type, old_exc_value, traceback = sys.exc_info()
@@ -7,8 +7,7 @@ def reraise(prefix=None, suffix=None):
         old_exc_value = old_exc_type()
 
     e = ReraisedException(old_exc_value, prefix, suffix)
-    is_py3 = sys.version_info[0] == 3
-    if is_py3:
+    if PY3:
         # Python 3 has exception chaining, which we don't want in this case.
         # Setting `__cause__` to None is equivalent to `from None` syntax
         # which will disable the chaining.

--- a/gym/utils/reraise_impl_py2.py
+++ b/gym/utils/reraise_impl_py2.py
@@ -1,2 +1,0 @@
-def reraise_impl(e, traceback):
-    raise e.__class__, e, traceback

--- a/gym/utils/reraise_impl_py3.py
+++ b/gym/utils/reraise_impl_py3.py
@@ -1,4 +1,0 @@
-# http://stackoverflow.com/a/33822606 -- `from None` disables Python 3'
-# semi-smart exception chaining, which we don't want in this case.
-def reraise_impl(e, traceback):
-    raise e.with_traceback(traceback) from None


### PR DESCRIPTION
`reraise.py` imports `reraise_impl` from two different files according to python version.
I think there is a better way to deal with the compatibility issue without using separated module.
This project already uses `six`.
`six.reraise` will handle a syntax difference between python 2 and 3 when we want to inject traceback to exception.
Also, setting `__cause__` to `None` in runtime will disable exception chaining in python 3.
There seems to be no existing testcases to test `reraise.py`.
Please review this change. If you guys think this change makes sense, I will add testcases.