### PR TITLE
Prevent "Can't pickle local object 'patch_deprecated_methods.<locals>.render'"

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -1,4 +1,5 @@
 import re
+from functools import partial
 from gym import error, logger
 
 # This format is true today, but it's *not* an official spec.
@@ -183,9 +184,5 @@ def patch_deprecated_methods(env):
     env.reset = env._reset
     env.step  = env._step
     env.seed  = env._seed
-    def render(mode):
-        return env._render(mode, close=False)
-    def close():
-        env._render("human", close=True)
-    env.render = render
-    env.close = close
+    env.render = partial(env._render, close=False)
+    env.close = partial(env._render, "human", close=True)


### PR DESCRIPTION
In `Env` object defining `_reset` or `_step` like roboschool, these functions are replaced by the local functions defined in `patch_deprecated_methods` when calling `env.make`.
This causes the following error when pickling it.

```
In [1]: import pickle
In [2]: import roboschool
In [3]: import gym
In [4]: e = gym.make("RoboschoolAnt-v1")
WARN: gym.spaces.Box autodetected dtype as <class 'numpy.float32'>. Please provide explicit dtype.
WARN: gym.spaces.Box autodetected dtype as <class 'numpy.float32'>. Please provide explicit dtype.
WARN: Environment '<class 'roboschool.gym_mujoco_walkers.RoboschoolAnt'>' has deprecated methods '_step' and '_reset' rather than 'step' and 'reset'. Compatibility code invoked. Set _gym_disable_underscore_compat = True to disable this behavior.
In [5]: pickle.dumps(e)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-5-25726dc74973> in <module>()
----> 1 pickle.dumps(e)
AttributeError: Can't pickle local object 'patch_deprecated_methods.<locals>.render'
```

In order to prevent this, the local function is changed to `functools.partial` in this pull request.