### PR TITLE
Action wrappers

### DIFF
--- a/gym/wrappers/__init__.py
+++ b/gym/wrappers/__init__.py
@@ -2,3 +2,4 @@ from gym import error
 from gym.wrappers.frame_skipping import SkipWrapper
 from gym.wrappers.monitoring import Monitor
 from gym.wrappers.time_limit import TimeLimit
+from gym.wrappers.action_wrappers import FlattenedActionWrapper, DiscretizedActionWrapper, RescaledActionWrapper

--- a/gym/wrappers/action_wrappers.py
+++ b/gym/wrappers/action_wrappers.py
@@ -1,0 +1,137 @@
+from gym import spaces, ActionWrapper
+import numpy as np
+import itertools
+import numbers
+
+def is_discrete(space):
+    # check if space is discrete
+    if isinstance(space, (spaces.Discrete, spaces.MultiDiscrete, spaces.MultiBinary)):
+        return True
+    elif isinstance(space, spaces.Box):
+        return False
+    raise TypeError("Unknown space {} supplied".format(type(space)))
+
+def is_compound(space):
+    if isinstance(space, spaces.Discrete):
+        return False
+    elif isinstance(space, spaces.Box):
+        return len(space.shape) != 1 or space.shape[0] != 1
+    elif isinstance(space, (spaces.MultiDiscrete, spaces.MultiBinary)):
+        return True
+
+    raise TypeError("Unknown space %r supplied"%type(space))
+
+
+# Discretization 
+def discretize(space, steps):
+    # there are two possible ways how we could handle already
+    # discrete spaces. 
+    #  1) throw an error because (unless
+    #     steps is configured to fit) we would try to convert 
+    #     an already discrete space to one with a different number
+    #     of states.
+    #  2) keep the space as is.
+    # here, we implement the second. This allows scripts that 
+    # train a discrete agent to just apply discretize, only 
+    # changing envs that are not already discrete.
+    if is_discrete(space):
+        return space, lambda x: x
+
+    # check that step number is valid and convert steps into a np array
+    if not isinstance(steps, numbers.Integral):
+        steps = np.array(steps, dtype=int)
+        if (steps < 2).any():
+            raise ValueError("Need at least two steps to discretize, got {}".format(steps))
+    elif steps < 2:
+        raise ValueError("Need at least two steps to discretize, got %i"%steps)
+
+    if isinstance(space, spaces.Box):
+        if len(space.shape) == 1 and space.shape[0] == 1:
+            discrete_space = spaces.Discrete(steps)
+            lo = space.low[0]
+            hi = space.high[0]
+            def convert(x):
+                return lo + (hi - lo) * float(x) / (steps-1)
+            return discrete_space, convert
+        else:
+            if isinstance(steps, numbers.Integral):
+                steps = np.full(space.low.shape, steps)
+            assert steps.shape == space.shape, "supplied steps have invalid shape"
+            starts = np.zeros_like(steps)
+            # MultiDiscrete is inclusive, thus we need steps-1 as last value
+            discrete_space = spaces.MultiDiscrete(zip(starts.flatten(), (steps-1).flatten()))
+            lo = space.low.flatten()
+            hi = space.high.flatten()
+            def convert(x):
+                return np.reshape(lo + (hi - lo) * x / (steps-1), space.shape)
+            return discrete_space, convert
+    raise ValueError()
+
+# Flattening
+def flatten(space):
+    # no need to do anything if already flat
+    if not is_compound(space):
+        return space, lambda x: x
+
+    if isinstance(space, spaces.Box):
+        shape = space.low.shape
+        lo = space.low.flatten()
+        hi = space.high.flatten()
+        def convert(x):
+            return np.reshape(x, shape)
+        return spaces.Box(low=lo, high=hi), convert
+
+    elif isinstance(space, (spaces.MultiDiscrete, spaces.MultiBinary)):
+        if isinstance(space, spaces.MultiDiscrete):
+            ranges = [range(space.low[i], space.high[i]+1, 1) for i in range(space.num_discrete_space)]
+        elif isinstance(space, spaces.MultiBinary):
+            ranges = [range(0, 2) for i in range(space.n)]
+        prod   = itertools.product(*ranges)
+        lookup = list(prod)
+        dspace = spaces.Discrete(len(lookup))
+        convert = lambda x: lookup[x]
+        return dspace, convert
+
+    raise TypeError("Cannot flatten {}".format(type(space)))
+
+
+# rescale a continuous action space
+def rescale(space, low, high):
+    if is_discrete(space):
+        raise TypeError("Cannot rescale discrete space {}".format(space))
+
+    if not isinstance(space, spaces.Box):
+        raise TypeError("Cannot rescale non-Box space {}".format(space))
+
+    lo = space.low
+    hi = space.high
+    rg = hi - lo
+    rs = high - low
+    sc = rg / rs
+    def convert(x):
+        y = (x - low) * sc # y is in [0, rg]
+        return y + space.low
+    return spaces.Box(low, high), convert
+
+
+###########################################################################
+class FlattenedActionWrapper(ActionWrapper):
+    def __init__(self, env):
+        super(FlattenedActionWrapper, self).__init__(env)
+        s, a = flatten(env.action_space)
+        self.action_space = s
+        self._action = a
+
+class DiscretizedActionWrapper(ActionWrapper):
+    def __init__(self, env, steps):
+        super(DiscretizedActionWrapper, self).__init__(env)
+        s, a = discretize(env.action_space, steps)
+        self.action_space = s
+        self._action = a
+
+class RescaledActionWrapper(ActionWrapper):
+    def __init__(self, env, low, high):
+        super(RescaledActionWrapper, self).__init__(env)
+        s, a = rescale(env.action_space, low=low, high=high)
+        self.action_space = s
+        self._action = a

