### PR TITLE
Bugfix: frozen_lake.py generate_random_map can now reliably create mu…

### DIFF
--- a/gym/envs/tests/test_frozenlake_dfs.py
+++ b/gym/envs/tests/test_frozenlake_dfs.py
@@ -1,0 +1,33 @@
+import pytest
+import numpy as np
+
+from gym.envs.toy_text.frozen_lake import generate_random_map
+
+# Test that FrozenLake map generation creates valid maps of various sizes.
+def test_frozenlake_dfs_map_generation():
+
+    def frozenlake_dfs_path_exists(res):
+        frontier, discovered = [], set()
+        frontier.append((0,0))
+        while frontier:
+            r, c = frontier.pop()
+            if not (r,c) in discovered:
+                discovered.add((r,c))
+                directions = [(1, 0), (0, 1), (-1, 0), (0, -1)]
+                for x, y in directions:
+                    r_new = r + x
+                    c_new = c + y
+                    if r_new < 0 or r_new >= size or c_new < 0 or c_new >= size:
+                        continue
+                    if res[r_new][c_new] == 'G':
+                        return True
+                    if (res[r_new][c_new] not in '#H'):
+                        frontier.append((r_new, c_new))
+        return False
+
+    map_sizes = [5, 10, 200]
+    for size in map_sizes:
+        new_frozenlake = generate_random_map(size)
+        assert len(new_frozenlake) == size
+        assert len(new_frozenlake[0]) == size
+        assert frozenlake_dfs_path_exists(new_frozenlake)

--- a/gym/envs/toy_text/frozen_lake.py
+++ b/gym/envs/toy_text/frozen_lake.py
@@ -39,28 +39,24 @@ def generate_random_map(size=8, p=0.8):
     """
     valid = False
 
-    # BFS to check that it's a valid path.
-    def is_valid(arr, r=0, c=0):
-        if arr[r][c] == 'G':
-            return True
-
-        tmp = arr[r][c]
-        arr[r][c] = "#"
-
-        # Recursively check in all four directions.
-        directions = [(1, 0), (0, 1), (-1, 0), (0, -1)]
-        for x, y in directions:
-            r_new = r + x
-            c_new = c + y
-            if r_new < 0 or r_new >= size or c_new < 0 or c_new >= size:
-                continue
-
-            if arr[r_new][c_new] not in '#H':
-                if is_valid(arr, r_new, c_new):
-                    arr[r][c] = tmp
-                    return True
-
-        arr[r][c] = tmp
+    # DFS to check that it's a valid path.
+    def is_valid(res):
+        frontier, discovered = [], set()
+        frontier.append((0,0))
+        while frontier:
+            r, c = frontier.pop()
+            if not (r,c) in discovered:
+                discovered.add((r,c))
+                directions = [(1, 0), (0, 1), (-1, 0), (0, -1)]
+                for x, y in directions:
+                    r_new = r + x
+                    c_new = c + y
+                    if r_new < 0 or r_new >= size or c_new < 0 or c_new >= size:
+                        continue
+                    if res[r_new][c_new] == 'G':
+                        return True
+                    if (res[r_new][c_new] not in '#H'):
+                        frontier.append((r_new, c_new))
         return False
 
     while not valid:
@@ -119,7 +115,7 @@ class FrozenLakeEnv(discrete.DiscreteEnv):
 
         def to_s(row, col):
             return row*ncol + col
-        
+
         def inc(row, col, a):
             if a == LEFT:
                 col = max(col-1,0)


### PR DESCRIPTION
Bugfix: frozen_lake.py generate_random_map can now reliably create much larger maps (300x300+) without recursion errors.

Context: analyzing RL algorithms time to convergence as state space increases and frozen_lake.py generate_random_map() had a high risk of maximum recursion errors for any grids above 30x30. Current implementation doesn't track a frontier or explored states, and can redundantly check previously explored positions thousands (or millions) of times for sufficiently large grids.

Solution: swapped in proper BFS and DFS implementations to compare performance. Both reliably generate maps of any size, but DFS performs around 20% faster on average for larger grids. Considered A* as a better solution, but it'd require another import (heapq) and probably grow the code more than desired for this simple FrozenLake environment.

Overall, this updated DFS implementation take fewer lines of code while increasing reliability for bigger grid sizes.
