### PR TITLE
added missing dependencies to main Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,20 @@ RUN apt-get update \
     curl \
     cmake \
     swig \
+    freeglut3 \
     python-opengl \
     libboost-all-dev \
+    libglu1-mesa \
+    libglu1-mesa-dev \
+    libsdl2-2.0-0\
+    libgles2-mesa-dev \
     libsdl2-dev \
     wget \
     unzip \
     git \
+    xserver-xorg-input-void \
+    xserver-xorg-video-dummy \
+    python-gtkglext1 \
     xpra \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
At the moment a clean (--no-chache) build of the master branch crashes. This PR fixes it by adding the necessary dependencies.

A while back someone had trouble building the gym in docker using

    docker build .

in Issue #706 . I had the same issue, fixed it and posted the updated docker file [here](https://gist.github.com/FirefoxMetzger/3abb9ea3a2924d8006cc4b4a71963917).

Hopefully, someone from the openAI team has 5 minutes to look into this =) It would be nice to be able to build master from scratch in docker without resorting to workarounds.