### PR TITLE
fixed and added missing __eq__ for spaces

### DIFF
--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -41,4 +41,5 @@ class Box(gym.Space):
     def __repr__(self):
         return "Box" + str(self.shape)
     def __eq__(self, other):
-        return np.allclose(self.low, other.low) and np.allclose(self.high, other.high)
+        return np.allclose(self.low, other.low) and np.allclose(self.high, other.high) and\
+               isinstance(other, Box)

--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -25,4 +25,4 @@ class Discrete(gym.Space):
     def __repr__(self):
         return "Discrete(%d)" % self.n
     def __eq__(self, other):
-        return self.n == other.n
+        return self.n == other.n and isinstance(other, Discrete)

--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -13,3 +13,5 @@ class MultiBinary(gym.Space):
         return sample_n.tolist()
     def from_jsonable(self, sample_n):
         return np.array(sample_n)
+    def __eq__(self, other):
+        return self.n == other.n and isinstance(other, MultiBinary)

--- a/gym/spaces/multi_discrete.py
+++ b/gym/spaces/multi_discrete.py
@@ -44,4 +44,5 @@ class MultiDiscrete(gym.Space):
     def __repr__(self):
         return "MultiDiscrete" + str(self.num_discrete_space)
     def __eq__(self, other):
-        return np.array_equal(self.low, other.low) and np.array_equal(self.high, other.high)
+        return isinstance(other, MultiDiscrete) and np.array_equal(self.low, other.low) and \
+                                                    np.array_equal(self.high, other.high)

--- a/gym/spaces/tests/test_spaces.py
+++ b/gym/spaces/tests/test_spaces.py
@@ -1,7 +1,7 @@
 import json # note: ujson fails this test due to float equality
 import numpy as np
 import pytest
-from gym.spaces import Tuple, Box, Discrete, MultiDiscrete
+from gym.spaces import Tuple, Box, Discrete, MultiDiscrete, MultiBinary
 
 
 @pytest.mark.parametrize("space", [
@@ -29,3 +29,31 @@ def test_roundtripping(space):
     s2p = space.to_jsonable([sample_2_prime])
     assert s1 == s1p, "Expected {} to equal {}".format(s1, s1p)
     assert s2 == s2p, "Expected {} to equal {}".format(s2, s2p)
+
+def test_space_eq():
+  # Tuple Spaces
+  ts1 = Tuple((Discrete(5), Discrete(8)))
+  ts2 = Tuple([Discrete(5), Discrete(8)])
+  ts3 = Tuple((Discrete(6), Discrete(8)))
+
+  assert ts1 == ts2
+  assert not (ts1 == ts3)
+
+  # Discrete spaces
+  ds1 = Discrete(5)
+  mb1 = MultiBinary(5)
+  ds2 = Discrete(5)
+  mb2 = MultiBinary(5)
+  assert not (ds1 == mb1)
+  assert not (mb1 == ds1)
+  assert ds1 == ds2
+  assert mb1 == mb2
+
+  md1 = MultiDiscrete(np.array([[0, 2], [0, 2]]))
+  bs1 = Box(np.array([0, 0]), np.array([2, 2]))
+  md2 = MultiDiscrete(np.array([[0, 2], [0, 2]]))
+  bs2 = Box(np.array([0, 0]), np.array([2, 2]))
+  assert not (md1 == bs1)
+  assert not (bs1 == md1)
+  assert md1 == md2
+  assert bs1 == bs2

--- a/gym/spaces/tuple_space.py
+++ b/gym/spaces/tuple_space.py
@@ -8,7 +8,7 @@ class Tuple(Space):
     self.observation_space = spaces.Tuple((spaces.Discrete(2), spaces.Discrete(3)))
     """
     def __init__(self, spaces):
-        self.spaces = spaces
+        self.spaces = tuple(spaces)
 
     def sample(self):
         return tuple([space.sample() for space in self.spaces])
@@ -21,6 +21,8 @@ class Tuple(Space):
 
     def __repr__(self):
         return "Tuple(" + ", ". join([str(s) for s in self.spaces]) + ")"
+    def __eq__(self, other):
+        return self.spaces == other.spaces
 
     def to_jsonable(self, sample_n):
         # serialize as list-repr of tuple of vectors


### PR DESCRIPTION
This PR adds `__eq__` to the spaces that do not have this operator yet, and fixes the old equality operator that could not distinguish some spaces (i.e. Discrete and MultiBinary with the same n).