### PR TITLE
Updated Calculation Order

### DIFF
--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -25,6 +25,7 @@ class CartPoleEnv(gym.Env):
         self.polemass_length = (self.masspole * self.length)
         self.force_mag = 10.0
         self.tau = 0.02  # seconds between state updates
+        self.kinematics_integrator = 'euler'
 
         # Angle at which to fail the episode
         self.theta_threshold_radians = 12 * 2 * math.pi / 360
@@ -60,10 +61,16 @@ class CartPoleEnv(gym.Env):
         temp = (force + self.polemass_length * theta_dot * theta_dot * sintheta) / self.total_mass
         thetaacc = (self.gravity * sintheta - costheta* temp) / (self.length * (4.0/3.0 - self.masspole * costheta * costheta / self.total_mass))
         xacc  = temp - self.polemass_length * thetaacc * costheta / self.total_mass
-        x_dot = x_dot + self.tau * xacc
-        x  = x + self.tau * x_dot
-        theta_dot = theta_dot + self.tau * thetaacc
-        theta = theta + self.tau * theta_dot
+        if self.kinematics_integrator == 'euler':
+            x_dot = x_dot + self.tau * xacc
+            x  = x + self.tau * x_dot
+            theta_dot = theta_dot + self.tau * thetaacc
+            theta = theta + self.tau * theta_dot
+        else: # semi-implicit euler
+            x  = x + self.tau * x_dot
+            x_dot = x_dot + self.tau * xacc
+            theta = theta + self.tau * theta_dot
+            theta_dot = theta_dot + self.tau * thetaacc
         self.state = (x,x_dot,theta,theta_dot)
         done =  x < -self.x_threshold \
                 or x > self.x_threshold \

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -60,10 +60,10 @@ class CartPoleEnv(gym.Env):
         temp = (force + self.polemass_length * theta_dot * theta_dot * sintheta) / self.total_mass
         thetaacc = (self.gravity * sintheta - costheta* temp) / (self.length * (4.0/3.0 - self.masspole * costheta * costheta / self.total_mass))
         xacc  = temp - self.polemass_length * thetaacc * costheta / self.total_mass
-        x  = x + self.tau * x_dot
         x_dot = x_dot + self.tau * xacc
-        theta = theta + self.tau * theta_dot
+        x  = x + self.tau * x_dot
         theta_dot = theta_dot + self.tau * thetaacc
+        theta = theta + self.tau * theta_dot
         self.state = (x,x_dot,theta,theta_dot)
         done =  x < -self.x_threshold \
                 or x > self.x_threshold \

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -25,7 +25,7 @@ class CartPoleEnv(gym.Env):
         self.polemass_length = (self.masspole * self.length)
         self.force_mag = 10.0
         self.tau = 0.02  # seconds between state updates
-        self.kinematics_integrator = 'semi-implicit-euler'
+        self.kinematics_integrator = 'euler'
 
         # Angle at which to fail the episode
         self.theta_threshold_radians = 12 * 2 * math.pi / 360

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -25,7 +25,7 @@ class CartPoleEnv(gym.Env):
         self.polemass_length = (self.masspole * self.length)
         self.force_mag = 10.0
         self.tau = 0.02  # seconds between state updates
-        self.kinematics_integrator = 'euler'
+        self.kinematics_integrator = 'semi-implicit-euler'
 
         # Angle at which to fail the episode
         self.theta_threshold_radians = 12 * 2 * math.pi / 360
@@ -62,15 +62,15 @@ class CartPoleEnv(gym.Env):
         thetaacc = (self.gravity * sintheta - costheta* temp) / (self.length * (4.0/3.0 - self.masspole * costheta * costheta / self.total_mass))
         xacc  = temp - self.polemass_length * thetaacc * costheta / self.total_mass
         if self.kinematics_integrator == 'euler':
-            x_dot = x_dot + self.tau * xacc
             x  = x + self.tau * x_dot
-            theta_dot = theta_dot + self.tau * thetaacc
+            x_dot = x_dot + self.tau * xacc
             theta = theta + self.tau * theta_dot
+            theta_dot = theta_dot + self.tau * thetaacc
         else: # semi-implicit euler
-            x  = x + self.tau * x_dot
             x_dot = x_dot + self.tau * xacc
-            theta = theta + self.tau * theta_dot
+            x  = x + self.tau * x_dot
             theta_dot = theta_dot + self.tau * thetaacc
+            theta = theta + self.tau * theta_dot
         self.state = (x,x_dot,theta,theta_dot)
         done =  x < -self.x_threshold \
                 or x > self.x_threshold \


### PR DESCRIPTION
Updated order of `x` and `theta` calculations so that they are no longer one timestamp behind `x_dot` and `theta_dot`.

See issue below:
https://github.com/openai/gym/issues/1018