### PR TITLE
New text games group and two text-based games

### DIFF
--- a/examples/agents/random_agent.py
+++ b/examples/agents/random_agent.py
@@ -51,6 +51,11 @@ if __name__ == '__main__':
     for i in range(episode_count):
         ob = env.reset()
         while True:
+
+            # handle dynamic action spaces (has no effect if the action space is static):
+            if agent.action_space != env.env.action_space:
+                agent.action_space = env.env.action_space
+
             action = agent.act(ob, reward, done)
             ob, reward, done, _ = env.step(action)
             if done:

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -128,6 +128,19 @@ register(
     reward_threshold=900,
 )
 
+# Text games
+# ----------------------------------------
+
+register(
+    id='SavingJohn-v0',
+    entry_point='gym.envs.text_games:SavingJohnEnv',
+)
+
+register(
+    id='MachineOfDeath-v0',
+    entry_point='gym.envs.text_games:MachineOfDeathEnv',
+)
+
 # Toy Text
 # ----------------------------------------
 

--- a/gym/envs/tests/spec_list.py
+++ b/gym/envs/tests/spec_list.py
@@ -17,6 +17,7 @@ def should_skip_env_spec_for_tests(spec):
             ep.startswith('gym.envs.box2d:') or
             ep.startswith('gym.envs.parameter_tuning:') or
             ep.startswith('gym.envs.safety:Semisuper') or
+            ep.startswith('gym.envs.text_games') or
             (ep.startswith("gym.envs.atari") and not spec.id.startswith("Pong") and not spec.id.startswith("Seaquest"))
     ):
         logger.warning("Skipping tests for env {}".format(ep))

--- a/gym/envs/text_games/__init__.py
+++ b/gym/envs/text_games/__init__.py
@@ -1,0 +1,2 @@
+from gym.envs.text_games.saving_john import SavingJohnEnv
+from gym.envs.text_games.machine_of_death import MachineOfDeathEnv

--- a/gym/envs/text_games/machine_of_death.py
+++ b/gym/envs/text_games/machine_of_death.py
@@ -1,0 +1,53 @@
+from pyfiction.simulators.games.machineofdeath_simulator import MachineOfDeathSimulator
+
+import gym
+from gym import spaces
+from gym.utils import seeding
+
+
+class MachineOfDeathEnv(gym.Env):
+    """Machine of Death text game environment
+    There are 3 game branches and more than 14 different endings with different rewards;
+     the optimal cumulative rewards in the three game branches are close to 17.4, 18.5 and 28.5
+
+    Available to play online at:
+     http://ifarchive.giga.or.at/if-archive/games/competition2013/web/machineofdeath/MachineOfDeath.html
+
+    The returned observation is a tuple (state, actions), where state is the complete state descriptions
+     and actions is a list of action substrings sorted by their index (0..len(actions)-1).
+    """
+
+    def __init__(self):
+        # number of actions is variable:
+        self.action_space = spaces.Discrete(0)
+
+        # observation space is unbounded:
+        self.observation_space = spaces.Discrete(0)
+
+        self.reward_range = (-30, 30)
+
+        self._seed()
+        self.simulator = MachineOfDeathSimulator()
+
+    def _seed(self, seed=None):
+        self.np_random, seed = seeding.np_random(seed)
+        return [seed]
+
+    def _step(self, action):
+        assert self.action_space.contains(action)
+
+        self.simulator.write(action)
+        state, actions, reward = self.simulator.read()
+
+        self.action_space = spaces.Discrete(len(actions))
+
+        return (state, actions), reward, bool(actions), {}
+
+    def _reset(self):
+        self.simulator.restart()
+
+        state, actions, _ = self.simulator.read()
+
+        self.action_space = spaces.Discrete(len(actions))
+
+        return state, actions

