### PR TITLE
Small fix for calculation of forward reward term in Humanoid Environment

### DIFF
--- a/gym/envs/mujoco/humanoid.py
+++ b/gym/envs/mujoco/humanoid.py
@@ -27,7 +27,7 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         pos_after = mass_center(self.model, self.sim)
         alive_bonus = 5.0
         data = self.sim.data
-        lin_vel_cost = 0.25 * (pos_after - pos_before) / self.model.opt.timestep
+        lin_vel_cost = 1.25 * (pos_after - pos_before) / self.dt
         quad_ctrl_cost = 0.1 * np.square(data.ctrl).sum()
         quad_impact_cost = .5e-6 * np.square(data.cfrc_ext).sum()
         quad_impact_cost = min(quad_impact_cost, 10)

--- a/gym/envs/mujoco/humanoid_v3.py
+++ b/gym/envs/mujoco/humanoid_v3.py
@@ -20,7 +20,7 @@ def mass_center(model, sim):
 class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self,
                  xml_file='humanoid.xml',
-                 forward_reward_weight=0.25,
+                 forward_reward_weight=1.25,
                  ctrl_cost_weight=0.1,
                  contact_cost_weight=5e-7,
                  contact_cost_range=(-np.inf, 10.0),
@@ -109,11 +109,8 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         self.do_simulation(action, self.frame_skip)
         xy_position_after = mass_center(self.model, self.sim)
 
-        xy_velocity = (xy_position_after - xy_position_before) / self.dt
-        x_velocity, y_velocity = xy_velocity
-
         x_velocity = ((xy_position_after[0] - xy_position_before[0])
-                      / self.model.opt.timestep)
+                      / self.dt)
 
         ctrl_cost = self.control_cost(action)
         contact_cost = self.contact_cost

--- a/gym/envs/mujoco/humanoid_v3.py
+++ b/gym/envs/mujoco/humanoid_v3.py
@@ -109,8 +109,8 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         self.do_simulation(action, self.frame_skip)
         xy_position_after = mass_center(self.model, self.sim)
 
-        x_velocity = ((xy_position_after[0] - xy_position_before[0])
-                      / self.dt)
+        xy_velocity = (xy_position_after - xy_position_before) / self.dt
+        x_velocity, y_velocity = xy_velocity
 
         ctrl_cost = self.control_cost(action)
         contact_cost = self.contact_cost


### PR DESCRIPTION
This is regarding the discussion in issue #1380. For consistency, the calculation of the forward reward term should be done by division with `self.dt` instead of `self.model.opt.timestep`. Correspondingly, the reward weights have been changed to have the same behavior. 
