### PR TITLE
CartPole/Acrobot rendering fix

### DIFF
--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -194,7 +194,7 @@ class AcrobotEnv(core.Env):
 
         self.viewer.draw_line((-2.2, 1), (2.2, 1))
         for ((x,y),th) in zip(xys, thetas):
-            l,r,t,b = 0, 1, .1, -.1
+            l,r,t,b = 0, self.LINK_LENGTH_1, .1, -.1
             jtransform = rendering.Transform(rotation=th, translation=(x,y))
             link = self.viewer.draw_polygon([(l,b), (l,t), (r,t), (r,b)])
             link.add_attr(jtransform)

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -179,7 +179,8 @@ class AcrobotEnv(core.Env):
 
         if self.viewer is None:
             self.viewer = rendering.Viewer(500,500)
-            self.viewer.set_bounds(-2.2,2.2,-2.2,2.2)
+            bound = self.LINK_LENGTH_1 + self.LINK_LENGTH_2 + 0.2  # 2.2 for default
+            self.viewer.set_bounds(-bound,bound,-bound,bound)
 
         if s is None: return None
 

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -192,10 +192,11 @@ class AcrobotEnv(core.Env):
 
         xys = np.array([[0,0], p1, p2])[:,::-1]
         thetas = [s[0]-np.pi/2, s[0]+s[1]-np.pi/2]
+        link_lengths = [self.LINK_LENGTH_1, self.LINK_LENGTH_2]
 
         self.viewer.draw_line((-2.2, 1), (2.2, 1))
-        for ((x,y),th) in zip(xys, thetas):
-            l,r,t,b = 0, self.LINK_LENGTH_1, .1, -.1
+        for ((x,y),th,llen) in zip(xys, thetas, link_lengths):
+            l,r,t,b = 0, llen, .1, -.1
             jtransform = rendering.Transform(rotation=th, translation=(x,y))
             link = self.viewer.draw_polygon([(l,b), (l,t), (r,t), (r,b)])
             link.add_attr(jtransform)

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -142,7 +142,7 @@ class CartPoleEnv(gym.Env):
         scale = screen_width/world_width
         carty = 100 # TOP OF CART
         polewidth = 10.0
-        polelen = scale * 1.0
+        polelen = scale * self.length
         cartwidth = 50.0
         cartheight = 30.0
 
@@ -171,7 +171,14 @@ class CartPoleEnv(gym.Env):
             self.track.set_color(0,0,0)
             self.viewer.add_geom(self.track)
 
+            self._pole_geom = pole
+
         if self.state is None: return None
+
+        # Edit the pole polygon vertex
+        pole = self._pole_geom
+        l,r,t,b = -polewidth/2,polewidth/2,polelen-polewidth/2,-polewidth/2
+        pole.v = [(l,b), (l,t), (r,t), (r,b)]
 
         x = self.state
         cartx = x[0]*scale+screen_width/2.0 # MIDDLE OF CART

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -142,7 +142,7 @@ class CartPoleEnv(gym.Env):
         scale = screen_width/world_width
         carty = 100 # TOP OF CART
         polewidth = 10.0
-        polelen = scale * self.length
+        polelen = scale * (2 * self.length)
         cartwidth = 50.0
         cartheight = 30.0
 


### PR DESCRIPTION
Modified code so that CartPole/Acrobot still render correctly when pole/link lengths are changed. Unless the length values are changed by the user, the new code should be equivalent to current version (i.e., the task should remain unmodified).

### Examples:

Acrobot w/ longer link lengths (**current** version has phantom links):
<img width="200" alt="screen shot 2018-10-05 at 3 08 42 pm" src="https://user-images.githubusercontent.com/5475622/46562450-f7ae6180-c8b0-11e8-89be-5c90307867a3.png">

Acrobot w/ longer link lengths (**fixed** version has properly rendered links, and expands the viewer to accommodate link size):
<img width="200" alt="screen shot 2018-10-05 at 3 08 25 pm" src="https://user-images.githubusercontent.com/5475622/46562455-fd0bac00-c8b0-11e8-8b12-fdb2c2247305.png">

CartPole w/ longer link lengths (**current** version doesn't render longer pole):
<img width="200" alt="screen shot 2018-10-05 at 3 14 07 pm" src="https://user-images.githubusercontent.com/5475622/46562577-86bb7980-c8b1-11e8-80a8-a1e32cd9de06.png">

CartPole w/ longer link lengths (**fixed** version properly renders longer/shorter poles):
<img width="200" alt="screen shot 2018-10-05 at 3 14 29 pm" src="https://user-images.githubusercontent.com/5475622/46562623-d4d07d00-c8b1-11e8-85e3-ac4c20a0455f.png">
