### PR TITLE
Fix sim_env script for python3

### DIFF
--- a/examples/scripts/sim_env
+++ b/examples/scripts/sim_env
@@ -5,6 +5,7 @@ import argparse
 import numpy as np
 import itertools
 import time
+from six.moves import input as raw_input
 
 parser = argparse.ArgumentParser()
 parser.add_argument("env")


### PR DESCRIPTION
```raw_input``` has become ```input``` in python3. Using ```six``` to support both python2 and python3.