### PR TITLE
Remove sudo tag in travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ deploy:
     on:
         tags: true
         condition: $PY_VER = 3.5
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 language: python
 python:
   - "3.7"
-sudo: required
 services:
   - docker
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,3 @@ deploy:
     on:
         tags: true
         condition: $PY_VER = 3.5
-


### PR DESCRIPTION
Travis are now recommending removing the sudo tag.
Check out [this](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).