### PR TITLE
Fix equality operation between Box spaces

### DIFF
--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -56,4 +56,4 @@ class Box(Space):
         return "Box" + str(self.shape)
 
     def __eq__(self, other):
-        return isinstance(other, Box) and np.allclose(self.low, other.low) and np.allclose(self.high, other.high)
+        return isinstance(other, Box) and (self.shape == other.shape) and np.allclose(self.low, other.low) and np.allclose(self.high, other.high)

--- a/gym/spaces/tests/test_spaces.py
+++ b/gym/spaces/tests/test_spaces.py
@@ -88,6 +88,7 @@ def test_sample(space):
 @pytest.mark.parametrize("spaces", [
     (Discrete(5), MultiBinary(5)),
     (Box(low=np.array([-10, 0]), high=np.array([10,10]), dtype=np.float32), MultiDiscrete([2, 2, 8])),
+    (Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8), Box(low=0, high=255, shape=(32, 32, 3), dtype=np.uint8)),
     (Dict({"position": Discrete(5)}), Tuple([Discrete(5)])),
     (Dict({"position": Discrete(5)}), Discrete(5)),
     (Tuple((Discrete(5),)), Discrete(5)),


### PR DESCRIPTION
 - Check for the `shape` in the `__eq__` method of `Box` spaces
 - Add a test for equality between `Box` spaces

Before:
```python
space1 = Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8)
space2 = Box(low=0, high=255, shape=(32, 32, 3), dtype=np.uint8)
assert space1 != space2
# ValueError: operands could not be broadcast together with shapes (64,64,3) (32,32,3)
```

After:
```python
space1 = Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8)
space2 = Box(low=0, high=255, shape=(32, 32, 3), dtype=np.uint8)
assert space1 != space2
```