### PR TITLE
allow nd array for multidiscrete

### DIFF
--- a/gym/spaces/multi_discrete.py
+++ b/gym/spaces/multi_discrete.py
@@ -7,10 +7,9 @@ class MultiDiscrete(gym.Space):
         nvec: vector of counts of each categorical variable
         """
         self.nvec = np.asarray(nvec, dtype=np.int32)
-        assert self.nvec.ndim == 1, 'nvec should be a 1d array (or list) of ints'
-        gym.Space.__init__(self, (self.nvec.size,), np.int8)
+        gym.Space.__init__(self, (self.nvec.shape,), np.int8)
     def sample(self):
-        return (gym.spaces.np_random.rand(self.nvec.size) * self.nvec).astype(self.dtype)
+        return (gym.spaces.np_random.random_sample(self.nvec.shape) * self.nvec).astype(self.dtype)
     def contains(self, x):
         return (0 <= x).all() and (x < self.nvec).all() and x.dtype.kind in 'ui'
     


### PR DESCRIPTION
Fixes #1148
Currently multidiscrete only supports 1 dimensional array which seems like an unnessecary restriction.
