### PR TITLE
Use six.raise_from() and six.reraise() to unify implementation

### DIFF
--- a/gym/utils/reraise_impl_py3.py
+++ b/gym/utils/reraise_impl_py3.py
@@ -1,4 +1,8 @@
 # http://stackoverflow.com/a/33822606 -- `from None` disables Python 3'
 # semi-smart exception chaining, which we don't want in this case.
+import six
+
+
 def reraise_impl(e, traceback):
-    raise e.with_traceback(traceback) from None
+    # raise e.with_traceback(traceback) from None
+    six.raise_from(e.with_traceback(traceback), None)


### PR DESCRIPTION
http://six.readthedocs.io/#six.raise_from should allow us to get to a single implementation for both Python 2 and Python 3.  Related to #859