### PR TITLE
Move _raise_if_errors after recv in AsyncVectorEnv

### DIFF
--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -129,8 +129,8 @@ class AsyncVectorEnv(VectorEnv):
 
         for pipe, seed in zip(self.parent_pipes, seeds):
             pipe.send(('seed', seed))
-        for pipe in self.parent_pipes:
-            pipe.recv()
+        _, successes = zip(*[pipe.recv() for pipe in self.parent_pipes])
+        self._raise_if_errors(successes)
 
     def reset_async(self):
         self._assert_is_running()
@@ -166,13 +166,12 @@ class AsyncVectorEnv(VectorEnv):
             raise mp.TimeoutError('The call to `reset_wait` has timed out after '
                 '{0} second{1}.'.format(timeout, 's' if timeout > 1 else ''))
 
-        observations_list = [pipe.recv() for pipe in self.parent_pipes]
-        self._raise_if_errors()
+        results, successes = zip(*[pipe.recv() for pipe in self.parent_pipes])
+        self._raise_if_errors(successes)
         self._state = AsyncState.DEFAULT
 
         if not self.shared_memory:
-            concatenate(observations_list, self.observations,
-                self.single_observation_space)
+            concatenate(results, self.observations, self.single_observation_space)
 
         return deepcopy(self.observations) if self.copy else self.observations
 
@@ -225,8 +224,8 @@ class AsyncVectorEnv(VectorEnv):
             raise mp.TimeoutError('The call to `step_wait` has timed out after '
                 '{0} second{1}.'.format(timeout, 's' if timeout > 1 else ''))
 
-        results = [pipe.recv() for pipe in self.parent_pipes]
-        self._raise_if_errors()
+        results, successes = zip(*[pipe.recv() for pipe in self.parent_pipes])
+        self._raise_if_errors(successes)
         self._state = AsyncState.DEFAULT
         observations_list, rewards, dones, infos = zip(*results)
 
@@ -301,7 +300,9 @@ class AsyncVectorEnv(VectorEnv):
         self._assert_is_running()
         for pipe in self.parent_pipes:
             pipe.send(('_check_observation_space', self.single_observation_space))
