### PR TITLE
Replace deprecated load(False) with resolve()

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -11,7 +11,7 @@ env_id_re = re.compile(r'^(?:[\w:-]+\/)?([\w:.-]+)-v(\d+)$')
 
 def load(name):
     entry_point = pkg_resources.EntryPoint.parse('x={}'.format(name))
-    result = entry_point.load(False)
+    result = entry_point.resolve()
     return result
 
 class EnvSpec(object):


### PR DESCRIPTION
As per https://github.com/pypa/setuptools/blob/v38.5.2/pkg_resources/__init__.py#L2423 `entry_point.load(False)` is deprecated