### PR TITLE
Use utils.seeding in spaces.space

### DIFF
--- a/gym/spaces/space.py
+++ b/gym/spaces/space.py
@@ -1,3 +1,6 @@
+from gym.utils import seeding
+
+
 class Space(object):
     """Defines the observation and action spaces, so you can write generic
     code that applies to any Env. For example, you can choose a random
@@ -7,15 +10,17 @@ class Space(object):
         import numpy as np  # takes about 300-400ms to import, so we load lazily
         self.shape = None if shape is None else tuple(shape)
         self.dtype = None if dtype is None else np.dtype(dtype)
-        self.np_random = np.random.RandomState()
+        self.np_random = None
+        self.seed()
 
     def sample(self):
         """Uniformly randomly sample a random element of this space. """
         raise NotImplementedError
 
-    def seed(self, seed):
+    def seed(self, seed=None):
         """Seed the PRNG of this space. """
-        self.np_random.seed(seed)
+        self.np_random, seed = seeding.np_random(seed)
+        return [seed]
 
     def contains(self, x):
         """


### PR DESCRIPTION
The "strong random seed" defined in utils.seeding and used in environments
cannot be used to seed the action spaces (np.random.RandomState only
supports uint32 seeds).

For consistency, the same seeding procedure should be used everywhere.