### PR TITLE
_reset function and _step function not consistency

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -313,7 +313,7 @@ class ObservationWrapper(Wrapper):
 
     def _step(self, action):
         observation, reward, done, info = self.env.step(action)
-        return self.observation(observation), reward, done, info
+        return self._observation(observation), reward, done, info
 
     def observation(self, observation):
         return self._observation(observation)


### PR DESCRIPTION
In the `_reset` function in line 312, the function use `_observation()`, however, in the `_step` function in line 316, the function use `observation()`. It's not a big deal, but I think we should keep the consistency.