### PR TITLE
Fix RobotEnv rgb_array rendering

### DIFF
--- a/gym/envs/robotics/fetch_env.py
+++ b/gym/envs/robotics/fetch_env.py
@@ -185,3 +185,6 @@ class FetchEnv(robot_env.RobotEnv):
         self.initial_gripper_xpos = self.sim.data.get_site_xpos('robot0:grip').copy()
         if self.has_object:
             self.height_offset = self.sim.data.get_site_xpos('object0')[2]
+
+    def render(self, mode='human', width=500, height=500):
+        return super(FetchEnv, self).render(mode, width, height)

--- a/gym/envs/robotics/hand_env.py
+++ b/gym/envs/robotics/hand_env.py
@@ -47,3 +47,6 @@ class HandEnv(robot_env.RobotEnv):
         self.viewer.cam.distance = 0.5
         self.viewer.cam.azimuth = 55.
         self.viewer.cam.elevation = -25.
+
+    def render(self, mode='human', width=500, height=500):
+        return super(HandEnv, self).render(mode, width, height)

--- a/gym/envs/robotics/robot_env.py
+++ b/gym/envs/robotics/robot_env.py
@@ -11,6 +11,7 @@ try:
 except ImportError as e:
     raise error.DependencyNotInstalled("{}. (HINT: you need to install mujoco_py, and also perform the setup instructions here: https://github.com/openai/mujoco-py/.)".format(e))
 
+DEFAULT_SIZE = 500
 
 class RobotEnv(gym.GoalEnv):
     def __init__(self, model_path, initial_qpos, n_actions, n_substeps):
@@ -24,6 +25,7 @@ class RobotEnv(gym.GoalEnv):
         model = mujoco_py.load_model_from_path(fullpath)
         self.sim = mujoco_py.MjSim(model, nsubsteps=n_substeps)
         self.viewer = None
+        self._viewers = {}
 
         self.metadata = {
             'render.modes': ['human', 'rgb_array'],
@@ -85,23 +87,28 @@ class RobotEnv(gym.GoalEnv):
         if self.viewer is not None:
             # self.viewer.finish()
             self.viewer = None
+            self._viewers = {}
 
-    def render(self, mode='human'):
+    def render(self, mode='human', width=DEFAULT_SIZE, height=DEFAULT_SIZE):
         self._render_callback()
         if mode == 'rgb_array':
-            self._get_viewer().render()
+            self._get_viewer(mode).render(width, height)
             # window size used for old mujoco-py:
-            width, height = 500, 500
-            data = self._get_viewer().read_pixels(width, height, depth=False)
+            data = self._get_viewer(mode).read_pixels(width, height, depth=False)
             # original image is upside-down, so flip it
             return data[::-1, :, :]
         elif mode == 'human':
-            self._get_viewer().render()
+            self._get_viewer(mode).render()
 
-    def _get_viewer(self):
+    def _get_viewer(self, mode):
+        self.viewer = self._viewers.get(mode)
         if self.viewer is None:
-            self.viewer = mujoco_py.MjViewer(self.sim)
+            if mode == 'human':
+                self.viewer = mujoco_py.MjViewer(self.sim)
+            elif mode == 'rgb_array':
+                self.viewer = mujoco_py.MjRenderContextOffscreen(self.sim, device_id=-1)
             self._viewer_setup()
+            self._viewers[mode] = self.viewer
         return self.viewer
 
     # Extension methods


### PR DESCRIPTION
Issue #1000 also applies to `RobotEnv`: when `env.render` is called with `mode='rgb_array'`, currently only a 500x500 square from the bottom-left corner of the image is drawn. We fix it here using the same patch.

(As Issue #1000 notes, this code is shared between `RobotEnv` and `MujocoEnv`. Ideally we would move this to a more abstract class. I'm not sure what the best way of doing this is; for the time being I propose we just put up with a kludgy fix in two separate places.)