### PR TITLE
Use flake8 to find syntax errors & undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: required
 language: python
 services:
   - docker
+python:
+  - 2.7
+  - 3.6
 before_install:
   # Prime the cache. We currently manually keep this synced.
   - docker pull quay.io/openai/gym:test
@@ -9,6 +12,9 @@ before_install:
   # ^^^ commented out by joschu 2017/9/3
   # build command fails due to apt issue "The following packages have unmet dependencies:"
 install: "" # so travis doesn't do pip install requirements.txt
+before_script:
+  - pip install flake8
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 script:
   # In a pull request, there are no secrets, and hence no MuJoCo:
   # https://docs.travis-ci.com/user/pull-requests#Security-Restrictions-when-testing-Pull-Requests.


### PR DESCRIPTION
E901,E999,F821,F822,F823 are flake8 errors that can effect runtime execution.

This PR is a superset of #769 that achieves what #771 attempted to do.

__Python 2 output__: https://travis-ci.org/openai/gym/jobs/300962486#L485-L524
* 1     E999 SyntaxError: invalid syntax
* 11    F821 undefined name 'discrete'

__Python 3 output__: https://travis-ci.org/openai/gym/jobs/300962487#L480-L540
* 4     E999 SyntaxError: invalid syntax
* 15    F821 undefined name 'discrete'

Fixes to several of these issues can be found among https://github.com/openai/gym/pulls/cclauss