### PR TITLE
Update the Reacher environment to ensure reachability

### DIFF
--- a/gym/envs/mujoco/reacher.py
+++ b/gym/envs/mujoco/reacher.py
@@ -24,7 +24,7 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         qpos = self.np_random.uniform(low=-0.1, high=0.1, size=self.model.nq) + self.init_qpos
         while True:
             self.goal = self.np_random.uniform(low=-.2, high=.2, size=2)
-            if np.linalg.norm(self.goal) < 2:
+            if np.linalg.norm(self.goal) < 0.2:
                 break
         qpos[-2:] = self.goal
         qvel = self.init_qvel + self.np_random.uniform(low=-.005, high=.005, size=self.model.nv)


### PR DESCRIPTION
In the Reacher-v1 codebase, when setting the goal location, there is a check to see if the distance to the origin is less than 2. However, I believe that this is a typo (2 meters away?), and should have been 0.2 instead. As stated, the current check does nothing (it's always true), and with this change, the environment ensures that the goal location be accessible by the reacher. 