### PR TITLE
Make sure env.spec always exists and is valid.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -262,6 +262,8 @@ We are using `pytest <http://doc.pytest.org>`_ for tests. You can run them via:
 What's new
 ==========
 
+- 2017-06-16: Make env.spec into a property to fix a bug that occurs
+  when you try to print out an unregistered Env.
 - 2017-05-13: BACKWARDS INCOMPATIBILITY: The Atari environments are now at
   *v4*. To keep using the old v3 environments, keep gym <= 0.8.2 and atari-py
   <= 0.0.21. Note that the v4 environments will not give identical results to

--- a/gym/core.py
+++ b/gym/core.py
@@ -51,6 +51,7 @@ class Env(object):
         env = super(Env, cls).__new__(cls)
         env._env_closer_id = env_closer.register(env)
         env._closed = False
+        env._spec = None
 
         # Will be automatically set when creating an environment via 'make'
         return env
@@ -75,10 +76,6 @@ class Env(object):
 
     # Do not override
     _owns_render = True
-
-    @property
-    def monitor(self):
-        raise error.Error("env.monitor has been deprecated as of 12/23/2016. Remove your call to `env.monitor.start(directory)` and instead wrap your env with `env = gym.wrappers.Monitor(env, directory)` to record data.")
 
     def step(self, action):
         """Run one timestep of the environment's dynamics. When end of
@@ -190,6 +187,10 @@ class Env(object):
         return self._seed(seed)
 
     @property
+    def spec(self):
+        return self._spec
+
+    @property
     def unwrapped(self):
         """Completely unwrap this env.
 
@@ -202,10 +203,10 @@ class Env(object):
         self.close()
 
     def __str__(self):
-        if self.spec is not None:
-            return '<{}<{}>>'.format(type(self).__name__, self.spec.id)
-        else:
+        if self.spec is None:
             return '<{} instance>'.format(type(self).__name__)
+        else:
+            return '<{}<{}>>'.format(type(self).__name__, self.spec.id)
 
     def configure(self, *args, **kwargs):
         raise error.Error("Env.configure has been removed in gym v0.8.0, released on 2017/03/05. If you need Env.configure, please use gym version 0.7.x from pip, or checkout the `gym:v0.7.4` tag from git.")

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -86,7 +86,7 @@ class EnvSpec(object):
         env = cls(**self._kwargs)
 
         # Make the enviroment aware of which spec it came from.
-        env.unwrapped.spec = self
+        env.unwrapped._spec = self
 
         return env
 


### PR DESCRIPTION
Previously there was an error when you tried to print out an unregistered env.