### PR TITLE
json encode int8 and int16

### DIFF
--- a/gym/utils/json_utils.py
+++ b/gym/utils/json_utils.py
@@ -10,6 +10,10 @@ def json_encode_np(obj):
         return float(obj)
     elif isinstance(obj, np.float64):
         return float(obj)
+    elif isinstance(obj, np.int8):
+        return int(obj)
+    elif isinstance(obj, np.int16):
+        return int(obj)
     elif isinstance(obj, np.int32):
         return int(obj)
     elif isinstance(obj, np.int64):


### PR DESCRIPTION
currently some of the numpy types are missing from the json encoding. this adds support for int8 and int16.