### PR TITLE
Fix a bug in TimeLimit wrapper

### DIFF
--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -38,7 +38,7 @@ class TimeLimit(Wrapper):
 
         return observation, reward, done, info
 
-    def reset(self):
+    def reset(self, **kwargs):
         self._episode_started_at = time.time()
         self._elapsed_steps = 0
-        return self.env.reset()
+        return self.env.reset(**kwargs)


### PR DESCRIPTION
Correctly propagate `kwargs` in `TimeLimit.reset` to the wrapped environment.