### PR TITLE
done=true when successfully achieve the goal in robot_env

### DIFF
--- a/gym/envs/robotics/robot_env.py
+++ b/gym/envs/robotics/robot_env.py
@@ -63,10 +63,8 @@ class RobotEnv(gym.GoalEnv):
         self._step_callback()
         obs = self._get_obs()
 
-        done = False
-        info = {
-            'is_success': self._is_success(obs['achieved_goal'], self.goal),
-        }
+        done = self._is_success(obs['achieved_goal'], self.goal)
+        info = {'is_success': done}
         reward = self.compute_reward(obs['achieved_goal'], self.goal, info)
         return obs, reward, done, info
 


### PR DESCRIPTION
It feels more intuitive to return `done=true` when successfully achieve the goal in robot_env.
Or we keep this behavior but mention that in the documentation page: https://gym.openai.com/envs/#robotics?