### PR TITLE
Fix Wrapper ResizeObservation: Support list type shape

### DIFF
--- a/gym/wrappers/resize_observation.py
+++ b/gym/wrappers/resize_observation.py
@@ -13,7 +13,7 @@ class ResizeObservation(ObservationWrapper):
         assert all(x > 0 for x in shape), shape
         self.shape = tuple(shape)
 
-        obs_shape = shape + self.observation_space.shape[2:]
+        obs_shape = self.shape + self.observation_space.shape[2:]
         self.observation_space = Box(low=0, high=255, shape=obs_shape, dtype=np.uint8)
 
     def observation(self, observation):

--- a/gym/wrappers/test_resize_observation.py
+++ b/gym/wrappers/test_resize_observation.py
@@ -10,10 +10,11 @@ except ImportError:
 
 @pytest.mark.skipif(atari_py is None, reason='Only run this test when atari_py is installed')
 @pytest.mark.parametrize('env_id', ['Pong-v0', 'SpaceInvaders-v0'])
-@pytest.mark.parametrize('shape', [16, 32, (8, 5)])
+@pytest.mark.parametrize('shape', [16, 32, (8, 5), [10, 7]])
 def test_resize_observation(env_id, shape):
     env = gym.make(env_id)
     env = ResizeObservation(env, shape)
+
 
     assert env.observation_space.shape[-1] == 3
     obs = env.reset()
@@ -21,5 +22,5 @@ def test_resize_observation(env_id, shape):
         assert env.observation_space.shape[:2] == (shape, shape)
         assert obs.shape == (shape, shape, 3)
     else:
-        assert env.observation_space.shape[:2] == shape
-        assert obs.shape == shape + (3,)
+        assert env.observation_space.shape[:2] == tuple(shape)
+        assert obs.shape == tuple(shape) + (3,)


### PR DESCRIPTION
If you input the shape as a list to `ResizeObservation`, there will be an error:
```
TypeError: can only concatenate list (not "tuple") to list
```
Related to https://github.com/openai/gym/pull/1487 and these lines of code:
https://github.com/openai/gym/blob/220ae8487d9436fba0322b18bcb0402790c25335/gym/wrappers/resize_observation.py#L14-L16