### PR TITLE
Changed MujocoEnv and inheriting environment classes to use mujoco_py 1.5

### DIFF
--- a/gym/envs/mujoco/ant.py
+++ b/gym/envs/mujoco/ant.py
@@ -14,7 +14,7 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         forward_reward = (xposafter - xposbefore)/self.dt
         ctrl_cost = .5 * np.square(a).sum()
         contact_cost = 0.5 * 1e-3 * np.sum(
-            np.square(np.clip(self.model.data.cfrc_ext, -1, 1)))
+            np.square(np.clip(self.sim.data.cfrc_ext, -1, 1)))
         survive_reward = 1.0
         reward = forward_reward - ctrl_cost - contact_cost + survive_reward
         state = self.state_vector()
@@ -30,9 +30,9 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def _get_obs(self):
         return np.concatenate([
-            self.model.data.qpos.flat[2:],
-            self.model.data.qvel.flat,
-            np.clip(self.model.data.cfrc_ext, -1, 1).flat,
+            self.sim.data.qpos.flat[2:],
+            self.sim.data.qvel.flat,
+            np.clip(self.sim.data.cfrc_ext, -1, 1).flat,
         ])
 
     def reset_model(self):

--- a/gym/envs/mujoco/half_cheetah.py
+++ b/gym/envs/mujoco/half_cheetah.py
@@ -8,9 +8,9 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         utils.EzPickle.__init__(self)
 
     def _step(self, action):
-        xposbefore = self.model.data.qpos[0, 0]
+        xposbefore = self.sim.data.qpos[0, 0]
         self.do_simulation(action, self.frame_skip)
-        xposafter = self.model.data.qpos[0, 0]
+        xposafter = self.sim.data.qpos[0, 0]
         ob = self._get_obs()
         reward_ctrl = - 0.1 * np.square(action).sum()
         reward_run = (xposafter - xposbefore)/self.dt
@@ -20,8 +20,8 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def _get_obs(self):
         return np.concatenate([
-            self.model.data.qpos.flat[1:],
-            self.model.data.qvel.flat,
+            self.sim.data.qpos.flat[1:],
+            self.sim.data.qvel.flat,
         ])
 
     def reset_model(self):

--- a/gym/envs/mujoco/hopper.py
+++ b/gym/envs/mujoco/hopper.py
@@ -8,9 +8,9 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         utils.EzPickle.__init__(self)
 
     def _step(self, a):
-        posbefore = self.model.data.qpos[0, 0]
+        posbefore = self.sim.data.qpos[0, 0]
         self.do_simulation(a, self.frame_skip)
-        posafter, height, ang = self.model.data.qpos[0:3, 0]
+        posafter, height, ang = self.sim.data.qpos[0:3, 0]
         alive_bonus = 1.0
         reward = (posafter - posbefore) / self.dt
         reward += alive_bonus
@@ -23,8 +23,8 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def _get_obs(self):
         return np.concatenate([
-            self.model.data.qpos.flat[1:],
-            np.clip(self.model.data.qvel.flat, -10, 10)
+            self.sim.data.qpos.flat[1:],
+            np.clip(self.sim.data.qvel.flat, -10, 10)
         ])
 
     def reset_model(self):

--- a/gym/envs/mujoco/humanoid.py
+++ b/gym/envs/mujoco/humanoid.py
@@ -4,9 +4,9 @@ from gym import utils
 
 def mass_center(sim):
     #mass = model.body_mass
-    # No body_mass in new mujoco_py API available. Recheck needed.
+    mass = sim.model.body_mass
     xpos = sim.data.xipos
-    return np.mean(xpos, 0)[0]
+    return (np.sum(mass*xpos, 0) / np.sum(mass))[0]
     #return (np.sum(mass * xpos, 0) / np.sum(mass))[0]
 
 class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):

--- a/gym/envs/mujoco/humanoid.py
+++ b/gym/envs/mujoco/humanoid.py
@@ -6,7 +6,7 @@ def mass_center(sim):
     #mass = model.body_mass
     # No body_mass in new mujoco_py API available. Recheck needed.
     xpos = sim.data.xipos
-    return xpos[0] 
+    return np.mean(xpos, 0)[0]
     #return (np.sum(mass * xpos, 0) / np.sum(mass))[0]
 
 class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):

