### PR TITLE
rm unnecessary `__contains__` duplicate code

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -215,6 +215,8 @@ class Space(object):
         """
         raise NotImplementedError
 
+    __contains__ = contains
+
     def to_jsonable(self, sample_n):
         """Convert a batch of samples from this space to a JSONable data type."""
         # By default, assume identity is JSONable

--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -38,8 +38,6 @@ class Box(gym.Space):
     def contains(self, x):
         return x.shape == self.shape and (x >= self.low).all() and (x <= self.high).all()
 
-    __contains__ = contains
-
     def to_jsonable(self, sample_n):
         return np.array(sample_n).tolist()
     def from_jsonable(self, sample_n):

--- a/gym/spaces/dict_space.py
+++ b/gym/spaces/dict_space.py
@@ -51,8 +51,6 @@ class Dict(gym.Space):
                 return False
         return True
 
-    __contains__ = contains
-
     def __repr__(self):
         return "Dict(" + ", ". join([k + ":" + str(s) for k, s in self.spaces.items()]) + ")"
 

--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -22,8 +22,6 @@ class Discrete(gym.Space):
             return False
         return as_int >= 0 and as_int < self.n
 
-    __contains__ = contains
-
     def __repr__(self):
         return "Discrete(%d)" % self.n
     def __eq__(self, other):

--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -10,8 +10,6 @@ class MultiBinary(gym.Space):
     def contains(self, x):
         return ((x==0) | (x==1)).all()
 
-    __contains__ = contains
-
     def to_jsonable(self, sample_n):
         return np.array(sample_n).tolist()
     def from_jsonable(self, sample_n):

--- a/gym/spaces/multi_discrete.py
+++ b/gym/spaces/multi_discrete.py
@@ -13,9 +13,7 @@ class MultiDiscrete(gym.Space):
         return (gym.spaces.np_random.rand(self.nvec.size) * self.nvec).astype(self.dtype)
     def contains(self, x):
         return (0 <= x).all() and (x < self.nvec).all() and x.dtype.kind in 'ui'
-    
-    __contains__ = contains
-    
+
     def to_jsonable(self, sample_n):
         return [sample.tolist() for sample in sample_n]
     def from_jsonable(self, sample_n):

--- a/gym/spaces/tuple_space.py
+++ b/gym/spaces/tuple_space.py
@@ -20,8 +20,6 @@ class Tuple(gym.Space):
         return isinstance(x, tuple) and len(x) == len(self.spaces) and all(
             space.contains(part) for (space,part) in zip(self.spaces,x))
 
-    __contains__ = contains
-
     def __repr__(self):
         return "Tuple(" + ", ". join([str(s) for s in self.spaces]) + ")"
 


### PR DESCRIPTION
`contains` really should not exist when it does exactly what the builtin
magic method `__contains__` was meant for, but that would break backward
compatibility.


@joschu This implements the change you mentioned.