### PR TITLE
Fix in keyword with Spaces

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -215,7 +215,8 @@ class Space(object):
         """
         raise NotImplementedError
 
-    __contains__ = contains
+    def __contains__(self, x):
+        return self.contains(x)
 
     def to_jsonable(self, sample_n):
         """Convert a batch of samples from this space to a JSONable data type."""


### PR DESCRIPTION
Binding `__contains__` to the Space class' `contains` method this way prevents overriding it in subclasses, which leads to `NotImplementedException`s when trying to do things like 

    2 in gym.spaces.Discrete(2)