--- a/gym/wrappers/action_wrappers.py
+++ b/gym/wrappers/action_wrappers.py
@@ -59,7 +59,9 @@ def discretize(space, steps):
             assert steps.shape == space.shape, "supplied steps have invalid shape"
             starts = np.zeros_like(steps)
             # MultiDiscrete is inclusive, thus we need steps-1 as last value
-            discrete_space = spaces.MultiDiscrete(zip(starts.flatten(), (steps-1).flatten()))
+            # currently, MultiDiscrete iterates twice over its input, which is not possible for a zip
+            # result in python 3
+            discrete_space = spaces.MultiDiscrete(list(zip(starts.flatten(), (steps-1).flatten())))
             lo = space.low.flatten()
             hi = space.high.flatten()
             def convert(x):

--- a/gym/wrappers/tests/test_action_wrappers.py
+++ b/gym/wrappers/tests/test_action_wrappers.py
@@ -1,0 +1,158 @@
+import gym
+from gym import error
+from gym.wrappers import action_wrappers as awrap
+from gym import spaces
+import numpy as np
+import itertools
+
+# discretize
+
+def test_discretize_1d_box():
+    cont = spaces.Box(np.array([0.0]), np.array([1.0]))
+    disc, f = awrap.discretize(cont, 10)
+
+    assert disc == spaces.Discrete(10)
+    assert f(0) == 0.0
+    assert f(9) == 1.0
+
+def test_discretize_discrete():
+    start = spaces.Discrete(5)
+    d, f = awrap.discretize(start, 10)
+    assert d == start
+
+def test_discretize_nd_box():
+    cont = spaces.Box(np.array([0.0, 1.0]), np.array([1.0, 2.0]))
+    disc, f = awrap.discretize(cont, 10)
+
+    assert disc == spaces.MultiDiscrete([(0, 9), (0, 9)])
+    assert (f((0, 0)) == [0.0, 1.0]).all()
+    assert (f((9, 9)) == [1.0, 2.0]).all()
+
+    disc, f = awrap.discretize(cont, (5, 10))
+
+    assert disc == spaces.MultiDiscrete([(0, 4), (0, 9)])
+    assert (f((0, 0)) == [0.0, 1.0]).all()
+    assert (f((4, 9)) == [1.0, 2.0]).all()
+
+# flatten
+def test_flatten_single():
+    start = spaces.Discrete(5)
+    d, f = awrap.flatten(start)
+    assert d == start
+
+    start = spaces.Box(np.array([0.0]), np.array([1.0]))
+    d, f = awrap.flatten(start)
+    assert d == start
+
+def test_flatten_discrete():
+    md = spaces.MultiDiscrete([(0, 2), (0, 3)])
+    d, f = awrap.flatten(md)
+
+    assert d == spaces.Discrete(12)
+    # check that we get all actions exactly once
+    actions = []
+    for (i, j) in itertools.product([0, 1, 2], [0, 1, 2, 3]):
+        actions += [(i, j)]
+    for i in range(0, 12):
+        a = f(i)
+        assert a in actions
+        actions = filter(lambda x: x != a, actions)
+    assert len(actions) == 0
+
+    # same test for binary
+    md = spaces.MultiBinary(3)
+    d, f = awrap.flatten(md)
+
+    assert d == spaces.Discrete(2**3)
+    # check that we get all actions exactly once
+    actions = []
+    for (i, j, k) in itertools.product([0, 1], [0, 1], [0, 1]):
+        actions += [(i, j, k)]
+    for i in range(0, 8):
+        a = f(i)
+        assert a in actions
+        actions = filter(lambda x: x != a, actions)
+    assert len(actions) == 0
+
+def test_flatten_continuous():
+    ct = spaces.Box(np.zeros((2,2)), np.ones((2, 2)))
+    d, f = awrap.flatten(ct)
+
+    assert d == spaces.Box(np.zeros(4), np.ones(4))
+    assert (f([1, 2, 3, 4]) == [[1, 2], [3, 4]]).all()
+
+# rescale
+def test_rescale_discrete():
+    for s in [spaces.Discrete(10), spaces.MultiDiscrete([(0, 2), (0, 3)]), spaces.MultiBinary(5)]:
+        try:
+            awrap.rescale(s, 1.0)
+            assert False 
+        except TypeError: pass
+
+def test_rescale_box():
+    s = spaces.Box(np.array([0.0, 1.0]), np.array([1.0, 2.0]))
+    d, f = awrap.rescale(s, np.array([1.0, 0.0]), np.array([2.0, 1.0]))
+
+    assert d == spaces.Box(np.array([1.0, 0.0]), np.array([2.0, 1.0]))
+    assert (f([1.0, 0.0]) == [0.0, 1.0]).all()
+    assert (f([2.0, 1.0]) == [1.0, 2.0]).all()
+
+
+
+# wrappers
+class ExpectEnv(gym.Env):
+    def __init__(self):
+        super(ExpectEnv, self).__init__()
+
+    def _step(self, action):
+        assert action == self.expectation, "{} != {}".format(action, self.expectation)
+
+def test_discretized_wrapper():
+    gym.envs.register(id='ExpectTest-v0',
+        entry_point='test_action_wrappers:ExpectEnv'
+    )
+    expect = gym.make("ExpectTest-v0")
+    cont = spaces.Box(np.array([0.0]), np.array([1.0]))
+    expect.action_space = cont
+    expect.expectation  = 0.5
+    wrapper = awrap.DiscretizedActionWrapper(expect, 3)
+    wrapper.step(1)
+
+def test_flattened_wrapper():
+    gym.envs.register(id='ExpectTest-v1',
+        entry_point='test_action_wrappers:ExpectEnv'
+    )
+    expect = gym.make("ExpectTest-v1")
+    md = spaces.MultiDiscrete([(0, 1), (0, 1)])
+    expect.action_space = md
+    expect.expectation  = (1, 1)
+    wrapper = awrap.FlattenedActionWrapper(expect)
+    wrapper.step(3)
+
+def test_rescaled_wrapper():
+    gym.envs.register(id='ExpectTest-v2',
+        entry_point='test_action_wrappers:ExpectEnv'
+    )
+    expect = gym.make("ExpectTest-v2")
+    bx = spaces.Box(np.array([0.0]), np.array([1.0]))
+    expect.action_space = bx
+    expect.expectation  = 0.5
+    wrapper = awrap.RescaledActionWrapper(expect, np.array([1.0]), np.array([2.0]))
+    wrapper.step(1.5)
+
+
+if __name__ == '__main__':
+    test_discretize_1d_box()
+    test_discretize_discrete()
+    test_discretize_nd_box()
+
+    test_flatten_single()
+    test_flatten_discrete()
+    test_flatten_continuous()
+
+    test_rescale_discrete()
+    test_rescale_box()
+
+    test_discretized_wrapper()
+    test_flattened_wrapper()
+    test_rescaled_wrapper()