--- a/gym/envs/mujoco/humanoid.py
+++ b/gym/envs/mujoco/humanoid.py
@@ -2,10 +2,12 @@ import numpy as np
 from gym.envs.mujoco import mujoco_env
 from gym import utils
 
-def mass_center(model):
-    mass = model.body_mass
-    xpos = model.data.xipos
-    return (np.sum(mass * xpos, 0) / np.sum(mass))[0]
+def mass_center(sim):
+    #mass = model.body_mass
+    # No body_mass in new mujoco_py API available. Recheck needed.
+    xpos = sim.data.xipos
+    return xpos[0] 
+    #return (np.sum(mass * xpos, 0) / np.sum(mass))[0]
 
 class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self):
@@ -13,7 +15,7 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         utils.EzPickle.__init__(self)
 
     def _get_obs(self):
-        data = self.model.data
+        data = self.sim.data
         return np.concatenate([data.qpos.flat[2:],
                                data.qvel.flat,
                                data.cinert.flat,
@@ -22,17 +24,18 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
                                data.cfrc_ext.flat])
 
     def _step(self, a):
-        pos_before = mass_center(self.model)
+        pos_before = mass_center(self.sim)
+        
         self.do_simulation(a, self.frame_skip)
-        pos_after = mass_center(self.model)
+        pos_after = mass_center(self.sim)
         alive_bonus = 5.0
-        data = self.model.data
+        data = self.sim.data
         lin_vel_cost = 0.25 * (pos_after - pos_before) / self.model.opt.timestep
         quad_ctrl_cost = 0.1 * np.square(data.ctrl).sum()
         quad_impact_cost = .5e-6 * np.square(data.cfrc_ext).sum()
         quad_impact_cost = min(quad_impact_cost, 10)
         reward = lin_vel_cost - quad_ctrl_cost - quad_impact_cost + alive_bonus
-        qpos = self.model.data.qpos
+        qpos = self.sim.data.qpos
         done = bool((qpos[2] < 1.0) or (qpos[2] > 2.0))
         return self._get_obs(), reward, done, dict(reward_linvel=lin_vel_cost, reward_quadctrl=-quad_ctrl_cost, reward_alive=alive_bonus, reward_impact=-quad_impact_cost)
 

--- a/gym/envs/mujoco/humanoidstandup.py
+++ b/gym/envs/mujoco/humanoidstandup.py
@@ -2,10 +2,12 @@ import numpy as np
 from gym.envs.mujoco import mujoco_env
 from gym import utils
 
-def mass_center(model):
-    mass = model.body_mass
-    xpos = model.data.xipos
-    return (np.sum(mass * xpos, 0) / np.sum(mass))[0]
+def mass_center(sim):
+    #mass = model.body_mass
+    # New mujoco_py API has no body_mass available. so just returning xipos[0] (non weighted). Potentially wrong.
+    xpos = sim.data.xipos
+    return xpos[0]
+    #return (np.sum(mass * xpos, 0) / np.sum(mass))[0]
 
 class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self):
@@ -13,7 +15,7 @@ class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         utils.EzPickle.__init__(self)
 
     def _get_obs(self):
-        data = self.model.data
+        data = self.sim.data
         return np.concatenate([data.qpos.flat[2:],
                                data.qvel.flat,
                                data.cinert.flat,
@@ -23,8 +25,8 @@ class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def _step(self, a):
         self.do_simulation(a, self.frame_skip)
-        pos_after = self.model.data.qpos[2][0]
-        data = self.model.data
+        pos_after = self.sim.data.qpos[2][0]
+        data = self.sim.data
         uph_cost = (pos_after - 0) / self.model.opt.timestep
 
         quad_ctrl_cost = 0.1 * np.square(data.ctrl).sum()

--- a/gym/envs/mujoco/humanoidstandup.py
+++ b/gym/envs/mujoco/humanoidstandup.py
@@ -4,10 +4,9 @@ from gym import utils
 
 def mass_center(sim):
     #mass = model.body_mass
-    # New mujoco_py API has no body_mass available. so just returning xipos[0] (non weighted). Potentially wrong.
+    mass = sim.model.body_mass
     xpos = sim.data.xipos
-    return np.mean(xpos, 0)[0]
-    #return (np.sum(mass * xpos, 0) / np.sum(mass))[0]
+    return (np.sum(mass*xpos, 0) / np.sum(mass))[0]
 
 class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self):

--- a/gym/envs/mujoco/humanoidstandup.py
+++ b/gym/envs/mujoco/humanoidstandup.py
@@ -6,7 +6,7 @@ def mass_center(sim):
     #mass = model.body_mass
     # New mujoco_py API has no body_mass available. so just returning xipos[0] (non weighted). Potentially wrong.
     xpos = sim.data.xipos
-    return xpos[0]
+    return np.mean(xpos, 0)[0]
     #return (np.sum(mass * xpos, 0) / np.sum(mass))[0]
 
 class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):