-        if not all([pipe.recv() for pipe in self.parent_pipes]):
+        same_spaces, successes = zip(*[pipe.recv() for pipe in self.parent_pipes])
+        self._raise_if_errors(successes)
+        if not all(same_spaces):
             raise RuntimeError('Some environments have an observation space '
                 'different from `{0}`. In order to batch observations, the '
                 'observation spaces from all environments must be '
@@ -312,17 +313,22 @@ class AsyncVectorEnv(VectorEnv):
             raise ClosedEnvironmentError('Trying to operate on `{0}`, after a '
                 'call to `close()`.'.format(type(self).__name__))
 
-    def _raise_if_errors(self):
-        if not self.error_queue.empty():
-            while not self.error_queue.empty():
-                index, exctype, value = self.error_queue.get()
-                logger.error('Received the following error from Worker-{0}: '
-                    '{1}: {2}'.format(index, exctype.__name__, value))
-                logger.error('Shutting down Worker-{0}.'.format(index))
-                self.parent_pipes[index].close()
-                self.parent_pipes[index] = None
-            logger.error('Raising the last exception back to the main process.')
-            raise exctype(value)
+    def _raise_if_errors(self, successes):
+        if all(successes):
+            return
+
+        num_errors = self.num_envs - sum(successes)
+        assert num_errors > 0
+        for _ in range(num_errors):
+            index, exctype, value = self.error_queue.get()
+            logger.error('Received the following error from Worker-{0}: '
+                '{1}: {2}'.format(index, exctype.__name__, value))
+            logger.error('Shutting down Worker-{0}.'.format(index))
+            self.parent_pipes[index].close()
+            self.parent_pipes[index] = None
+
+        logger.error('Raising the last exception back to the main process.')
+        raise exctype(value)
 
     def __del__(self):
         if hasattr(self, 'closed'):
@@ -339,27 +345,27 @@ def _worker(index, env_fn, pipe, parent_pipe, shared_memory, error_queue):
             command, data = pipe.recv()
             if command == 'reset':
                 observation = env.reset()
-                pipe.send(observation)
+                pipe.send((observation, True))
             elif command == 'step':
                 observation, reward, done, info = env.step(data)
                 if done:
                     observation = env.reset()
-                pipe.send((observation, reward, done, info))
+                pipe.send(((observation, reward, done, info), True))
             elif command == 'seed':
                 env.seed(data)
-                pipe.send(None)
+                pipe.send((None, True))
             elif command == 'close':
-                pipe.send(None)
+                pipe.send((None, True))
                 break
             elif command == '_check_observation_space':
-                pipe.send(data == env.observation_space)
+                pipe.send((data == env.observation_space, True))
             else:
                 raise RuntimeError('Received unknown command `{0}`. Must '
                     'be one of {`reset`, `step`, `seed`, `close`, '
                     '`_check_observation_space`}.'.format(command))
     except Exception:
         error_queue.put((index,) + sys.exc_info()[:2])
-        pipe.send(None)
+        pipe.send((None, False))
     finally:
         env.close()
 
@@ -376,28 +382,28 @@ def _worker_shared_memory(index, env_fn, pipe, parent_pipe, shared_memory, error
                 observation = env.reset()
                 write_to_shared_memory(index, observation, shared_memory,
                                        observation_space)
-                pipe.send(None)
+                pipe.send((None, True))
             elif command == 'step':
                 observation, reward, done, info = env.step(data)
                 if done:
                     observation = env.reset()
                 write_to_shared_memory(index, observation, shared_memory,
                                        observation_space)
-                pipe.send((None, reward, done, info))
+                pipe.send(((None, reward, done, info), True))
             elif command == 'seed':
                 env.seed(data)
-                pipe.send(None)
+                pipe.send((None, True))
             elif command == 'close':
-                pipe.send(None)
+                pipe.send((None, True))
                 break
             elif command == '_check_observation_space':
-                pipe.send(data == observation_space)
+                pipe.send((data == observation_space, True))
             else:
                 raise RuntimeError('Received unknown command `{0}`. Must '
                     'be one of {`reset`, `step`, `seed`, `close`, '
                     '`_check_observation_space`}.'.format(command))
     except Exception:
         error_queue.put((index,) + sys.exc_info()[:2])
-        pipe.send(None)
+        pipe.send((None, False))
     finally:
         env.close()

--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -271,14 +271,15 @@ class AsyncVectorEnv(VectorEnv):
                     process.terminate()
         else:
             for pipe in self.parent_pipes:
-                if not pipe.closed:
+                if (pipe is not None) and (not pipe.closed):
                     pipe.send(('close', None))
             for pipe in self.parent_pipes:
-                if not pipe.closed:
+                if (pipe is not None) and (not pipe.closed):
                     pipe.recv()
 
         for pipe in self.parent_pipes:
-            pipe.close()
+            if pipe is not None:
+                pipe.close()
         for process in self.processes:
             process.join()
 

--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -292,6 +292,8 @@ class AsyncVectorEnv(VectorEnv):
         delta = None
         for pipe in self.parent_pipes:
             delta = max(end_time - time.time(), 0)
+            if pipe is None:
+                return False
             if pipe.closed or (not pipe.poll(delta)):
                 return False
         return True


### PR DESCRIPTION
There is a race condition in `AsyncVectorEnv`, most likely due to `_raise_if_errors` being called before the output of the workers is received: if the worker raises an error after `_raise_if_errors` is called, but before `pipe.recv()`, then the overall result contains spurious `None`, which cannot be iterated over anymore (see https://github.com/openai/gym/issues/1546#issuecomment-504585415).