### PR TITLE
registration.py depends on pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='gym',
                 if package.startswith('gym')],
       zip_safe=False,
       install_requires=[
-          'scipy', 'numpy>=1.10.4', 'requests>=2.0', 'six', 'pyglet>=1.2.0',
+          'scipy', 'numpy>=1.10.4', 'requests>=2.0', 'six', 'pyglet>=1.2.0', 'setuptools',
       ],
       extras_require=extras,
       package_data={'gym': [


### PR DESCRIPTION
Fix the following dependency.

```python
In [1]: import gym
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-1-c727ea424a25> in <module>()
----> 1 import gym

/misc/vlgscratch4/LecunGroup/atcold/anaconda3/lib/python3.6/site-packages/gym/__init__.py in <module>()
      9 
     10 from gym.core import Env, GoalEnv, Space, Wrapper, ObservationWrapper, ActionWrapper, RewardWrapper
---> 11 from gym.envs import make, spec
     12 from gym import wrappers, spaces, logger
     13 

/misc/vlgscratch4/LecunGroup/atcold/anaconda3/lib/python3.6/site-packages/gym/envs/__init__.py in <module>()
----> 1 from gym.envs.registration import registry, register, make, spec
      2 
      3 # Algorithmic
      4 # ----------------------------------------
      5 

/misc/vlgscratch4/LecunGroup/atcold/anaconda3/lib/python3.6/site-packages/gym/envs/registration.py in <module>()
----> 1 import pkg_resources
      2 import re
      3 from gym import error, logger
      4 
      5 # This format is true today, but it's *not* an official spec.

ModuleNotFoundError: No module named 'pkg_resources'
```