--- a/gym/envs/text_games/saving_john.py
+++ b/gym/envs/text_games/saving_john.py
@@ -1,0 +1,60 @@
+from pyfiction.simulators.games.savingjohn_simulator import SavingJohnSimulator
+# Import this when using this env (!): from pyfiction.simulators.text_games.simulators.MySimulator import StoryNode
+
+import gym
+from gym import spaces
+from gym.utils import seeding
+
+
+class SavingJohnEnv(gym.Env):
+    """Saving John text game environment
+    There are 5 different endings with different rewards;
+     the optimal cumulative reward is 19.4.
+
+    Available to play online at:
+     http://www.ifarchive.org/if-archive/games/competition2013/web/savingjohn/Saving%20John.html
+
+    The returned observation is a tuple (state, actions), where state is the complete state descriptions
+     and actions is a list of action substrings sorted by their index (0..len(actions)-1).
+    """
+
+    def __init__(self):
+        # number of actions is variable:
+        self.action_space = spaces.Discrete(0)
+
+        # observation space is unbounded:
+        self.observation_space = spaces.Discrete(0)
+
+        self.reward_range = (-20, 20)
+
+        self._seed()
+
+        try:
+            self.simulator = SavingJohnSimulator()
+        except AttributeError as e:
+            print('AttributeError: ' + str(e) + '\nTo fix the StoryNode attribute error, please import:\n' +
+                  '  from pyfiction.simulators.text_games.simulators.MySimulator import StoryNode\n' +
+                  'when calling the Saving John simulator.')
+
+    def _seed(self, seed=None):
+        self.np_random, seed = seeding.np_random(seed)
+        return [seed]
+
+    def _step(self, action):
+        assert self.action_space.contains(action)
+
+        self.simulator.write(action)
+        state, actions, reward = self.simulator.read()
+
+        self.action_space = spaces.Discrete(len(actions))
+
+        return (state, actions), reward, bool(actions), {}
+
+    def _reset(self):
+        self.simulator.restart()
+
+        state, actions, _ = self.simulator.read()
+
+        self.action_space = spaces.Discrete(len(actions))
+
+        return state, actions

--- a/gym/scoreboard/__init__.py
+++ b/gym/scoreboard/__init__.py
@@ -67,6 +67,12 @@ add_group(
 )
 
 add_group(
+    id='text_games',
+    name='Text games',
+    description='Various text-based games (interactive fiction) provided by the pyfiction library.'
+)
+
+add_group(
     id='toy_text',
     name='Toy text',
     description='Simple text environments to get you started.'
@@ -568,6 +574,24 @@ normalized by the number of labels in a dataset.
 This environment requires Keras with Theano or TensorFlow to run. When run on laptop
 gpu (GTX960M) one step takes on average 2 min.
 """,
+)
+
+# text games
+
+add_task(
+    id='SavingJohn-v0',
+    group='text_games',
+    experimental=True,
+    contributor='MikulasZelinka',
+    summary="The 'Saving John' text game by Josephine Tsay.",
+)
+
+add_task(
+    id='MachineOfDeath-v0',
+    group='text_games',
+    experimental=True,
+    contributor='MikulasZelinka',
+    summary="The 'Machine of Death' text game by Hulk Handsome.",
 )
 
 # toy text

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ extras = {
   'classic_control': ['PyOpenGL'],
   'mujoco': ['mujoco_py<1.0.0,>=0.4.3', 'imageio'],
   'parameter_tuning': ['keras', 'theano'],
+  'text_games': ['pyfiction'],
 }
 
 # Meta dependency groups.


### PR DESCRIPTION
Hello, I added a group for text-based games (interactive fiction) and two sample text games, Saving John and Machine of Death.

These two sample games are available in the [pyfiction](https://github.com/MikulasZelinka/pyfiction) library that supports different games which I plan to add to gym once some basic problems are resolved.

My questions are:

1. How to handle variable action space and unbounded observation space? See the pull request code for my approach (always checking for the dynamic environment action space). Is this approach valid?

2. Is it necessary that all environments support Python 2.7? The pyfiction games, for example, are only tested in Python 3.5 and 3.6.

Thank you :)