### PR TITLE
MAME support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,6 +209,21 @@ These are a variety of classic control tasks, which would appear in a typical re
 	  env.reset()
 	  env.render()
 
+MAME
+-----
+
+The MAME environments are a variety of arcade games. You can install dependencies via ``pip install -e '.[mame]'``. You'll need to have GL include files and the SDL-ttf library and development files installed (You'll need to have GL include files and the SDL-ttf library and development files installed. ``mesa-common-dev`` and ``libsdl2-ttf-dev`` under Debian-based distributions). Some example code:
+
+.. code:: python
+
+      import gym
+      env = gym.make('MameGalaxian-v0')
+      env.reset()
+      env.render()
+
+This will install `mamele <https://github.com/alito/mamele_pippable>`_, a wrapper around a modified `MAME <http://mamedev.org/>`_. This will compile MAME, which takes a couple of hours in most machines.  ROMs must be installed separately under your ~/.le/roms directory. Some ROMs can be legally downloaded from the `MAMEDev ROMs page <http://mamedev.org/roms/>`_.
+
+
 MuJoCo
 ------
 
@@ -236,6 +251,8 @@ Toy environments which are text-based. There's no extra dependency to install, s
 	  env = gym.make('FrozenLake-v0')
 	  env.reset()
 	  env.render()
+
+
 
 Examples
 ========

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -507,3 +507,20 @@ register(
     entry_point='gym.envs.safety:OffSwitchCartpoleProbEnv',
     max_episode_steps=200,
 )
+
+# Mame games
+for game_name in 'galaxian circus sidetrac ripcord crash'.split():
+    register(
+        id='Mame%s-v0' % game_name.capitalize(),
+        entry_point='gym.envs.mame:MAMEEnv',
+        kwargs={'game': game_name, 'frameskip': 1},
+        max_episode_steps=100000,
+    )
+
+    register(
+        id='Mame%s-watch-v0' % game_name.capitalize(),
+        entry_point='gym.envs.mame:MAMEEnv',
+        kwargs={'game': game_name, 'frameskip': 1, 'watch' : True},
+        max_episode_steps=100000,
+    )
+

--- a/gym/envs/mame/__init__.py
+++ b/gym/envs/mame/__init__.py
@@ -1,0 +1,1 @@
+from gym.envs.mame.mame_env import MAMEEnv

