### PR TITLE
Pass frameskip and repeat_action_probability to AtariEnv EzPickle

### DIFF
--- a/gym/envs/atari/atari_env.py
+++ b/gym/envs/atari/atari_env.py
@@ -23,7 +23,7 @@ class AtariEnv(gym.Env, utils.EzPickle):
         """Frameskip should be either a tuple (indicating a random range to
         choose from, with the top value exclude), or an int."""
 
-        utils.EzPickle.__init__(self, game, obs_type)
+        utils.EzPickle.__init__(self, game, obs_type, frameskip, repeat_action_probability)
         assert obs_type in ('ram', 'image')
 
         self.game_path = atari_py.get_game_path(game)


### PR DESCRIPTION
AtariEnv currently does not pass `frameskip` or `repeat_action_probability` to the EzPickle constructor. This leads to environments restored from pickle not being initialised correctly:

```
import gym, pickle
env = gym.make('PongNoFrameskip-v4')
print(env.unwrapped.frameskip)
```
```
1
```
```
env2 = pickle.loads(pickle.dumps(env))
print(env2.unwrapped.frameskip)
```
```
(2, 5)
```

This pull request fixes it.