### PR TITLE
Add verbosity to CarRacing-v0

### DIFF
--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -386,7 +386,7 @@ class CarRacing(gym.Env, EzPickle):
             self.human_render = True
             win.clear()
             t = self.transform
-            gl.glViewport(0, 0, 2 * WINDOW_W, 2 * WINDOW_H)
+            gl.glViewport(0, 0, WINDOW_W, WINDOW_H)
             t.enable()
             self.render_road()
             for geom in self.viewer.onetime_geoms:

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -104,7 +104,7 @@ class CarRacing(gym.Env, EzPickle):
         'video.frames_per_second' : FPS
     }
 
-    def __init__(self):
+    def __init__(self, verbose=1):
         EzPickle.__init__(self)
         self.seed()
         self.contactListener_keepref = FrictionDetector(self)
@@ -116,6 +116,7 @@ class CarRacing(gym.Env, EzPickle):
         self.car = None
         self.reward = 0.0
         self.prev_reward = 0.0
+        self.verbose = verbose
 
         self.action_space = spaces.Box( np.array([-1,0,0]), np.array([+1,+1,+1]), dtype=np.float32)  # steer, gas, brake
         self.observation_space = spaces.Box(low=0, high=255, shape=(STATE_H, STATE_W, 3), dtype=np.uint8)
@@ -214,7 +215,8 @@ class CarRacing(gym.Env, EzPickle):
             elif pass_through_start and i1==-1:
                 i1 = i
                 break
-        print("Track generation: %i..%i -> %i-tiles track" % (i1, i2, i2-i1))
+        if self.verbose == 1:
+            print("Track generation: %i..%i -> %i-tiles track" % (i1, i2, i2-i1))
         assert i1!=-1
         assert i2!=-1
 
@@ -287,7 +289,8 @@ class CarRacing(gym.Env, EzPickle):
         while True:
             success = self._create_track()
             if success: break
-            print("retry to generate track (normal if there are not many of this messages)")
+            if self.verbose == 1:
+                print("retry to generate track (normal if there are not many of this messages)")
         self.car = Car(self.world, *self.track[0][1:4])
 
         return self.step(None)[0]


### PR DESCRIPTION
While using the CarRacing-v0 environment, stdout is drowned with messages about track generation. This PR allows this to be disabled as follows:

```python
import gym
env = gym.make("CarRacing-v0", verbose=0)
```

The default value for verbose is currently 1 to continue previous behaviour by default.

**EDIT**: Edited for use of kwargs as suggested by @pzhokhov 