### PR TITLE
[Update time_limit.py]: explicit information to distinguish done by passing limit

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -36,7 +36,7 @@ class EnvSpec(object):
         trials (int): The number of trials run in official evaluation
     """
 
-    def __init__(self, id, entry_point=None, trials=100, reward_threshold=None, local_only=False, kwargs=None, nondeterministic=False, tags=None, max_episode_steps=None, max_episode_seconds=None, timestep_limit=None):
+    def __init__(self, id, entry_point=None, trials=100, reward_threshold=None, local_only=False, kwargs=None, nondeterministic=False, tags=None, max_episode_steps=None):
         self.id = id
         # Evaluation parameters
         self.trials = trials
@@ -48,21 +48,9 @@ class EnvSpec(object):
             tags = {}
         self.tags = tags
 
-        # BACKWARDS COMPAT 2017/1/18
-        if tags.get('wrapper_config.TimeLimit.max_episode_steps'):
-            max_episode_steps = tags.get('wrapper_config.TimeLimit.max_episode_steps')
-            warnings.warn("DEPRECATION WARNING wrapper_config.TimeLimit has been deprecated. Replace any calls to `register(tags={'wrapper_config.TimeLimit.max_episode_steps': 200)}` with `register(max_episode_steps=200)`. This change was made 2017/1/31 and is included in gym version 0.8.0. If you are getting many of these warnings, you may need to update switch from universe 0.21.3 to retro (https://github.com/openai/retro)")
-
         tags['wrapper_config.TimeLimit.max_episode_steps'] = max_episode_steps
-        ######
-
-        # BACKWARDS COMPAT 2017/1/31
-        if timestep_limit is not None:
-            max_episode_steps = timestep_limit
-            warnings.warn("register(timestep_limit={}) is deprecated. Use register(max_episode_steps={}) instead.".format(timestep_limit, timestep_limit))
-
+        
         self.max_episode_steps = max_episode_steps
-        self.max_episode_seconds = max_episode_seconds
 
         # We may make some of these other parameters public if they're
         # useful.
@@ -94,14 +82,6 @@ class EnvSpec(object):
     def __repr__(self):
         return "EnvSpec({})".format(self.id)
 
-    @property
-    def timestep_limit(self):
-        return self.max_episode_steps
-
-    @timestep_limit.setter
-    def timestep_limit(self, value):
-        self.max_episode_steps = value
-
 
 class EnvRegistry(object):
     """Register an env by ID. IDs remain stable over time and are
@@ -127,11 +107,9 @@ class EnvRegistry(object):
         # compatibility code to be invoked.
         if hasattr(env, "_reset") and hasattr(env, "_step") and not getattr(env, "_gym_disable_underscore_compat", False):
             patch_deprecated_methods(env)
-        if (env.spec.timestep_limit is not None) and not spec.tags.get('vnc'):
+        if (env.spec.max_episode_steps is not None) and not spec.tags.get('vnc'):
             from gym.wrappers.time_limit import TimeLimit
-            env = TimeLimit(env,
-                            max_episode_steps=env.spec.max_episode_steps,
-                            max_episode_seconds=env.spec.max_episode_seconds)
+            env = TimeLimit(env, max_episode_steps=env.spec.max_episode_steps)
         return env
 
 

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -112,7 +112,6 @@ class EnvRegistry(object):
             env = TimeLimit(env, max_episode_steps=env.spec.max_episode_steps)
         return env
 
-
     def all(self):
         return self.env_specs.values()
 

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -35,6 +35,7 @@ class TimeLimit(Wrapper):
             if self.metadata.get('semantics.autoreset'):
                 _ = self.reset() # automatically reset the env
             done = True 
+            info['pass_limit'] = True
 
         return observation, reward, done, info
 

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -1,49 +1,24 @@
-import time
-from gym import Wrapper, logger
+import gym
 
-class TimeLimit(Wrapper):
-    def __init__(self, env, max_episode_seconds=None, max_episode_steps=None):
+
+class TimeLimit(gym.Wrapper):
+    def __init__(self, env, max_episode_steps=None, done_on_limit=True):
         super(TimeLimit, self).__init__(env)
-        self._max_episode_seconds = max_episode_seconds
-        if max_episode_seconds is not None:
-            self.env.spec.max_episode_seconds = max_episode_seconds
-        self._max_episode_steps = max_episode_steps
         if max_episode_steps is not None:
             self.env.spec.max_episode_steps = max_episode_steps
-
+        self._max_episode_steps = max_episode_steps
+        self._done_on_limit = done_on_limit
         self._elapsed_steps = 0
