### PR TITLE
Implement context handler protocol for Env

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -151,6 +151,14 @@ class Env(object):
         else:
             return '<{}<{}>>'.format(type(self).__name__, self.spec.id)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+        # propagate exception
+        return False
+
 
 class GoalEnv(Env):
     """A goal-based environment. It functions just as any regular OpenAI Gym environment but it


### PR DESCRIPTION
This enables writing
```
import gym

with gym.make(...) as env:
    ...
```
without the need to remember to call `env.close()` later.