--- a/gym/envs/mujoco/inverted_double_pendulum.py
+++ b/gym/envs/mujoco/inverted_double_pendulum.py
@@ -11,9 +11,9 @@ class InvertedDoublePendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def _step(self, action):
         self.do_simulation(action, self.frame_skip)
         ob = self._get_obs()
-        x, _, y = self.model.data.site_xpos[0]
+        x, _, y = self.sim.data.site_xpos[0]
         dist_penalty = 0.01 * x ** 2 + (y - 2) ** 2
-        v1, v2 = self.model.data.qvel[1:3]
+        v1, v2 = self.sim.data.qvel[1:3]
         vel_penalty = 1e-3 * v1**2 + 5e-3 * v2**2
         alive_bonus = 10
         r = (alive_bonus - dist_penalty - vel_penalty)[0]
@@ -22,11 +22,11 @@ class InvertedDoublePendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def _get_obs(self):
         return np.concatenate([
-            self.model.data.qpos[:1],  # cart x pos
-            np.sin(self.model.data.qpos[1:]),  # link angles
-            np.cos(self.model.data.qpos[1:]),
-            np.clip(self.model.data.qvel, -10, 10),
-            np.clip(self.model.data.qfrc_constraint, -10, 10)
+            self.sim.data.qpos[:1],  # cart x pos
+            np.sin(self.sim.data.qpos[1:]),  # link angles
+            np.cos(self.sim.data.qpos[1:]),
+            np.clip(self.sim.data.qvel, -10, 10),
+            np.clip(self.sim.data.qfrc_constraint, -10, 10)
         ]).ravel()
 
     def reset_model(self):

--- a/gym/envs/mujoco/inverted_pendulum.py
+++ b/gym/envs/mujoco/inverted_pendulum.py
@@ -22,7 +22,7 @@ class InvertedPendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         return self._get_obs()
 
     def _get_obs(self):
-        return np.concatenate([self.model.data.qpos, self.model.data.qvel]).ravel()
+        return np.concatenate([self.sim.data.qpos, self.sim.data.qvel]).ravel()
 
     def viewer_setup(self):
         v = self.viewer

