### PR TITLE
fix degree character encoding problem

### DIFF
--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 Classic cart-pole system implemented by Rich Sutton et al.
 Copied from http://incompleteideas.net/sutton/book/code/pole.c


### PR DESCRIPTION
SyntaxError: Non-ASCII character '\xc2' in file /home/asc/gym/gym/envs/classic_control/cartpole.py on line 27, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

while running Atari game on Linux.