-        self._episode_started_at = None
-
-    @property
-    def _elapsed_seconds(self):
-        return time.time() - self._episode_started_at
-
-    def _past_limit(self):
-        """Return true if we are past our limit"""
-        if self._max_episode_steps is not None and self._max_episode_steps <= self._elapsed_steps:
-            logger.debug("Env has passed the step limit defined by TimeLimit.")
-            return True
-
-        if self._max_episode_seconds is not None and self._max_episode_seconds <= self._elapsed_seconds:
-            logger.debug("Env has passed the seconds limit defined by TimeLimit.")
-            return True
-
-        return False
 
     def step(self, action):
-        assert self._episode_started_at is not None, "Cannot call env.step() before calling reset()"
         observation, reward, done, info = self.env.step(action)
         self._elapsed_steps += 1
-
-        if self._past_limit():
-            if self.metadata.get('semantics.autoreset'):
-                _ = self.reset() # automatically reset the env
-            done = True 
-            info['pass_limit'] = True
-
+        if self._elapsed_steps >= self._max_episode_steps:
+            if self._done_on_limit:
+                done = True
+            info['TimeLimit.truncated'] = True
         return observation, reward, done, info
 
     def reset(self, **kwargs):
-        self._episode_started_at = time.time()
         self._elapsed_steps = 0
         return self.env.reset(**kwargs)

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -2,10 +2,9 @@ import gym
 
 
 class TimeLimit(gym.Wrapper):
-    def __init__(self, env, max_episode_steps=None):
+    def __init__(self, env, max_episode_steps):
         super(TimeLimit, self).__init__(env)
-        if max_episode_steps is not None:
-            self.env.spec.max_episode_steps = max_episode_steps
+        self.env.spec.max_episode_steps = max_episode_steps
         self._max_episode_steps = max_episode_steps
         self._elapsed_steps = None
 

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -2,8 +2,10 @@ import gym
 
 
 class TimeLimit(gym.Wrapper):
-    def __init__(self, env, max_episode_steps):
+    def __init__(self, env, max_episode_steps=None):
         super(TimeLimit, self).__init__(env)
+        if max_episode_steps is None:
+            max_episode_steps = env.spec.max_episode_steps
         self.env.spec.max_episode_steps = max_episode_steps
         self._max_episode_steps = max_episode_steps
         self._elapsed_steps = None

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -5,7 +5,11 @@ class TimeLimit(Wrapper):
     def __init__(self, env, max_episode_seconds=None, max_episode_steps=None):
         super(TimeLimit, self).__init__(env)
         self._max_episode_seconds = max_episode_seconds
+        if max_episode_seconds is not None:
+            self.env.spec.max_episode_seconds = max_episode_seconds
         self._max_episode_steps = max_episode_steps
+        if max_episode_steps is not None:
+            self.env.spec.max_episode_steps = max_episode_steps
 
         self._elapsed_steps = 0
         self._episode_started_at = None

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -14,8 +14,7 @@ class TimeLimit(gym.Wrapper):
         observation, reward, done, info = self.env.step(action)
         self._elapsed_steps += 1
         if self._elapsed_steps >= self._max_episode_steps:
-            if not done:
-                info['TimeLimit.truncated'] = True
+            info['TimeLimit.truncated'] = not done
             done = True
         return observation, reward, done, info
 

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -2,21 +2,20 @@ import gym
 
 
 class TimeLimit(gym.Wrapper):
-    def __init__(self, env, max_episode_steps=None, done_on_limit=True):
+    def __init__(self, env, max_episode_steps=None):
         super(TimeLimit, self).__init__(env)
         if max_episode_steps is not None:
             self.env.spec.max_episode_steps = max_episode_steps
         self._max_episode_steps = max_episode_steps
-        self._done_on_limit = done_on_limit
         self._elapsed_steps = 0
 
     def step(self, action):
         observation, reward, done, info = self.env.step(action)
         self._elapsed_steps += 1
         if self._elapsed_steps >= self._max_episode_steps:
-            if self._done_on_limit:
-                done = True
-            info['TimeLimit.truncated'] = True
+            if not done:
+                info['TimeLimit.truncated'] = True
+            done = True
         return observation, reward, done, info
 
     def reset(self, **kwargs):

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -7,9 +7,10 @@ class TimeLimit(gym.Wrapper):
         if max_episode_steps is not None:
             self.env.spec.max_episode_steps = max_episode_steps
         self._max_episode_steps = max_episode_steps
-        self._elapsed_steps = 0
+        self._elapsed_steps = None
 
     def step(self, action):
+        assert self._elapsed_steps is not None, "Cannot call env.step() before calling reset()"
         observation, reward, done, info = self.env.step(action)
         self._elapsed_steps += 1
         if self._elapsed_steps >= self._max_episode_steps:


### PR DESCRIPTION
This will be very convenient for certain RL algorithms to distinguish between terminal state and done by passing limit, in which we should not handle the last observation as terminal state, say setting value function to be zero. 