--- a/gym/envs/mujoco/pusher.py
+++ b/gym/envs/mujoco/pusher.py
@@ -50,8 +50,8 @@ class PusherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def _get_obs(self):
         return np.concatenate([
-            self.model.data.qpos.flat[:7],
-            self.model.data.qvel.flat[:7],
+            self.sim.data.qpos.flat[:7],
+            self.sim.data.qvel.flat[:7],
             self.get_body_com("tips_arm"),
             self.get_body_com("object"),
             self.get_body_com("goal"),

--- a/gym/envs/mujoco/pusher.py
+++ b/gym/envs/mujoco/pusher.py
@@ -3,7 +3,7 @@ from gym import utils
 from gym.envs.mujoco import mujoco_env
 
 import mujoco_py
-from mujoco_py.mjlib import mjlib
+#from mujoco_py.import mjlib
 
 class PusherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self):

--- a/gym/envs/mujoco/reacher.py
+++ b/gym/envs/mujoco/reacher.py
@@ -33,11 +33,11 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         return self._get_obs()
 
     def _get_obs(self):
-        theta = self.model.data.qpos.flat[:2]
+        theta = self.sim.data.qpos.flat[:2]
         return np.concatenate([
             np.cos(theta),
             np.sin(theta),
-            self.model.data.qpos.flat[2:],
-            self.model.data.qvel.flat[:2],
+            self.sim.data.qpos.flat[2:],
+            self.sim.data.qvel.flat[:2],
             self.get_body_com("fingertip") - self.get_body_com("target")
         ])

--- a/gym/envs/mujoco/striker.py
+++ b/gym/envs/mujoco/striker.py
@@ -67,8 +67,8 @@ class StrikerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def _get_obs(self):
         return np.concatenate([
-            self.model.data.qpos.flat[:7],
-            self.model.data.qvel.flat[:7],
+            self.sim.data.qpos.flat[:7],
+            self.sim.data.qvel.flat[:7],
             self.get_body_com("tips_arm"),
             self.get_body_com("object"),
             self.get_body_com("goal"),

--- a/gym/envs/mujoco/swimmer.py
+++ b/gym/envs/mujoco/swimmer.py
@@ -9,9 +9,9 @@ class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def _step(self, a):
         ctrl_cost_coeff = 0.0001
-        xposbefore = self.model.data.qpos[0, 0]
+        xposbefore = self.sim.data.qpos[0, 0]
         self.do_simulation(a, self.frame_skip)
-        xposafter = self.model.data.qpos[0, 0]
+        xposafter = self.sim.data.qpos[0, 0]
         reward_fwd = (xposafter - xposbefore) / self.dt
         reward_ctrl = - ctrl_cost_coeff * np.square(a).sum()
         reward = reward_fwd + reward_ctrl
@@ -19,8 +19,8 @@ class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         return ob, reward, False, dict(reward_fwd=reward_fwd, reward_ctrl=reward_ctrl)
 
     def _get_obs(self):
-        qpos = self.model.data.qpos
-        qvel = self.model.data.qvel
+        qpos = self.sim.data.qpos
+        qvel = self.sim.data.qvel
         return np.concatenate([qpos.flat[2:], qvel.flat])
 
     def reset_model(self):

--- a/gym/envs/mujoco/thrower.py
+++ b/gym/envs/mujoco/thrower.py
@@ -52,8 +52,8 @@ class ThrowerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def _get_obs(self):
         return np.concatenate([
-            self.model.data.qpos.flat[:7],
-            self.model.data.qvel.flat[:7],
+            self.sim.data.qpos.flat[:7],
+            self.sim.data.qvel.flat[:7],
             self.get_body_com("r_wrist_roll_link"),
             self.get_body_com("ball"),
             self.get_body_com("goal"),

--- a/gym/envs/mujoco/walker2d.py
+++ b/gym/envs/mujoco/walker2d.py
@@ -9,9 +9,9 @@ class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         utils.EzPickle.__init__(self)
 
     def _step(self, a):
-        posbefore = self.model.data.qpos[0, 0]
+        posbefore = self.sim.data.qpos[0, 0]
         self.do_simulation(a, self.frame_skip)
-        posafter, height, ang = self.model.data.qpos[0:3, 0]
+        posafter, height, ang = self.sim.data.qpos[0:3, 0]
         alive_bonus = 1.0
         reward = ((posafter - posbefore) / self.dt)
         reward += alive_bonus
@@ -22,8 +22,8 @@ class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         return ob, reward, done, {}
 
     def _get_obs(self):
-        qpos = self.model.data.qpos
-        qvel = self.model.data.qvel
+        qpos = self.sim.data.qpos
+        qvel = self.sim.data.qvel
         return np.concatenate([qpos[1:], np.clip(qvel, -10, 10)]).ravel()
 
     def reset_model(self):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ extras = {
   'board_game' : ['pachi-py>=0.0.19'],
   'box2d': ['Box2D-kengz'],
   'classic_control': ['PyOpenGL'],
-  'mujoco': ['mujoco_py<1.0.0,>=0.4.3', 'imageio'],
+  'mujoco': ['mujoco_py', 'imageio']
+  #'mujoco': ['mujoco_py<1.0.0,>=0.4.3', 'imageio'],
   'parameter_tuning': ['keras', 'theano'],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras = {
   'board_game' : ['pachi-py>=0.0.19'],
   'box2d': ['Box2D-kengz'],
   'classic_control': ['PyOpenGL'],
-  'mujoco': ['mujoco_py', 'imageio']
+  'mujoco': ['mujoco_py', 'imageio'],
   #'mujoco': ['mujoco_py<1.0.0,>=0.4.3', 'imageio'],
   'parameter_tuning': ['keras', 'theano'],
 }


### PR DESCRIPTION
Changed MujocoEnv and inheriting task environment classes to use the new mujoco_py 1.5 API.
Issues to be figured out:

1. mjlib.mj_resetData(self.model.ptr, self.data.ptr) - the new API's equivalent of it is not clear
2. viewer.autoscale() - no equivalent in new API. Not sure if it's needed. 

Changed setup.py to remove @jonasschneider's mujoco pin to <1.0.0