### PR TITLE
fix renaming of _seed

### DIFF
--- a/gym/utils/seeding.py
+++ b/gym/utils/seeding.py
@@ -42,7 +42,7 @@ def hash_seed(seed=None, max_bytes=8):
         max_bytes: Maximum number of bytes to use in the hashed seed.
     """
     if seed is None:
-        seed = _seed(max_bytes=max_bytes)
+        seed = create_seed(max_bytes=max_bytes)
     hash = hashlib.sha512(str(seed).encode('utf8')).digest()
     return _bigint_from_bytes(hash[:max_bytes])
 


### PR DESCRIPTION
There was one call to the old function name `_seed` left in `utils/seeding.py`. This PR fixes it. Not sure if such a trivial PR is desirable for you, I figured it would be simpler than opening an issue. 