### PR TITLE
[gym/spaces/space.py] Refactor: delete unnecessary import

### DIFF
--- a/gym/spaces/space.py
+++ b/gym/spaces/space.py
@@ -7,7 +7,6 @@ class Space(object):
     action.
     """
     def __init__(self, shape=None, dtype=None):
-        import numpy as np # takes about 300-400ms to import, so we load lazily
         self.shape = None if shape is None else tuple(shape)
         self.dtype = None if dtype is None else np.dtype(dtype)
 


### PR DESCRIPTION
In the initialization of `Space` class, there is unnecessary import `numpy`.
`numpy` is already imported in the first line of that code here
https://github.com/iory/gym/blob/b2335a394da965009ffe08b79f4d17472beafa7b/gym/spaces/space.py#L1
