### PR TITLE
Fixed typo

### DIFF
--- a/gym/envs/toy_text/taxi.py
+++ b/gym/envs/toy_text/taxi.py
@@ -24,7 +24,7 @@ class TaxiEnv(discrete.DiscreteEnv):
     There are four designated locations in the grid world indicated by R(ed), B(lue), G(reen), and Y(ellow). When the episode starts, the taxi starts off at a random square and the passenger is at a random location. The taxi drive to the passenger's location, pick up the passenger, drive to the passenger's destination (another one of the four specified locations), and then drop off the passenger. Once the passenger is dropped off, the episode ends.
 
     Observations: 
-    There are 500 discrete actions since there are 25 taxi positions, 5 possible locations of the passenger (including the case when the passenger is the taxi), and 4 destination locations. 
+    There are 500 discrete states since there are 25 taxi positions, 5 possible locations of the passenger (including the case when the passenger is the taxi), and 4 destination locations. 
     
     Actions: 
     There are 6 discrete deterministic actions:


### PR DESCRIPTION
Fixed the typo 'actions' to 'states', which is what is implied by context.