### PR TITLE
Switch to np.frombuffer in classic_control/rendering.py

### DIFF
--- a/gym/envs/classic_control/rendering.py
+++ b/gym/envs/classic_control/rendering.py
@@ -93,7 +93,7 @@ class Viewer(object):
         if return_rgb_array:
             buffer = pyglet.image.get_buffer_manager().get_color_buffer()
             image_data = buffer.get_image_data()
-            arr = np.fromstring(image_data.data, dtype=np.uint8, sep='')
+            arr = np.frombuffer(image_data.data, dtype=np.uint8)
             # In https://github.com/openai/gym-http-api/issues/2, we
             # discovered that someone using Xmonad on Arch was having
             # a window of size 598 x 398, though a 600 x 400 window


### PR DESCRIPTION
This fixes the deprecation warning when rendering classic control or Box2D environments:

```
/path/to/gym/envs/classic_control/rendering.py:96: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
  arr = np.fromstring(image_data.data, dtype=np.uint8, sep='')
```