### PR TITLE
Not sorting OrderedDict

### DIFF
--- a/gym/spaces/dict_space.py
+++ b/gym/spaces/dict_space.py
@@ -31,7 +31,7 @@ class Dict(Space):
     })
     """
     def __init__(self, spaces):
-        if isinstance(spaces, dict):
+        if isinstance(spaces, dict) and not isinstance(spaces, OrderedDict):
             spaces = OrderedDict(sorted(list(spaces.items())))
         if isinstance(spaces, list):
             spaces = OrderedDict(spaces)


### PR DESCRIPTION
If the input is already an OrderedDict, its keys were getting sorted (as `isinstance(spaces, dict)` evaluates to `True`), which is usually not desired.