--- a/gym/wrappers/tests/test_action_wrappers.py
+++ b/gym/wrappers/tests/test_action_wrappers.py
@@ -109,7 +109,7 @@ class ExpectEnv(gym.Env):
 
 def test_discretized_wrapper():
     gym.envs.register(id='ExpectTest-v0',
-        entry_point='test_action_wrappers:ExpectEnv'
+        entry_point='gym.wrappers.tests.test_action_wrappers:ExpectEnv'
     )
     expect = gym.make("ExpectTest-v0")
     cont = spaces.Box(np.array([0.0]), np.array([1.0]))
@@ -120,7 +120,7 @@ def test_discretized_wrapper():
 
 def test_flattened_wrapper():
     gym.envs.register(id='ExpectTest-v1',
-        entry_point='test_action_wrappers:ExpectEnv'
+        entry_point='gym.wrappers.tests.test_action_wrappers:ExpectEnv'
     )
     expect = gym.make("ExpectTest-v1")
     md = spaces.MultiDiscrete([(0, 1), (0, 1)])
@@ -131,7 +131,7 @@ def test_flattened_wrapper():
 
 def test_rescaled_wrapper():
     gym.envs.register(id='ExpectTest-v2',
-        entry_point='test_action_wrappers:ExpectEnv'
+        entry_point='gym.wrappers.tests.test_action_wrappers:ExpectEnv'
     )
     expect = gym.make("ExpectTest-v2")
     bx = spaces.Box(np.array([0.0]), np.array([1.0]))

