### PR TITLE
Change docstring for generate_random_map in frozen_lake env

### DIFF
--- a/gym/envs/toy_text/frozen_lake.py
+++ b/gym/envs/toy_text/frozen_lake.py
@@ -31,10 +31,12 @@ MAPS = {
     ],
 }
 
-# Generates a random valid map (one that has a path from start to goal)
-# @params size, size of each side of the grid
-# @prams p, probability that a tile is frozen
+
 def generate_random_map(size=8, p=0.8):
+    """Generates a random valid map (one that has a path from start to goal)
+    :param size: size of each side of the grid
+    :param p: probability that a tile is frozen
+    """
     valid = False
     
     #BFS to check that it's a valid path


### PR DESCRIPTION
It seems there's no other docstring using Epytext style, so I changed it to reST style (which is used a few times) for a bit more consistency.