### PR TITLE
Recover from KeyError in utils/play.py

### DIFF
--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -115,11 +115,15 @@ def play(env, transpose=True, fps=30, zoom=None, callback=None, keys_to_action=N
             env_done = False
             obs = env.reset()
         else:
-            action = keys_to_action[tuple(sorted(pressed_keys))]
-            prev_obs = obs
-            obs, rew, env_done, info = env.step(action)
-            if callback is not None:
-                callback(prev_obs, obs, action, rew, env_done, info)
+            try:
+                action = keys_to_action[tuple(sorted(pressed_keys))]
+                prev_obs = obs
+                obs, rew, env_done, info = env.step(action)
+                if callback is not None:
+                    callback(prev_obs, obs, action, rew, env_done, info)
+            except KeyError as e:
+                print("WARNING: ignoring illegal action '{}'.".format(e))
+
         if obs is not None:
             if len(obs.shape) == 2:
                 obs = obs[:, :, None]


### PR DESCRIPTION
When playing with the Atari Gym environments as a human, Gym will crash if invalid keypresses are passed. Generally this happens when you press 3+ buttons simultaneously.
```
~/git/gym(master ✗) python gym/utils/play.py
[2017-08-06 13:32:31,407] Making new env: MontezumaRevengeNoFrameskip-v0
Traceback (most recent call last):
  File "gym/utils/play.py", line 186, in <module>
    play(env, zoom=4, fps=60)
  File "gym/utils/play.py", line 118, in play
    action = keys_to_action[tuple(sorted(pressed_keys))]
KeyError: (32, 97, 100)
```
The KeyError issue happens somewhat regularly for me in the `MontezumaRevenge` env. This PR adds an exception handler to the `/gym/utils/play.py` loop, causing the environment to skip the key input if the key input is invalid. Instead you will see a log message:

<img width="388" alt="screen shot 2017-08-06 at 5 57 37 pm" src="https://user-images.githubusercontent.com/1892071/29008795-80423eec-7ad1-11e7-8ca8-6baf0b48f5b7.png">
