### PR TITLE
fix for classic_control rendering

### DIFF
--- a/gym/envs/classic_control/rendering.py
+++ b/gym/envs/classic_control/rendering.py
@@ -102,7 +102,7 @@ class Viewer(object):
         if return_rgb_array:
             buffer = pyglet.image.get_buffer_manager().get_color_buffer()
             image_data = buffer.get_image_data()
-            arr = np.frombuffer(image_data.data, dtype=np.uint8)
+            arr = np.frombuffer(image_data.get_data(), dtype=np.uint8)
             # In https://github.com/openai/gym-http-api/issues/2, we
             # discovered that someone using Xmonad on Arch was having
             # a window of size 598 x 398, though a 600 x 400 window


### PR DESCRIPTION
I just tried rendering CartPole-v0 with mode 'rgb_array' and I got the error:
```
    arr = env.render(mode=mode)
  File "gym/core.py", line 249, in render
    return self.env.render(mode, **kwargs)
  File "gym/envs/classic_control/cartpole.py", line 188, in render
    return self.viewer.render(return_rgb_array = mode=='rgb_array')
  File "gym/envs/classic_control/rendering.py", line 105, in render
    arr = np.frombuffer(image_data.data, dtype=np.uint8)
AttributeError: 'ImageData' object has no attribute 'data'
```

Changing 
```
arr = np.frombuffer(image_data.data, dtype=np.uint8)
```
to
```
arr = np.frombuffer(image_data.get_data(), dtype=np.uint8)
```
seems to fix it.
