### PR TITLE
Support kwargs for callable entry point

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -80,7 +80,7 @@ class EnvSpec(object):
             raise error.Error('Attempting to make deprecated env {}. (HINT: is there a newer registered version of this env?)'.format(self.id))
 
         elif callable(self._entry_point):
-            env = self._entry_point()
+            env = self._entry_point(**self._kwargs)
         else:
             cls = load(self._entry_point)
             env = cls(**self._kwargs)


### PR DESCRIPTION
Since the code already supports using callable entry_points, it seems reasonable to allow this callable to take in parameters.

I have a use case for this, and I imagine it could be useful for others who want to use a function to create environments (rather than through constructor + kwargs).