### PR TITLE
fix Box dtype in pendulum env

### DIFF
--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -17,8 +17,8 @@ class PendulumEnv(gym.Env):
         self.viewer = None
 
         high = np.array([1., 1., self.max_speed])
-        self.action_space = spaces.Box(low=-self.max_torque, high=self.max_torque, shape=(1,))
-        self.observation_space = spaces.Box(low=-high, high=high)
+        self.action_space = spaces.Box(low=-self.max_torque, high=self.max_torque, shape=(1,), dtype='float32')
+        self.observation_space = spaces.Box(low=-high, high=high, dtype='float32')
 
         self.seed()
 


### PR DESCRIPTION
Without this fix you get spammed with annoying logger warnings:
> WARN: gym.spaces.Box autodetected dtype as <class 'numpy.float32'>. Please provide explicit dtype.