### PR TITLE
Add grayscale support to AtariEnv

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -115,6 +115,8 @@ class Env(object):
         - rgb_array: Return an numpy.ndarray with shape (x, y, 3),
           representing RGB values for an x-by-y pixel image, suitable
           for turning into a video.
+        - grayscale_array: Return an numpy.ndarray with shape (x, y, 1),
+          representing luminance values for an x-by-y pixel image. (AtariEnv only)
         - ansi: Return a string (str) or StringIO.StringIO containing a
           terminal-style text representation. The text can include newlines
           and ANSI escape sequences (e.g. for colors).

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -304,11 +304,15 @@ for game in ['air_raid', 'alien', 'amidar', 'assault', 'asterix', 'asteroids', '
     'private_eye', 'qbert', 'riverraid', 'road_runner', 'robotank', 'seaquest', 'skiing',
     'solaris', 'space_invaders', 'star_gunner', 'tennis', 'time_pilot', 'tutankham', 'up_n_down',
     'venture', 'video_pinball', 'wizard_of_wor', 'yars_revenge', 'zaxxon']:
-    for obs_type in ['image', 'ram']:
+    for obs_type in ['image', 'ram', 'grayscale_image']:
         # space_invaders should yield SpaceInvaders-v0 and SpaceInvaders-ram-v0
         name = ''.join([g.capitalize() for g in game.split('_')])
         if obs_type == 'ram':
             name = '{}-ram'.format(name)
+        elif obs_type == 'grayscale_image':
+            # register grayscale ?
+            continue
+            # name = '{}-grayscale'.format(name)
 
         nondeterministic = False
         if game == 'elevator_action' and obs_type == 'ram':

--- a/gym/envs/tests/test_envs.py
+++ b/gym/envs/tests/test_envs.py
@@ -61,3 +61,11 @@ def test_double_close():
     assert env.close_count == 1
     env.close()
     assert env.close_count == 1
+
+def test_grayscale():
+    env = envs.make('Pong-v0')
+    env.env._obs_type = 'grayscale_image'
+    ob = env.reset()
+    assert ob.shape == (210, 160, 1)
+    ob = env.render('grayscale_array')
+    assert ob.shape == (210, 160, 1)


### PR DESCRIPTION
ALE has getScreenGrayscale() interface for grayscale rendering, but many DQN based algorithms extracts Y' channel from RGB data since gym only supports RGB rendering output. I added grayscale rendering support for the algorithms.

Try this:

```python
import gym
import matplotlib.pyplot as plt
env = gym.make('Breakout-v0')
x = env.render('grayscale_array')
plt.imshow(x[...,0], cmap='gray')
plt.show()
```