### PR TITLE
combine monitor close methods (fixes #1282)

### DIFF
--- a/gym/wrappers/monitor.py
+++ b/gym/wrappers/monitor.py
@@ -40,13 +40,6 @@ class Monitor(Wrapper):
 
         return observation
 
-    def close(self):
-        super(Monitor, self)._close()
-
-        # _monitor will not be set if super(Monitor, self).__init__ raises, this check prevents a confusing error message
-        if getattr(self, '_monitor', None):
-            self.close()
-
     def set_monitor_mode(self, mode):
         logger.info("Setting the monitor mode is deprecated and will be removed soon")
         self._set_mode(mode)
@@ -138,6 +131,12 @@ class Monitor(Wrapper):
 
     def close(self):
         """Flush all monitor data to disk and close any open rending windows."""
+        super(Monitor, self).close()
+
+        # _monitor will not be set if super(Monitor, self).__init__ raises, this check prevents a confusing error message
+        if not hasattr(self, '_monitor'):
+            return
+
         if not self.enabled:
             return
         self.stats_recorder.close()


### PR DESCRIPTION
Looks like `Monitor` had two definitions of the `close()` method, probably left over from the `_close()` => `close()` change.