### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/examples/agents/tabular_q_agent.py
+++ b/examples/agents/tabular_q_agent.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 class TabularQAgent(object):
     """
     Agent implementing tabular Q-learning.

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys, math
 import numpy as np
 

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys, math
 import numpy as np
 

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys, math
 import numpy as np
 

--- a/gym/envs/tests/test_determinism.py
+++ b/gym/envs/tests/test_determinism.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import numpy as np
 import pytest
 import os

--- a/gym/envs/toy_text/kellycoinflip.py
+++ b/gym/envs/toy_text/kellycoinflip.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import gym
 from gym import spaces
 from gym.utils import seeding

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import gym
 import pygame
 import sys

--- a/misc/check_envs_for_change.py
+++ b/misc/check_envs_for_change.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 ENVS = ["Ant-v0", "HalfCheetah-v0", "Hopper-v0", "Humanoid-v0", "InvertedDoublePendulum-v0", "Reacher-v0", "Swimmer-v0", "Walker2d-v0"]
 OLD_COMMIT = "HEAD"
 
@@ -9,7 +10,7 @@ from os import path
 
 def cap(cmd):
     "Call and print command"
-    print utils.colorize(cmd, "green")
+    print(utils.colorize(cmd, "green"))
     subprocess.check_call(cmd,shell=True)
 
 # ================================================================
@@ -20,12 +21,12 @@ comparedir = "/tmp/gym-comparison"
 
 oldgymbase = path.basename(oldgymroot)
 
-print "gym root", gymroot
+print("gym root", gymroot)
 thisdir = path.abspath(path.dirname(__file__))
-print "this directory", thisdir
+print("this directory", thisdir)
 cap("rm -rf %(oldgymroot)s %(comparedir)s && mkdir %(comparedir)s && cd /tmp && git clone %(gymroot)s %(oldgymbase)s"%locals())
 for env in ENVS:
-    print utils.colorize("*"*50 + "\nENV: %s" % env, "red")
+    print(utils.colorize("*"*50 + "\nENV: %s" % env, "red"))
     writescript = path.join(thisdir, "write_rollout_data.py")
     outfileA = path.join(comparedir, env) + "-A.npz"
     cap("python %(writescript)s %(env)s %(outfileA)s"%locals())

--- a/misc/compare_rollout_data.py
+++ b/misc/compare_rollout_data.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import argparse, numpy as np
 
 def main():
@@ -13,13 +14,13 @@ def main():
         arr2 = file2[k]
         if arr1.shape == arr2.shape:
             if np.allclose(file1[k], file2[k]):
-                print "%s: matches!"%k
+                print("%s: matches!"%k)
                 continue
             else:
-                print "%s: arrays are not equal. Difference = %g"%(k, np.abs(arr1 - arr2).max())
+                print("%s: arrays are not equal. Difference = %g"%(k, np.abs(arr1 - arr2).max()))
         else:
-            print "%s: arrays have different shape! %s vs %s"%(k, arr1.shape, arr2.shape)
-        print "first 30 els:\n1. %s\n2. %s"%(arr1.flat[:30], arr2.flat[:30])
+            print("%s: arrays have different shape! %s vs %s"%(k, arr1.shape, arr2.shape))
+        print("first 30 els:\n1. %s\n2. %s"%(arr1.flat[:30], arr2.flat[:30]))
 
 
 if __name__ == "__main__":

--- a/misc/write_rollout_data.py
+++ b/misc/write_rollout_data.py
@@ -3,6 +3,7 @@ This script does a few rollouts with an environment and writes the data to an np
 Its purpose is to help with verifying that you haven't functionally changed an environment.
 (If you have, you should bump the version number.)
 """
+from __future__ import print_function
 import argparse, numpy as np, collections, sys
 from os import path
 
@@ -40,7 +41,7 @@ def main():
         sys.path.insert(0, args.gymdir)
     import gym
     from gym import utils
-    print utils.colorize("gym directory: %s"%path.dirname(gym.__file__), "yellow")
+    print(utils.colorize("gym directory: %s"%path.dirname(gym.__file__), "yellow"))
     env = gym.make(args.envid)
     agent = RandomAgent(env.action_space)
     alldata = {}


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. More work _might_ be required to complete the port to Python 3 but this is a minimal, safe first step.

* [futurize stage 1](http://python-future.org/futurize_cheatsheet.html#step-1-modern-py2-code)
* `from __future__ import print_function`