### PR TITLE
Take out call to `.reset` in `DiscreteEnv.__init__`

### DIFF
--- a/gym/envs/toy_text/discrete.py
+++ b/gym/envs/toy_text/discrete.py
@@ -39,7 +39,8 @@ class DiscreteEnv(Env):
         self.observation_space = spaces.Discrete(self.nS)
 
         self.seed()
-        self.reset()
+        self.s = categorical_sample(self.isd, self.np_random)
+        self.lastaction=None
 
     def seed(self, seed=None):
         self.np_random, seed = seeding.np_random(seed)


### PR DESCRIPTION
When inheriting from `DiscreteEnv`, the call to `reset` in `__init__` can cause a major hassle. To illustrate:
```python
class MyDiscreteEnv(DiscreteEnv):
    def __init__(*args, **kwargs):
        super().__init__(*args, **kwargs)
        self.x = f(self.s)  # or f(some other attribute set in `super().__init__`)

    def reset(self):
        g(self.x)  # <- uh oh! 
        return super().reset()
```
The line marked `uh-oh!` will throw an attribute error when I initialize `MyDiscreteEnv` because of the call to `self.reset()` in `DiscreteEnv.__init__` (`self.x` will not have been defined yet).