--- a/gym/wrappers/tests/test_action_wrappers.py
+++ b/gym/wrappers/tests/test_action_wrappers.py
@@ -55,8 +55,8 @@ def test_flatten_discrete():
         actions += [(i, j)]
     for i in range(0, 12):
         a = f(i)
-        assert a in actions
-        actions = filter(lambda x: x != a, actions)
+        assert a in actions, (a, actions)
+        actions = list(filter(lambda x: x != a, list(actions)))
     assert len(actions) == 0
 
     # same test for binary
@@ -70,8 +70,8 @@ def test_flatten_discrete():
         actions += [(i, j, k)]
     for i in range(0, 8):
         a = f(i)
-        assert a in actions
-        actions = filter(lambda x: x != a, actions)
+        assert a in actions, (a, actions)
+        actions = list(filter(lambda x: x != a, actions))
     assert len(actions) == 0
 
 def test_flatten_continuous():


### PR DESCRIPTION
Thre wrappers that change the apparent action space used by an env. With this it is possible to train an agent that is designed for single discrete actions on multi-discrete or even continuous envs. For the latter it is also possible to rescale the actions, e.g. to always assume actions in the range [0, 1] for the agent.

What is currently not implemented is interpreting a discrete space as continuous, any transformations of TupleSpace and the reverse_action method. If there is interest in any of that I can implement it, at least to a degree to which it is sensible (e.g. flattening a tuple space with continuous and discrete subspaces does not make sense).  