### PR TITLE
Support for Env.__init__() parameters overridding

### DIFF
--- a/gym/envs/tests/test_envs.py
+++ b/gym/envs/tests/test_envs.py
@@ -61,3 +61,7 @@ def test_double_close():
     assert env.close_count == 1
     env.close()
     assert env.close_count == 1
+
+def test_override():
+    env = envs.make('Pong-v0', frameskip=0)
+    assert env.env.frameskip == 0


### PR DESCRIPTION
```python
env = gym.make('Pong-v0', frameskip=0)
```

Above code will generate Pong-v0 with frameskip=0. Sometimes I wanted to change the spec of the environment for my study, so added support for the parameter overriding.