### PR TITLE
ALE 0.6 - modes and difficulties for Atari games

### DIFF
--- a/gym/envs/atari/atari_env.py
+++ b/gym/envs/atari/atari_env.py
@@ -26,6 +26,8 @@ class AtariEnv(gym.Env, utils.EzPickle):
     def __init__(
             self,
             game='pong',
+            mode=0,
+            difficulty=0,
             obs_type='ram',
             frameskip=(2, 5),
             repeat_action_probability=0.,
@@ -36,12 +38,18 @@ class AtariEnv(gym.Env, utils.EzPickle):
         utils.EzPickle.__init__(
                 self,
                 game,
+                mode,
+                difficulty,
                 obs_type,
                 frameskip,
                 repeat_action_probability)
         assert obs_type in ('ram', 'image')
 
+        self.game = game
         self.game_path = atari_py.get_game_path(game)
+        self.game_mode = mode
+        self.game_difficulty = difficulty
+
         if not os.path.exists(self.game_path):
             msg = 'You asked for game %s but path %s does not exist'
             raise IOError(msg % (game, self.game_path))
@@ -81,6 +89,20 @@ class AtariEnv(gym.Env, utils.EzPickle):
         # Empirically, we need to seed before loading the ROM.
         self.ale.setInt(b'random_seed', seed2)
         self.ale.loadROM(self.game_path)
+
+        modes = self.ale.getAvailableModes()
+        difficulties = self.ale.getAvailableDifficulties()
+
+        assert self.game_mode in modes, (
+            "Invalid game mode \"{}\" for game {}.\nAvailable modes are: {}"
+        ).format(self.game_mode, self.game, modes)
+        assert self.game_difficulty in difficulties, (
+            "Invalid game difficulty \"{}\" for game {}.\nAvailable difficulties are: {}"
+        ).format(self.game_difficulty, self.game, difficulties)
+
+        self.ale.setMode(self.game_mode)
+        self.ale.setDifficulty(self.game_difficulty)
+
         return [seed1, seed2]
 
     def step(self, a):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from version import VERSION
 
 # Environment-specific dependencies.
 extras = {
-  'atari': ['atari_py~=0.1.4', 'Pillow', 'opencv-python'],
+  'atari': ['atari_py~=0.2.0', 'Pillow', 'opencv-python'],
   'box2d': ['box2d-py~=2.3.5'],
   'classic_control': [],
   'mujoco': ['mujoco_py>=1.50, <2.1', 'imageio'],


### PR DESCRIPTION
This PR along with https://github.com/openai/atari-py/pull/49 introduces modes and difficulties for Atari 2600 games in Gym. This was introduced in version 0.6 of the ALE and also outlined in the paper ["Revisiting the Arcade Learning Environment: Evaluation Protocols and Open Problems for General Agents"](https://arxiv.org/abs/1709.06009) by Machado et al.

I had previously discussed versioning in  https://github.com/openai/atari-py/pull/49 with @christopherhesse as this PR would rely on a new API in v0.6 which allows you to query and set the mode and/or difficulty.

The other thing to note in this PR is the removal of `self.game_path`. I don't understand why you call `ale.loadROM` in the seed function. To my knowledge, you don't need to set the random seed before loading the ROM. The seed only affects the RNG for sticky actions. In fact, most examples in the ALE repository set the seed after loading the ROM.
I had to make this change as it seems `seed` gets called twice and the second call would override any previously defined modes or difficulties (each call to `loadROM` resets the mode and difficulty to the default of 0).

To get this PR merged I think we should discuss:

1) <del>How to handle versioning in Gym with respect to `atari-py`. It's probably necessary to check for `setDifficulty` and `setMode` in `atari-py`. If the newer API isn't found we can throw an error asking the user to upgrade `atari-py`.</del>
2) <del>Gain some clarity on the `ale.loadRom` call in `seed`. I don't see this breaking anything but it would be nice to get some clarity on why this existed in the first place.</del>