### PR TITLE
remove instructions for adding new environments to gym

### DIFF
--- a/docs/creating-environments.md
+++ b/docs/creating-environments.md
@@ -70,27 +70,3 @@
   ```
 
 * After you have installed your package with `pip install -e gym-foo`, you can create an instance of the environment with `gym.make('gym_foo:foo-v0')`
-
-## How to add new environments to Gym, within this repo (not recommended for new environments)
-
-1. Write your environment in an existing collection or a new collection. All collections are subfolders of `/gym/envs`.
-2. Import your environment into the `__init__.py` file of the collection. This file will be located at `/gym/envs/my_collection/__init__.py`. Add `from gym.envs.my_collection.my_awesome_env import MyEnv` to this file.
-3. Register your env in `/gym/envs/__init__.py`:
-
- ```
-register(
-		id='MyEnv-v0',
-		entry_point='gym.envs.my_collection:MyEnv',
-)
-```
-
-4. Add your environment to the scoreboard in `/gym/scoreboard/__init__.py`:
-
- ```
-add_task(
-		id='MyEnv-v0',
-		summary="Super cool environment",
-		group='my_collection',
-		contributor='mygithubhandle',
-)
-```


### PR DESCRIPTION
The instructions seem pointless since we rarely add new environments to the gym library directly.