### PR TITLE
Move 3 toy_text environment to the correct env_type

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -181,20 +181,20 @@ register(
 
 register(
     id='Taxi-v2',
-    entry_point='gym.envs.toy_text.taxi:TaxiEnv',
+    entry_point='gym.envs.toy_text:TaxiEnv',
     reward_threshold=8, # optimum = 8.46
     max_episode_steps=200,
 )
 
 register(
     id='GuessingGame-v0',
-    entry_point='gym.envs.toy_text.guessing_game:GuessingGame',
+    entry_point='gym.envs.toy_text:GuessingGame',
     max_episode_steps=200,
 )
 
 register(
     id='HotterColder-v0',
-    entry_point='gym.envs.toy_text.hotter_colder:HotterColder',
+    entry_point='gym.envs.toy_text:HotterColder',
     max_episode_steps=200,
 )
 

--- a/gym/envs/toy_text/__init__.py
+++ b/gym/envs/toy_text/__init__.py
@@ -7,3 +7,6 @@ from gym.envs.toy_text.guessing_game import GuessingGame
 from gym.envs.toy_text.kellycoinflip import KellyCoinflipEnv
 from gym.envs.toy_text.kellycoinflip import KellyCoinflipGeneralizedEnv
 from gym.envs.toy_text.cliffwalking import CliffWalkingEnv
+from gym.envs.toy_text.taxi import TaxiEnv
+from gym.envs.toy_text.guessing_game import GuessingGame
+from gym.envs.toy_text.hotter_colder import HotterColder


### PR DESCRIPTION
If you run the snippet below [(taken from `baselines` `run.py` )](https://github.com/openai/baselines/blob/master/baselines/run.py#L34-L37), you will see 3 toy text (Taxi, GuessingGame and HotterColder) environments are registered a bit differently:
```python
import gym
for env in gym.envs.registry.all(): 
    env_type =  env._entry_point.split(':')[0].split('.')[-1] 
    print(env._entry_point, env_type, env.id)
```

Currently:
```
gym.envs.box2d:CarRacing box2d CarRacing-v0
gym.envs.toy_text:BlackjackEnv toy_text Blackjack-v0
gym.envs.toy_text:KellyCoinflipEnv toy_text KellyCoinflip-v0
gym.envs.toy_text:KellyCoinflipGeneralizedEnv toy_text KellyCoinflipGeneralized-v0
gym.envs.toy_text:FrozenLakeEnv toy_text FrozenLake-v0
gym.envs.toy_text:FrozenLakeEnv toy_text FrozenLake8x8-v0
gym.envs.toy_text:CliffWalkingEnv toy_text CliffWalking-v0
gym.envs.toy_text:NChainEnv toy_text NChain-v0
gym.envs.toy_text:RouletteEnv toy_text Roulette-v0
gym.envs.toy_text.taxi:TaxiEnv taxi Taxi-v2
gym.envs.toy_text.guessing_game:GuessingGame guessing_game GuessingGame-v0
gym.envs.toy_text.hotter_colder:HotterColder hotter_colder HotterColder-v0
gym.envs.mujoco:ReacherEnv mujoco Reacher-v2
```

Proposed  change:
```
gym.envs.box2d:CarRacing box2d CarRacing-v0
gym.envs.toy_text:BlackjackEnv toy_text Blackjack-v0
gym.envs.toy_text:KellyCoinflipEnv toy_text KellyCoinflip-v0
gym.envs.toy_text:KellyCoinflipGeneralizedEnv toy_text KellyCoinflipGeneralized-v0
gym.envs.toy_text:FrozenLakeEnv toy_text FrozenLake-v0
gym.envs.toy_text:FrozenLakeEnv toy_text FrozenLake8x8-v0
gym.envs.toy_text:CliffWalkingEnv toy_text CliffWalking-v0
gym.envs.toy_text:NChainEnv toy_text NChain-v0
gym.envs.toy_text:RouletteEnv toy_text Roulette-v0
gym.envs.toy_text:TaxiEnv toy_text Taxi-v2
gym.envs.toy_text:GuessingGame toy_text GuessingGame-v0
gym.envs.toy_text:HotterColder toy_text HotterColder-v0
gym.envs.mujoco:ReacherEnv mujoco Reacher-v2
```