### PR TITLE
Add automatic discovery of envs defined in custom packages (plugins)

### DIFF
--- a/gym/envs/README.md
+++ b/gym/envs/README.md
@@ -37,7 +37,7 @@ ant.AntEnv
         foo_env.py
         foo_extrahard_env.py
   ```
-  Note: Ensure that your top level package name is of the format `gym_<yourname>`, otherwise **it won't automatically be imported by gym**.
+  Note: Ensure that your top level package name is of the format `gym_<yourname>`, otherwise **your new envs won't automatically be imported by gym**.
 
 
 * `gym-foo/setup.py` should have:

--- a/gym/envs/README.md
+++ b/gym/envs/README.md
@@ -37,6 +37,8 @@ ant.AntEnv
         foo_env.py
         foo_extrahard_env.py
   ```
+  Note: Ensure that your top level package name is of the format `gym_<yourname>`, otherwise **it won't automatically be imported by gym**.
+
 
 * `gym-foo/setup.py` should have:
 

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -3,6 +3,8 @@ import pkg_resources
 import re
 from gym import error
 import warnings
+import importlib
+import pkgutil
 
 logger = logging.getLogger(__name__)
 # This format is true today, but it's *not* an official spec.
@@ -162,3 +164,9 @@ def make(id):
 
 def spec(id):
     return registry.spec(id)
+
+
+# Import plugins modules
+for _, module, _ in pkgutil.iter_modules():
+    if module.startswith("gym_"):
+        importlib.import_module(module)


### PR DESCRIPTION
This PR adds plugin support to gym envs.

Currently, packages that add additional plugins require to be manually imported in order to be registered. 
For example, if we have a `gym_custom` package, providing the `custom_env`, we should do:
```
import gym 
import gym_custom

env = gym.make("Custom-v0")
```

With this PR, discovery of plugin packages is automatic during the `gym import`:
```
import gym

env = gym.make("Custom-v0")
```
This is working using a naming convention (as Flask does): every package whose toplevel dir begins with (`gym_`) is considered a plugin package and will be imported.

N.B.: While there are other possible solutions, this one is the most lightweight and won't break current custom envs.