--- a/gym/envs/mame/mame_env.py
+++ b/gym/envs/mame/mame_env.py
@@ -1,0 +1,122 @@
+"""
+MAME interface, based on atari_env
+"""
+
+import logging
+logger = logging.getLogger(__name__)
+
+import gym
+from gym import error
+from gym.spaces import Box, MultiDiscrete
+from gym import utils
+from gym.utils import seeding
+
+
+try:
+    import mamele
+except ImportError as e:
+    raise error.DependencyNotInstalled("{}. (HINT: you can install MAME dependencies by running 'pip install mamele')".format(e))
+
+class MAMEEnv(gym.Env, utils.EzPickle):
+    metadata = {'render.modes': ['human', 'rgb_array']}
+
+
+    def __init__(self, game='galaxian', frameskip=(2, 5), watch=False):
+        """Frameskip should be either a tuple (indicating a random range to
+        choose from, with the top value exclude), or an int.
+
+        If watch is True, we leave the video and sound on, and throttle to run realtime"""
+
+        utils.EzPickle.__init__(self, game=game, frameskip=frameskip)
+
+        self.frameskip = frameskip
+        self.viewer = None
+        self.previous_score = self.score = 0
+        self.watch = watch
+
+        self.mame = mamele.Mamele(game_name=game, watch=watch)
+
+        self._seed()
+
+        self.action_set = self.mame.get_minimal_action_set()
+        self.initialise_action_space(self.action_set)
+
+        screen_width, screen_height = self.mame.get_screen_dimensions()
+        self._initialise_screen(screen_width, screen_height)
+
+
+    def _initialise_screen(self, width, height):
+        self.width = width
+        self.height = height
+        self.observation_space = Box(low=0, high=255, shape=(self.height, self.width, 3))
+
+
+
+    def initialise_action_space(self, action_spaces):
+
+        # The description is a set of spaces, with the possible states for each of the spaces
+        # eg [('vertical', ['noop', 'up', 'bottom']), ('coin1', ['noop', 'coin1']), ...]
+
+        # We are meant to send back the state of each space as an action
+        self.action_space = MultiDiscrete([[0, len(action_space[1])-1] for action_space in action_spaces])
+
+
+    def _seed(self, seed=None):
+        self.np_random, seed1 = seeding.np_random(seed)
+        # Derive a random seed. This gets passed as a uint, but gets
+        # checked as an int elsewhere, so we need to keep it below
+        # 2**31.
+        seed2 = seeding.hash_seed(seed1 + 1) % 2**31
+        return [seed1, seed2]
+
+
+    def _step(self, action):
+        
+        mapped_action = [space[1][index] for index, space in zip(action, self.action_set)]
+
+        if isinstance(self.frameskip, int):
+            steps = self.frameskip
+        else:
+            steps = self.np_random.randint(self.frameskip[0], self.frameskip[1])
+
+
+        reward = 0.0
+        for _ in range(steps):
+            reward += self.mame.act(mapped_action)
+
+        return self._get_obs(), reward, self.mame.is_game_over(), {}
+        
+
+    @property
+    def _n_actions(self):
+        total = 1
+        for subspace in self.action_set:
+            total *= len(subspace[1])
+        return total
+
+    def _get_obs(self):    
+        return self.mame.get_screen_rgb()
+
+    # return: (states, observations)
+    def _reset(self):
+        self.mame.restart_game()
+        return self._get_obs()
+
+    def _render(self, mode='human', close=False):
+        if close:
+            if self.viewer is not None:
+                self.viewer.close()
+                self.viewer = None
+            return
+        return self._get_obs()
+
+
+
+    # def save_state(self):
+
+    # def load_state(self):
+
+    # def clone_state(self):
+
+    # def restore_state(self, state):
+

--- a/gym/envs/tests/spec_list.py
+++ b/gym/envs/tests/spec_list.py
@@ -17,6 +17,7 @@ def should_skip_env_spec_for_tests(spec):
             ep.startswith('gym.envs.box2d:') or
             ep.startswith('gym.envs.parameter_tuning:') or
             ep.startswith('gym.envs.safety:Semisuper') or
+            ep == 'gym.envs.mame:MAMEEnv' or
             (ep.startswith("gym.envs.atari") and not spec.id.startswith("Pong") and not spec.id.startswith("Seaquest"))
     ):
         logger.warning("Skipping tests for env {}".format(ep))

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ extras = {
   'classic_control': ['PyOpenGL'],
   'mujoco': ['mujoco_py<1.0.0,>=0.4.3', 'imageio'],
   'parameter_tuning': ['keras', 'theano'],
+  'mame' : ['mamele']
 }
 
 # Meta dependency groups.


### PR DESCRIPTION
This adds support for mamele, which is a wrapper around the MAME emulator. At the moment only 5 games are supported, but more should come online soonish.

The name of the currently implemented environments are:

MameGalaxian-v0
MameCircus-v0
MameSidetrac-v0
MameRipcord-v0
MameCrash-v0

and their corresponding -watch- versions (eg MameGalaxian-watch-v0), which leave the screen and sound on and run at normal speed.

The last four ROMs can be legally downloaded from http://mamedev.org/roms/

There are some gross inefficiencies in the way that the frame data is transferred between MAME and gym, and some minor issues when running (eg the MAME windows remains onscreen, even though it doesn't get updated). It is also Python2 only for now (the code has very old roots). The installation is slow, since it compiles MAME, but shouldn't be too fragile.

The code from https://github.com/alito/deep_q_rl successfully trains on (at least) the circus environment, although not successfully on Galaxian for now (Arcade Galaxian is a tricky environment)