### PR TITLE
Video Recorder: skip current frame if env._recorder_skip_frame is True

### DIFF
--- a/gym/monitoring/video_recorder.py
+++ b/gym/monitoring/video_recorder.py
@@ -104,6 +104,10 @@ class VideoRecorder(object):
 
         render_mode = 'ansi' if self.ansi_mode else 'rgb_array'
         frame = self.env.render(mode=render_mode)
+        
+        # enable env to request to skip recording this frame
+        if getattr(self.env.unwrapped, '_recorder_skip_frame', False):
+            return        
 
         if frame is None:
             if self._async:


### PR DESCRIPTION
I need a way to skip recording some frame. 

I add a lag between the agent and the enviroment so the first n frames are blank which creates a flicker in the video

This allows me to offset ping and gives a significant speed boost to training in a distributed enviroment.