### PR TITLE
Also avoid AttributeError in MultiDiscrete and MultiBinary .contains() check

### DIFF
--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -11,6 +11,8 @@ class MultiBinary(Space):
         return self.np_random.randint(low=0, high=2, size=self.n, dtype=self.dtype)
 
     def contains(self, x):
+        if isinstance(x, list):
+            x = np.array(x)  # Promote list to array for contains check
         return ((x==0) | (x==1)).all()
 
     def to_jsonable(self, sample_n):

--- a/gym/spaces/multi_discrete.py
+++ b/gym/spaces/multi_discrete.py
@@ -36,6 +36,8 @@ class MultiDiscrete(Space):
         return (self.np_random.random_sample(self.nvec.shape)*self.nvec).astype(self.dtype)
 
     def contains(self, x):
+        if isinstance(x, list):
+            x = np.array(x)  # Promote list to array for contains check
         # if nvec is uint32 and space dtype is uint32, then 0 <= x < self.nvec guarantees that x
         # is within correct bounds for space dtype (even though x does not have to be unsigned)
         return (0 <= x).all() and (x < self.nvec).all()


### PR DESCRIPTION
As a followup to https://github.com/openai/gym/pull/1431, also fix the check for Multi-* spaces. This was originally reported in https://github.com/ray-project/ray/issues/4578.

cc @pzhokhov 