### PR TITLE
Finish removing `close` as an argument from render

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ should know:
 
 - `reset(self)`: Reset the environment's state. Returns `observation`.
 - `step(self, action)`: Step the environment by one timestep. Returns `observation`, `reward`, `done`, `info`.
-- `render(self, mode='human', close=False)`: Render one frame of the environment. The default mode will do something human friendly, such as pop up a window. Passing the `close` flag signals the renderer to close any such windows.
+- `render(self, mode='human')`: Render one frame of the environment. The default mode will do something human friendly, such as pop up a window. Passing the `close` flag signals the renderer to close any such windows.
 
 Installation
 ============

--- a/gym/core.py
+++ b/gym/core.py
@@ -93,7 +93,6 @@ class Env(object):
 
         Args:
             mode (str): the mode to render with
-            close (bool): close all open renderings
 
         Example:
 

--- a/gym/envs/README.md
+++ b/gym/envs/README.md
@@ -46,7 +46,7 @@ ant.AntEnv
   setup(name='gym_foo',
         version='0.0.1',
         install_requires=['gym']  # And any other dependencies foo needs
-  )  
+  )
   ```
 
 * `gym-foo/gym_foo/__init__.py` should have:
@@ -84,7 +84,9 @@ ant.AntEnv
       ...
     def reset(self):
       ...
-    def render(self, mode='human', close=False):
+    def render(self, mode='human'):
+      ...
+    def close(self):
       ...
   ```
 

--- a/gym/envs/unittest/cube_crash.py
+++ b/gym/envs/unittest/cube_crash.py
@@ -73,7 +73,7 @@ class CubeCrash(gym.Env):
     def reset(self):
         self.cube_x = self.np_random.randint(low=3, high=FIELD_W-3)
         self.cube_y = self.np_random.randint(low=3, high=FIELD_H//6)
-        self.hole_x = self.np_random.randint(low=HOLE_WIDTH, high=FIELD_W-HOLE_WIDTH) 
+        self.hole_x = self.np_random.randint(low=HOLE_WIDTH, high=FIELD_W-HOLE_WIDTH)
         self.bg_color = self.random_color() if self.use_random_colors else color_black
         self.potential  = None
         self.step_n = 0
@@ -83,7 +83,7 @@ class CubeCrash(gym.Env):
             if np.linalg.norm(self.wall_color - self.bg_color) < 50 or np.linalg.norm(self.cube_color - self.bg_color) < 50: continue
             break
         return self.step(0)[0]
-    
+
     def step(self, action):
         if action==0: pass
         elif action==1: self.cube_x -= 1
@@ -107,7 +107,7 @@ class CubeCrash(gym.Env):
             reward = (self.potential - dist) * 0.01
         self.potential = dist
 
-        if self.cube_x-1 < 0 or self.cube_x+1 >= FIELD_W:       
+        if self.cube_x-1 < 0 or self.cube_x+1 >= FIELD_W:
             done = True
             reward = -1
         elif self.cube_y+1 >= FIELD_H-5:
@@ -120,13 +120,7 @@ class CubeCrash(gym.Env):
         self.last_obs = obs
         return obs, reward, done, {}
 
-    def render(self, mode='human', close=False):
-        if close:
-            if self.viewer is not None:
-                self.viewer.close()
-                self.viewer = None
-            return
-
+    def render(self, mode='human'):
         if mode == 'rgb_array':
             return self.last_obs
 
@@ -139,6 +133,11 @@ class CubeCrash(gym.Env):
 
         else:
             assert 0, "Render mode '%s' is not supported" % mode
+
+    def close(self):
+        if self.viewer is not None:
+            self.viewer.close()
+            self.viewer = None
 
 class CubeCrashSparse(CubeCrash):
     use_shaped_reward = False

--- a/gym/envs/unittest/memorize_digits.py
+++ b/gym/envs/unittest/memorize_digits.py
@@ -151,7 +151,7 @@ class MemorizeDigits(gym.Env):
             break
         self.digit = -1
         return self.step(0)[0]
-    
+
     def step(self, action):
         reward = -1
         done = False
@@ -173,13 +173,7 @@ class MemorizeDigits(gym.Env):
         self.last_obs = obs
         return obs, reward, done, {}
 
-    def render(self, mode='human', close=False):
-        if close:
-            if self.viewer is not None:
-                self.viewer.close()
-                self.viewer = None
-            return
-
+    def render(self, mode='human'):
         if mode == 'rgb_array':
             return self.last_obs
 
@@ -192,4 +186,9 @@ class MemorizeDigits(gym.Env):
 
         else:
             assert 0, "Render mode '%s' is not supported" % mode
+
+    def close(self):
+        if self.viewer is not None:
+            self.viewer.close()
+            self.viewer = None
 


### PR DESCRIPTION
This cleans up some leftover changes after PR #836 which changed `close` to be a method on `Env` and `Wrapper` subclasses instead of being an argument to `render`. There were a few cases where that were missed as part of that pull request and this pull request aims to fix those. 