### PR TITLE
Rendering fix for envs with outputs with odd-dimensions

### DIFF
--- a/gym/wrappers/monitoring/video_recorder.py
+++ b/gym/wrappers/monitoring/video_recorder.py
@@ -278,6 +278,7 @@ class ImageEncoder(object):
                      '-i', '-', # this used to be /dev/stdin, which is not Windows-friendly
 
                      # output
+                     '-vf', 'scale=trunc(iw/2)*2:trunc(ih/2)*2',
                      '-vcodec', 'libx264',
                      '-pix_fmt', 'yuv420p',
                      self.output_path


### PR DESCRIPTION
Due to YUV h264 encoding, image size has to be even. This just forces the input size to be even (by cropping the offending dimension).