### PR TITLE
Handle KeyboardInterrupt exception in AsyncVectorEnv

### DIFF
--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -359,7 +359,7 @@ def _worker(index, env_fn, pipe, parent_pipe, shared_memory, error_queue):
                 raise RuntimeError('Received unknown command `{0}`. Must '
                     'be one of {`reset`, `step`, `seed`, `close`, '
                     '`_check_observation_space`}.'.format(command))
-    except Exception:
+    except (KeyboardInterrupt, Exception):
         error_queue.put((index,) + sys.exc_info()[:2])
         pipe.send(None)
     finally:
@@ -398,7 +398,7 @@ def _worker_shared_memory(index, env_fn, pipe, parent_pipe, shared_memory, error
                 raise RuntimeError('Received unknown command `{0}`. Must '
                     'be one of {`reset`, `step`, `seed`, `close`, '
                     '`_check_observation_space`}.'.format(command))
-    except Exception:
+    except (KeyboardInterrupt, Exception):
         error_queue.put((index,) + sys.exc_info()[:2])
         pipe.send(None)
     finally:


### PR DESCRIPTION
`KeyboardInterrupt` now gets caught inside the workers (`KeyboardInterrupt` is not an `Exception` for some reasons).