### PR TITLE
Fixed import error message for pachi-py.

### DIFF
--- a/gym/envs/board_game/go.py
+++ b/gym/envs/board_game/go.py
@@ -3,7 +3,7 @@ try:
     import pachi_py
 except ImportError as e:
     # The dependency group [pachi] should match the name is setup.py.
-    raise error.DependencyNotInstalled('{}. (HINT: you may need to install the Go dependencies via "pip install gym[pachi]".)'.format(e))
+    raise error.DependencyNotInstalled('{}. (HINT: you may need to install the Go dependencies via "pip install gym[board_game]".)'.format(e))
 
 import numpy as np
 import gym


### PR DESCRIPTION
The import error message for pachi-py suggested a fix which was not correct.

It should be pip install gym[board_game] instead.