### PR TITLE
Slow writing to shared memory in VectorEnv

### DIFF
--- a/gym/vector/utils/shared_memory.py
+++ b/gym/vector/utils/shared_memory.py
@@ -100,9 +100,8 @@ def read_tuple_from_shared_memory(shared_memory, space, n=1):
         for (memory, subspace) in zip(shared_memory, space.spaces))
 
 def read_dict_from_shared_memory(shared_memory, space, n=1):
-    return OrderedDict([(key, read_from_shared_memory(memory, subspace, n=n))
-        for ((key, memory), subspace) in zip(shared_memory.items(), 
-        space.spaces.values())])
+    return OrderedDict([(key, read_from_shared_memory(shared_memory[key],
+        subspace, n=n)) for (key, subspace) in space.spaces.items()])
 
 
 def write_to_shared_memory(index, value, shared_memory, space):
@@ -147,5 +146,5 @@ def write_tuple_to_shared_memory(index, values, shared_memory, space):
         write_to_shared_memory(index, value, memory, subspace)
 
 def write_dict_to_shared_memory(index, values, shared_memory, space):
-    for key, value in values.items():
-        write_to_shared_memory(index, value, shared_memory[key], space.spaces[key])
+    for key, subspace in space.spaces.items():
+        write_to_shared_memory(index, values[key], shared_memory[key], subspace)

--- a/gym/vector/utils/shared_memory.py
+++ b/gym/vector/utils/shared_memory.py
@@ -138,8 +138,9 @@ def write_to_shared_memory(index, value, shared_memory, space):
 
 def write_base_to_shared_memory(index, value, shared_memory, space):
     size = int(np.prod(space.shape))
-    shared_memory[index * size:(index + 1) * size] = np.asarray(value,
-        dtype=space.dtype).flatten()
+    destination = np.frombuffer(shared_memory.get_obj(), dtype=space.dtype)
+    np.copyto(destination[index * size:(index + 1) * size], np.asarray(
+        value, dtype=space.dtype).flatten())
 
 def write_tuple_to_shared_memory(index, values, shared_memory, space):
     for value, memory, subspace in zip(values, shared_memory, space.spaces):


### PR DESCRIPTION
Writing to shared memory was very slow, most likely due to slicing the shared memory. It is now using numpy to copy data over the shared memory (similar to what is done in `baselines`).