### PR TITLE
[Discrete tasks]: automatic un-nest the scalar action

### DIFF
--- a/gym/envs/atari/atari_env.py
+++ b/gym/envs/atari/atari_env.py
@@ -84,6 +84,8 @@ class AtariEnv(gym.Env, utils.EzPickle):
         return [seed1, seed2]
 
     def step(self, a):
+        if not np.isscalar(a):
+            a = np.asarray(a).item()
         reward = 0.0
         action = self._action_set[a]
 

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -239,6 +239,8 @@ class LunarLander(gym.Env, EzPickle):
         if self.continuous:
             action = np.clip(action, -1, +1).astype(np.float32)
         else:
+            if not np.isscalar(action):
+                action = np.asarray(action).item()
             assert self.action_space.contains(action), "%r (%s) invalid " % (action, type(action))
 
         # Engines

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -101,6 +101,8 @@ class AcrobotEnv(core.Env):
         return self._get_ob()
 
     def step(self, a):
+        if not np.isscalar(a):
+            a = np.asarray(a).item()
         s = self.state
         torque = self.AVAIL_TORQUE[a]
 

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -89,6 +89,8 @@ class CartPoleEnv(gym.Env):
         return [seed]
 
     def step(self, action):
+        if not np.isscalar(action):
+            action = np.asarray(action).item()
         assert self.action_space.contains(action), "%r (%s) invalid"%(action, type(action))
         state = self.state
         x, x_dot, theta, theta_dot = state

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -41,6 +41,8 @@ class MountainCarEnv(gym.Env):
         return [seed]
 
     def step(self, action):
+        if not np.isscalar(action):
+            action = np.asarray(action).item()
         assert self.action_space.contains(action), "%r (%s) invalid" % (action, type(action))
 
         position, velocity = self.state


### PR DESCRIPTION
It can be very convenient for cases that action output from neural network with a batch size one, while still keeping minimal code change. 