### PR TITLE
Support kwargs in gym.make and export register

### DIFF
--- a/gym/__init__.py
+++ b/gym/__init__.py
@@ -8,7 +8,7 @@ from gym.utils import reraise
 from gym.version import VERSION as __version__
 
 from gym.core import Env, GoalEnv, Space, Wrapper, ObservationWrapper, ActionWrapper, RewardWrapper
-from gym.envs import make, spec
+from gym.envs import make, spec, register
 from gym import logger
 
-__all__ = ["Env", "Space", "Wrapper", "make", "spec"]
+__all__ = ["Env", "Space", "Wrapper", "make", "spec", "register"]

--- a/gym/envs/tests/test_registration.py
+++ b/gym/envs/tests/test_registration.py
@@ -5,9 +5,19 @@ from gym.envs import registration
 from gym.envs.classic_control import cartpole
 
 class ArgumentEnv(gym.Env):
-    def __init__(self, arg):
-        self.arg = arg
-gym.register(id='test.ArgumentEnv-v0', entry_point='gym.envs.tests.test_registration:ArgumentEnv')
+    def __init__(self, arg1, arg2, arg3):
+        self.arg1 = arg1
+        self.arg2 = arg2
+        self.arg3 = arg3
+
+gym.register(
+    id='test.ArgumentEnv-v0',
+    entry_point='gym.envs.tests.test_registration:ArgumentEnv',
+    kwargs={
+        'arg1': 'arg1',
+        'arg2': 'arg2',
+    }
+)
 
 def test_make():
     env = envs.make('CartPole-v0')
@@ -15,10 +25,12 @@ def test_make():
     assert isinstance(env.unwrapped, cartpole.CartPoleEnv)
 
 def test_make_with_kwargs():
-    env = envs.make('test.ArgumentEnv-v0', arg='data')
+    env = envs.make('test.ArgumentEnv-v0', arg2='override_arg2', arg3='override_arg3')
     assert env.spec.id == 'test.ArgumentEnv-v0'
     assert isinstance(env.unwrapped, ArgumentEnv)
-    assert env.arg == 'data'
+    assert env.arg1 == 'arg1'
+    assert env.arg2 == 'override_arg2'
+    assert env.arg3 == 'override_arg3'
 
 def test_make_deprecated():
     try:

--- a/gym/envs/tests/test_registration.py
+++ b/gym/envs/tests/test_registration.py
@@ -1,12 +1,24 @@
 # -*- coding: utf-8 -*-
+import gym
 from gym import error, envs
 from gym.envs import registration
 from gym.envs.classic_control import cartpole
+
+class ArgumentEnv(gym.Env):
+    def __init__(self, arg):
+        self.arg = arg
+gym.register(id='test.ArgumentEnv-v0', entry_point='gym.envs.tests.test_registration:ArgumentEnv')
 
 def test_make():
     env = envs.make('CartPole-v0')
     assert env.spec.id == 'CartPole-v0'
     assert isinstance(env.unwrapped, cartpole.CartPoleEnv)
+
+def test_make_with_kwargs():
+    env = envs.make('test.ArgumentEnv-v0', arg='data')
+    assert env.spec.id == 'test.ArgumentEnv-v0'
+    assert isinstance(env.unwrapped, ArgumentEnv)
+    assert env.arg == 'data'
 
 def test_make_deprecated():
     try:


### PR DESCRIPTION
We avoided adding kwargs for a long time in order to encourage people to statically register their environment definitions. However, over time we've found a few important use-cases for kwargs, such as:

- Runtime-specific objects, such as which GPU to run the environment on
- Parametrized environments, which can have an infinite number of meaningful variants

The latter breaks the invariant that the environment ID alone determines the semantics of the environment, but it's an advanced use-case and such users should be able to manage this on their own.

This PR also exports the `register` method so people can register their own environments more easily.