### PR TITLE
kwargs on reset for Reward and Action Wrapper

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -283,8 +283,8 @@ class ObservationWrapper(Wrapper):
 
 
 class RewardWrapper(Wrapper):
-    def reset(self):
-        return self.env.reset()
+    def reset(self, **kwargs):
+        return self.env.reset(**kwargs)
 
     def step(self, action):
         observation, reward, done, info = self.env.step(action)
@@ -300,8 +300,8 @@ class ActionWrapper(Wrapper):
         action = self.action(action)
         return self.env.step(action)
 
-    def reset(self):
-        return self.env.reset()
+    def reset(self, **kwargs):
+        return self.env.reset(**kwargs)
 
     def action(self, action):
         deprecated_warn_once("%s doesn't implement 'action' method. Maybe it implements deprecated '_action' method." % type(self))


### PR DESCRIPTION
Was having trouble passing reset arguments through some wrappers and traced it to the ActionWrapper and RewardWrapper not using reset(**kwargs) -- unlike ObservationWrapper for example. The simple fix of just adding that in seems to work for anything I've been doing