### PR TITLE
Separate tests for single and action_space

### DIFF
--- a/gym/vector/tests/test_async_vector_env.py
+++ b/gym/vector/tests/test_async_vector_env.py
@@ -37,12 +37,16 @@ def test_reset_async_vector_env(shared_memory):
 
 
 @pytest.mark.parametrize('shared_memory', [True, False])
-def test_step_async_vector_env(shared_memory):
+@pytest.mark.parametrize('use_single_action_space', [True, False])
+def test_step_async_vector_env(shared_memory, use_single_action_space):
     env_fns = [make_env('CubeCrash-v0', i) for i in range(8)]
     try:
         env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)
         observations = env.reset()
-        actions = [env.single_action_space.sample() for _ in range(8)]
+        if use_single_action_space:
+            actions = [env.single_action_space.sample() for _ in range(8)]
+        else:
+            actions = env.action_space.sample()
         observations, rewards, dones, _ = env.step(actions)
     finally:
         env.close()

--- a/gym/vector/tests/test_sync_vector_env.py
+++ b/gym/vector/tests/test_sync_vector_env.py
@@ -31,12 +31,16 @@ def test_reset_sync_vector_env():
     assert observations.shape == env.observation_space.shape
 
 
-def test_step_sync_vector_env():
+@pytest.mark.parametrize('use_single_action_space', [True, False])
+def test_step_sync_vector_env(use_single_action_space):
     env_fns = [make_env('CubeCrash-v0', i) for i in range(8)]
     try:
         env = SyncVectorEnv(env_fns)
         observations = env.reset()
-        actions = [env.single_action_space.sample() for _ in range(8)]
+        if use_single_action_space:
+            actions = [env.single_action_space.sample() for _ in range(8)]
+        else:
+            actions = env.action_space.sample()
         observations, rewards, dones, _ = env.step(actions)
     finally:
         env.close()


### PR DESCRIPTION
Separate `test_step_...` into two tests, depending on how the actions are created (either from a list of `env.single_action_space.sample()`, or with `env.action_space.sample()`).