### PR TITLE
Speed up time for `import gym`

### DIFF
--- a/gym/__init__.py
+++ b/gym/__init__.py
@@ -9,7 +9,7 @@ from gym.version import VERSION as __version__
 
 from gym.core import Env, GoalEnv, Space, Wrapper, ObservationWrapper, ActionWrapper, RewardWrapper
 from gym.envs import make, spec
-from gym import wrappers, spaces, logger
+from gym import logger
 
 def undo_logger_setup():
     warnings.warn("gym.undo_logger_setup is deprecated. gym no longer modifies the global logging configuration")

--- a/gym/core.py
+++ b/gym/core.py
@@ -1,5 +1,4 @@
 from gym import logger
-import numpy as np
 
 import gym
 from gym import error
@@ -37,7 +36,7 @@ class Env(object):
 
     # Set this in SOME subclasses
     metadata = {'render.modes': []}
-    reward_range = (-np.inf, np.inf)
+    reward_range = (-float('inf'), float('inf'))
     spec = None
 
     # Set these in ALL subclasses
@@ -199,6 +198,7 @@ class Space(object):
     action.
     """
     def __init__(self, shape=None, dtype=None):
+        import numpy as np # takes about 300-400ms to import, so we load lazily
         self.shape = None if shape is None else tuple(shape)
         self.dtype = None if dtype is None else np.dtype(dtype)
 

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -1,4 +1,3 @@
-import pkg_resources
 import re
 from gym import error, logger
 
@@ -10,6 +9,7 @@ from gym import error, logger
 env_id_re = re.compile(r'^(?:[\w:-]+\/)?([\w:.-]+)-v(\d+)$')
 
 def load(name):
+    import pkg_resources # takes ~400ms to load, so we import it lazily
     entry_point = pkg_resources.EntryPoint.parse('x={}'.format(name))
     result = entry_point.load(False)
     return result


### PR DESCRIPTION
This change avoids loading Numpy and pkg_resources by default, which collectively eat up about 600-700ms worth of load time on my laptop. While you need both of these loaded to use Gym, often I'm importing gym due to a dependency which imports gym, even though I'm not doing anything with Gym directly.