### PR TITLE
Headless versions for CartPole, Pendulum and Acrobot

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -103,6 +103,12 @@ register(
     max_episode_steps=500,
 )
 
+register(
+    id='AcrobotRawImg-v1',
+    entry_point='gym.envs.classic_control:AcrobotRawImgEnv',
+    max_episode_steps=500,
+)
+
 # Box2d
 # ----------------------------------------
 

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -92,6 +92,12 @@ register(
 )
 
 register(
+    id='PendulumRawImg-v0',
+    entry_point='gym.envs.classic_control:PendulumRawImgEnv',
+    max_episode_steps=200,
+)
+
+register(
     id='Acrobot-v1',
     entry_point='gym.envs.classic_control:AcrobotEnv',
     max_episode_steps=500,

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -65,6 +65,13 @@ register(
 )
 
 register(
+    id='CartPoleRawImg-v0',
+    entry_point='gym.envs.classic_control:CartPoleRawImgEnv',
+    max_episode_steps=200,
+    reward_threshold=195.0,
+)
+
+register(
     id='MountainCar-v0',
     entry_point='gym.envs.classic_control:MountainCarEnv',
     max_episode_steps=200,

--- a/gym/envs/classic_control/__init__.py
+++ b/gym/envs/classic_control/__init__.py
@@ -3,5 +3,6 @@ from gym.envs.classic_control.cartpole_rawimg import CartPoleRawImgEnv
 from gym.envs.classic_control.mountain_car import MountainCarEnv
 from gym.envs.classic_control.continuous_mountain_car import Continuous_MountainCarEnv
 from gym.envs.classic_control.pendulum import PendulumEnv
+from gym.envs.classic_control.pendulum_rawimg import PendulumRawImgEnv
 from gym.envs.classic_control.acrobot import AcrobotEnv
 

--- a/gym/envs/classic_control/__init__.py
+++ b/gym/envs/classic_control/__init__.py
@@ -1,4 +1,5 @@
 from gym.envs.classic_control.cartpole import CartPoleEnv
+from gym.envs.classic_control.cartpole_rawimg import CartPoleRawImgEnv
 from gym.envs.classic_control.mountain_car import MountainCarEnv
 from gym.envs.classic_control.continuous_mountain_car import Continuous_MountainCarEnv
 from gym.envs.classic_control.pendulum import PendulumEnv

--- a/gym/envs/classic_control/__init__.py
+++ b/gym/envs/classic_control/__init__.py
@@ -5,4 +5,5 @@ from gym.envs.classic_control.continuous_mountain_car import Continuous_Mountain
 from gym.envs.classic_control.pendulum import PendulumEnv
 from gym.envs.classic_control.pendulum_rawimg import PendulumRawImgEnv
 from gym.envs.classic_control.acrobot import AcrobotEnv
+from gym.envs.classic_control.acrobot_rawimg import AcrobotRawImgEnv
 

--- a/gym/envs/classic_control/acrobot_rawimg.py
+++ b/gym/envs/classic_control/acrobot_rawimg.py
@@ -1,3 +1,10 @@
+'''
+This environment gives the raw image
+as output instead of the low level state
+values. The implementation is based on
+AcrobotEnv.
+'''
+
 from gym.envs.classic_control import acrobot
 import numpy as np
 

--- a/gym/envs/classic_control/acrobot_rawimg.py
+++ b/gym/envs/classic_control/acrobot_rawimg.py
@@ -1,0 +1,115 @@
+from gym.envs.classic_control import acrobot
+import numpy as np
+
+
+class AcrobotRawImgEnv(acrobot.AcrobotEnv):
+
+    def __init__(self):
+        super().__init__()
+        self.drawer = DrawImage()
+        self.raw_img = None
+
+    def step(self, action):
+        obs, rw, done, inf = super().step(action)
+        cos_alpha = obs[0]  # the first angle is for the upper arm
+        sin_alpha = obs[1]
+        cos_beta = obs[2]
+        sin_beta = obs[3]
+
+        self.raw_img = self.drawer.draw(cos_alpha, sin_alpha, cos_beta, sin_beta)
+        return self.raw_img, rw, done, inf
+
+    def render(self, mode='human'):
+
+        if mode == 'rgb_array':
+            return self.raw_img
+        elif mode == 'human':
+            from gym.envs.classic_control import rendering
+            if self.viewer is None:
+                self.viewer = rendering.SimpleImageViewer()
+            self.viewer.imshow(self.raw_img)
+            return self.viewer.isopen
+
+    def reset(self):
+        obs = super().reset()
+        cos_alpha = obs[0]
+        sin_alpha = obs[1]
+        cos_beta = obs[2]
+        sin_beta = obs[3]
+
+        self.raw_img = self.drawer.draw(cos_alpha, sin_alpha, cos_beta, sin_beta)
+        return self.raw_img
+
+    def close(self):
+        if self.viewer is not None:
+            self.viewer.close()
+
+    def __del__(self):
+        self.close()
+
+colors = {
+        'black': np.array([0, 0, 0]),
+        'brown': np.array([173, 97, 14]),
+        'red': np.array([214, 25, 28]),
+    }
+
+
+class DrawImage:
+
+    def __init__(self):
+        self.height = 210  # Atari-like image size
+        self.width = 160
+        self.canvas = np.zeros((self.height, self.width, 3), dtype=np.uint8) + 255
+
+        self.rod_length = 40
+
+    def draw(self, cos_alpha, sin_alpha, cos_beta, sin_beta):
+        self.__clear()
+        self.__draw_base_line()
+        self.__draw_rod(cos_alpha, sin_alpha, cos_beta, sin_beta)
+
+        return self.canvas
+
+    # Draw the elements of the image
+
+    def __clear(self):
+
+        self.canvas[:, :, :] = 255
+
+    def __draw_base_line(self):
+
+        start_x = 5
+        end_x = self.width - 5
+
+        start_end_y = self.height // 2 - self.rod_length  # the line is horizontal
+
+        self.canvas[start_end_y, start_x:end_x] = colors['black']
+
+    def __draw_rod(self, cos_alpha, sin_alpha, cos_beta, sin_beta):
+
+        def draw_square(x, y, color):
+            self.canvas[y-2:y+2, x-2:x+2] = color
+
+        x0 = self.width // 2
+        y0 = self.height // 2
+
+        x1 = int(x0 + self.rod_length / 2 * sin_alpha)
+        y1 = int(y0 + self.rod_length / 2 * cos_alpha)
+
+        x2 = int(x0 + self.rod_length * sin_alpha)
+        y2 = int(y0 + self.rod_length * cos_alpha)
+
+        sin_alpha_plus_beta = sin_alpha * cos_beta + cos_alpha * sin_beta
+        cos_alpha_plus_beta = cos_alpha * cos_beta - sin_alpha * sin_beta
+
+        x3 = int(x2 + self.rod_length / 2 * sin_alpha_plus_beta)
+        y3 = int(y2 + self.rod_length / 2 * cos_alpha_plus_beta)
+
+        x4 = int(x2 + self.rod_length * sin_alpha_plus_beta)
+        y4 = int(y2 + self.rod_length * cos_alpha_plus_beta)
+
+        draw_square(x0, y0, colors['brown'])
+        draw_square(x1, y1, colors['red'])
+        draw_square(x2, y2, colors['brown'])
+        draw_square(x3, y3, colors['red'])
+        draw_square(x4, y4, colors['red'])

--- a/gym/envs/classic_control/cartpole_rawimg.py
+++ b/gym/envs/classic_control/cartpole_rawimg.py
@@ -83,7 +83,7 @@ class DrawImage:
         start_x = 5
         end_x = self.width - 5
 
-        start_end_y = self.height // 2 # the line is horizontal
+        start_end_y = self.height // 2  # the line is horizontal
 
         self.canvas[start_end_y, start_x:end_x] = colors['black']
 

--- a/gym/envs/classic_control/cartpole_rawimg.py
+++ b/gym/envs/classic_control/cartpole_rawimg.py
@@ -1,0 +1,63 @@
+'''
+This environment uses gives the raw image
+as output instead of the low level state
+values.
+'''
+
+from gym.envs.classic_control import cartpole
+import numpy as np
+
+
+class CartPoleRawImgEnv(cartpole.CartPoleEnv):
+
+    def __init__(self):
+        super().__init__()
+        self.drawer = DrawImage()
+        self.raw_img = None
+
+    def step(self, action):
+        obs, rw, done, inf = super().step(action)
+        cart_position = obs[0]
+        pole_angle = obs[2]
+
+        self.raw_img = self.drawer.draw(cart_position, pole_angle)
+        return self.raw_img, rw, done, inf
+
+    def render(self, mode='human'):
+
+        if mode == 'rgb_array':
+            return self.raw_img
+        elif mode == 'human':
+            from gym.envs.classic_control import rendering
+            if self.viewer is None:
+                self.viewer = rendering.SimpleImageViewer()
+            self.viewer.imshow(self.raw_img)
+            return self.viewer.isopen
+
+    def reset(self):
+        obs = super().reset()
+        cart_position = obs[0]
+        pole_angle = obs[2]
+
+        self.raw_img = self.drawer.draw(cart_position, pole_angle)
+        return self.raw_img
+
+    def close(self):
+        if self.viewer is not None:
+            self.viewer.close()
+
+    def __del__(self):
+        self.close()
+
+
+class DrawImage:
+
+    def __init__(self):
+        self.height = 210  # Atari-like image size
+        self.width = 160
+        self.canvas = np.zeros((self.height, self.width, 3), dtype=np.uint8) + 255
+
+    def draw(self, cart_pos, pol_angl):
+
+        return self.canvas
+

--- a/gym/envs/classic_control/cartpole_rawimg.py
+++ b/gym/envs/classic_control/cartpole_rawimg.py
@@ -6,6 +6,7 @@ values.
 
 from gym.envs.classic_control import cartpole
 import numpy as np
+import math
 
 
 class CartPoleRawImgEnv(cartpole.CartPoleEnv):
@@ -49,6 +50,12 @@ class CartPoleRawImgEnv(cartpole.CartPoleEnv):
     def __del__(self):
         self.close()
 
+colors = {
+        'black': np.array([0, 0, 0]),
+        'blue': np.array([33, 100, 209]),
+        'red': np.array([214, 25, 28])
+    }
+
 
 class DrawImage:
 
@@ -58,6 +65,52 @@ class DrawImage:
         self.canvas = np.zeros((self.height, self.width, 3), dtype=np.uint8) + 255
 
     def draw(self, cart_pos, pol_angl):
+        self.__clear()
+        self.__draw_base_line()
+        self.__draw_box(int((1.0 + cart_pos/2.4) * (self.width // 2)))
+        self.__draw_rod(int((1.0 + cart_pos/2.4) * (self.width // 2)), pol_angl)
 
         return self.canvas
 
+    # Draw the elements of the image
+
+    def __clear(self):
+
+        self.canvas[:, :, :] = 255
+
+    def __draw_base_line(self):
+
+        start_x = 5
+        end_x = self.width - 5
+
+        start_end_y = self.height // 2 # the line is horizontal
+
+        self.canvas[start_end_y, start_x:end_x] = colors['black']
+
+    def __draw_box(self, x):
+        y = self.height // 2
+        left = x - 20
+        right = x + 20
+        top = y - 10
+        bottom = y + 10
+
+        self.canvas[top:bottom, left:right] = colors['blue']
+
+    def __draw_rod(self, pos, angle):
+
+        def draw_square(x, y):
+            self.canvas[y-2:y+2, x-2:x+2] = colors['red']
+
+        rod_length = 40
+        x0 = pos
+        y0 = self.height // 2 - 10
+
+        x1 = int(x0 + rod_length / 2 * math.sin(angle))
+        y1 = int(y0 - rod_length / 2 * math.cos(angle))
+
+        x2 = int(x0 + rod_length * math.sin(angle))
+        y2 = int(y0 - rod_length * math.cos(angle))
+
+        draw_square(x0, y0)
+        draw_square(x1, y1)
+        draw_square(x2, y2)

--- a/gym/envs/classic_control/cartpole_rawimg.py
+++ b/gym/envs/classic_control/cartpole_rawimg.py
@@ -1,7 +1,8 @@
 '''
-This environment uses gives the raw image
+This environment gives the raw image
 as output instead of the low level state
-values.
+values. The implementation is based on
+CartPoleEnv.
 '''
 
 from gym.envs.classic_control import cartpole

--- a/gym/envs/classic_control/pendulum_rawimg.py
+++ b/gym/envs/classic_control/pendulum_rawimg.py
@@ -1,3 +1,10 @@
+'''
+This environment gives the raw image
+as output instead of the low level state
+values. The implementation is based on
+PendulumEnv.
+'''
+
 from gym.envs.classic_control import pendulum
 import numpy as np
 
@@ -80,8 +87,8 @@ class DrawImage:
         x1 = int(x0 + rod_length / 3 * sin_theta)
         y1 = int(y0 - rod_length / 3 * cos_theta)
 
-        x2 = int(x0 + 2* rod_length / 3 * sin_theta)
-        y2 = int(y0 - 2* rod_length / 3 * cos_theta)
+        x2 = int(x0 + 2 * rod_length / 3 * sin_theta)
+        y2 = int(y0 - 2 * rod_length / 3 * cos_theta)
 
         x3 = int(x0 + rod_length * sin_theta)
         y3 = int(y0 - rod_length * cos_theta)

--- a/gym/envs/classic_control/pendulum_rawimg.py
+++ b/gym/envs/classic_control/pendulum_rawimg.py
@@ -1,6 +1,5 @@
 from gym.envs.classic_control import pendulum
 import numpy as np
-import math
 
 
 class PendulumRawImgEnv(pendulum.PendulumEnv):


### PR DESCRIPTION
I have implemented a modified version for each of the mentioned environments. All of them returns the image of the controlled system as the observation instead of the low level states. The motivation behind this:
1. Faster and easier to use than using the render() method with rgb_array mode. 
2. In order to access the image it is not necessary to call the render() method therefore no window will be opened. This has advantage if you run your code on a server and the need for opening a window causes errors.
The implementation draws into a numpy array directly without pyglet. The design is simpler but expressive.