### PR TITLE
Run tests in parallel on Python 2.7 and Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: required
 language: python
+python:
+  - 2.7
+  - 3.6
 services:
   - docker
 before_install:


### PR DESCRIPTION
Replaces #689 

README [commits the support of both Python 2 and Python 3](https://github.com/openai/gym/blob/master/README.rst#supported-systems) so let's use Travis CI parallel execution to test both of them.

Output: https://travis-ci.org/openai/gym/builds/300895268