### PR TITLE
add maxwidth parameter to viewer; resize image if it’s larger

### DIFF
--- a/gym/envs/classic_control/rendering.py
+++ b/gym/envs/classic_control/rendering.py
@@ -310,14 +310,20 @@ class Image(Geom):
 # ================================================================
 
 class SimpleImageViewer(object):
-    def __init__(self, display=None):
+    def __init__(self, display=None, maxwidth=500):
         self.window = None
         self.isopen = False
         self.display = display
+        self.maxwidth = maxwidth
     def imshow(self, arr):
         if self.window is None:
             height, width, _channels = arr.shape
-            self.window = pyglet.window.Window(width=4*width, height=4*height, display=self.display, vsync=False, resizable=True)
+            if width > self.maxwidth:
+                scale = self.maxwidth / width
+                width = int(scale * width)
+                height = int(scale * height)
+            self.window = pyglet.window.Window(width=width, height=height, 
+                display=self.display, vsync=False, resizable=True)            
             self.width = width
             self.height = height
             self.isopen = True
@@ -332,11 +338,17 @@ class SimpleImageViewer(object):
                 self.isopen = False
 
         assert len(arr.shape) == 3, "You passed in an image with the wrong number shape"
-        image = pyglet.image.ImageData(arr.shape[1], arr.shape[0], 'RGB', arr.tobytes(), pitch=arr.shape[1]*-3)
+        image = pyglet.image.ImageData(arr.shape[1], arr.shape[0], 
+            'RGB', arr.tobytes(), pitch=arr.shape[1]*-3)
+        gl.glTexParameteri(gl.GL_TEXTURE_2D, 
+            gl.GL_TEXTURE_MAG_FILTER, gl.GL_NEAREST)
+        texture = image.get_texture()
+        texture.width = self.width
+        texture.height = self.height
         self.window.clear()
         self.window.switch_to()
         self.window.dispatch_events()
-        image.blit(0, 0, width=self.window.width, height=self.window.height)
+        texture.blit(0, 0) # draw
         self.window.flip()
     def close(self):
         if self.isopen:


### PR DESCRIPTION
Some envs produce a very large image when you try to render them.
I modified SimpleImageViewer to resize the image if you try to render too large of an image.