### PR TITLE
import modules when specified to gym.make

### DIFF
--- a/gym/envs/README.md
+++ b/gym/envs/README.md
@@ -90,6 +90,8 @@ ant.AntEnv
       ...
   ```
 
+* After you have installed your package with `pip install -e gym-foo`, you can create an instance of the environment with `gym.make('gym_foo:foo-v0')`
+
 ## How to add new environments to Gym, within this repo (not recommended for new environments)
 
 1. Write your environment in an existing collection or a new collection. All collections are subfolders of `/gym/envs`.

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -1,4 +1,5 @@
 import re
+import importlib
 from gym import error, logger
 
 # This format is true today, but it's *not* an official spec.
@@ -8,11 +9,13 @@ from gym import error, logger
 # to include an optional username.
 env_id_re = re.compile(r'^(?:[\w:-]+\/)?([\w:.-]+)-v(\d+)$')
 
+
 def load(name):
-    import pkg_resources # takes ~400ms to load, so we import it lazily
-    entry_point = pkg_resources.EntryPoint.parse('x={}'.format(name))
-    result = entry_point.resolve()
-    return result
+    mod_name, attr_name = name.split(":")
+    mod = importlib.import_module(mod_name)
+    fn = getattr(mod, attr_name)
+    return fn
+
 
 class EnvSpec(object):
     """A specification for a particular instance of the environment. Used
@@ -114,12 +117,12 @@ class EnvRegistry(object):
     def __init__(self):
         self.env_specs = {}
 
-    def make(self, id, **kwargs):
+    def make(self, path, **kwargs):
         if len(kwargs) > 0:
-            logger.info('Making new env: %s (%s)', id, kwargs)
+            logger.info('Making new env: %s (%s)', path, kwargs)
         else:
-            logger.info('Making new env: %s', id)
-        spec = self.spec(id)
+            logger.info('Making new env: %s', path)
+        spec = self.spec(path)
         env = spec.make(**kwargs)
         # We used to have people override _reset/_step rather than
         # reset/step. Set _gym_disable_underscore_compat = True on
@@ -138,7 +141,16 @@ class EnvRegistry(object):
     def all(self):
         return self.env_specs.values()
 
-    def spec(self, id):
+    def spec(self, path):
+        if ':' in path:
+            mod_name, _sep, id = path.partition(':')
+            try:
+                importlib.import_module(mod_name)
+            except ModuleNotFoundError:
+                raise error.Error('A module ({}) was specified for the environment but was not found, make sure the package is installed with `pip install` before calling `gym.make()`'.format(mod_name))
+        else:
+            id = path
+
         match = env_id_re.search(id)
         if not match:
             raise error.Error('Attempted to look up malformed environment ID: {}. (Currently all IDs must be of the form {}.)'.format(id.encode('utf-8'), env_id_re.pattern))


### PR DESCRIPTION
Right now in order to use `gym.make()` you must first register an environment.  This works fine for environments included in gym itself, but for environments in external packages you must import all packages that you need environments from.  This can look like this: https://github.com/openai/baselines/blob/master/baselines/run.py#L21 and also leaves around a number of unused imports (since they are only used for their side-effects of calling `register()`).

One alternative would be to allow the user to specify the module to import, so instead of `gym.make('gvgai-sokoban-lvl0-v0')` you could do `gym.make('gym_gvgai:gvgai-sokoban-lvl0-v0') `.  The python module being imported must still call register, but this means that it's not a requirement to import the environment package ahead of time, just gym.