### PR TITLE
Argument missing in description of EnvSpec in registration.py

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -30,6 +30,7 @@ class EnvSpec(object):
         kwargs (dict): The kwargs to pass to the environment class
         nondeterministic (bool): Whether this environment is non-deterministic even after seeding
         tags (dict[str:any]): A set of arbitrary key-value tags on this environment, including simple property=True tags
+        max_episode_steps (Optional[int]): The maximum number of steps that an episode can consist of
 
     Attributes:
         id (str): The official environment ID


### PR DESCRIPTION
Hi, 
I just noticed that max_episode_steps is an argument that gets passed to the constructor of this class, which I first didn't notice because it is not included in the description.
In order to avoid potential confusion, I just slightly modified the description.