### PR TITLE
box2d kengz vs py

### DIFF
--- a/gym/envs/tests/spec_list.py
+++ b/gym/envs/tests/spec_list.py
@@ -11,8 +11,6 @@ def should_skip_env_spec_for_tests(spec):
         return True
     if (    'GoEnv' in ep or
             'HexEnv' in ep or
-            ep.startswith('gym.envs.box2d:') or
-            ep.startswith('gym.envs.box2d:') or
             (ep.startswith("gym.envs.atari") and not spec.id.startswith("Pong") and not spec.id.startswith("Seaquest"))
     ):
         logger.warn("Skipping tests for env {}".format(ep))

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from version import VERSION
 # Environment-specific dependencies.
 extras = {
   'atari': ['atari_py>=0.1.1', 'Pillow', 'PyOpenGL'],
-  'box2d': ['Box2D-kengz'],
+  'box2d': ['box2d-py'],
   'classic_control': ['PyOpenGL'],
   'mujoco': ['mujoco_py>=1.50', 'imageio'],
   'robotics': ['mujoco_py>=1.50', 'imageio'],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='gym',
                 if package.startswith('gym')],
       zip_safe=False,
       install_requires=[
-          'numpy>=1.10.4', 'requests>=2.0', 'six', 'pyglet>=1.2.0',
+          'scipy', 'numpy>=1.10.4', 'requests>=2.0', 'six', 'pyglet>=1.2.0',
       ],
       extras_require=extras,
       package_data={'gym': [

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     Pillow
     PyOpenGL
     pachi-py>=0.0.19
-    box2d-py
+    box2d-kengz
     doom_py>=0.0.11
     mujoco_py>=1.50.1,<1.50.2
     keras
@@ -38,7 +38,7 @@ deps =
     Pillow
     PyOpenGL
     pachi-py>=0.0.19
-    box2d-py
+    box2d-kengz
     doom_py>=0.0.11
     mujoco_py<1.0.0,>=0.4.3
     keras

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35
+envlist = py35, py27
 
 [testenv:py35]
 whitelist_externals=make
@@ -12,8 +12,6 @@ passenv=DISPLAY TRAVIS*
 deps =
     pytest
     mock
-    pachi-py>=0.0.19
-    doom_py>=0.0.11
     keras
     theano
     -e .[all]
@@ -26,8 +24,6 @@ passenv=DISPLAY TRAVIS*
 deps =
     pytest
     mock
-    pachi-py>=0.0.19
-    doom_py>=0.0.11
     keras
     theano
     -e .[all]

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     Pillow
     PyOpenGL
     pachi-py>=0.0.19
-    box2d-kengz
+    box2d-py
     doom_py>=0.0.11
     mujoco_py>=1.50.1,<1.50.2
     keras
@@ -38,7 +38,7 @@ deps =
     Pillow
     PyOpenGL
     pachi-py>=0.0.19
-    box2d-kengz
+    box2d-py
     doom_py>=0.0.11
     mujoco_py<1.0.0,>=0.4.3
     keras

--- a/tox.ini
+++ b/tox.ini
@@ -12,19 +12,11 @@ passenv=DISPLAY TRAVIS*
 deps =
     pytest
     mock
-    atari_py>=0.0.17
-    Pillow
-    PyOpenGL
     pachi-py>=0.0.19
-    box2d-py
     doom_py>=0.0.11
-    mujoco_py>=1.50.1,<1.50.2
     keras
     theano
-    numpy>=1.10.4
-    requests>=2.0
-    six
-    pyglet>=1.2.0
+    -e .[all]
 commands =
     pytest {posargs}
 
@@ -34,18 +26,10 @@ passenv=DISPLAY TRAVIS*
 deps =
     pytest
     mock
-    atari_py>=0.0.17
-    Pillow
-    PyOpenGL
     pachi-py>=0.0.19
-    box2d-py
     doom_py>=0.0.11
-    mujoco_py<1.0.0,>=0.4.3
     keras
     theano
-    numpy>=1.10.4
-    requests>=2.0
-    six
-    pyglet>=1.2.0
+    -e .[all]
 commands =
     pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, py27
+envlist = py35
 
 [testenv:py35]
 whitelist_externals=make
@@ -12,8 +12,6 @@ passenv=DISPLAY TRAVIS*
 deps =
     pytest
     mock
-    keras
-    theano
     -e .[all]
 commands =
     pytest {posargs}
@@ -24,8 +22,6 @@ passenv=DISPLAY TRAVIS*
 deps =
     pytest
     mock
-    keras
-    theano
     -e .[all]
 commands =
     pytest {posargs}


### PR DESCRIPTION
use box2d-py instead of box2d-kengz; and enable tests of environments that use box2d