### PR TITLE
Extending the `Box` class to allow possibly unbounded boxes

### DIFF
--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -41,7 +41,6 @@ class Box(Space):
         # Boolean arrays which indicate the interval type for each coordinate
         self.bounded_below = -np.inf < self.low
         self.bounded_above = np.inf > self.high
-        self.bounded = np.all(self.bounded_below) and np.all(self.bounded_above)
 
         super(Box, self).__init__(self.shape, self.dtype)
 

--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -41,8 +41,21 @@ class Box(Space):
         # Boolean arrays which indicate the interval type for each coordinate
         self.bounded_below = -np.inf < self.low
         self.bounded_above = np.inf > self.high
+        self.bounded = np.all(self.bounded_below) and np.all(self.bounded_above)
 
         super(Box, self).__init__(self.shape, self.dtype)
+
+    def is_bounded(self, manner="both"):
+        below = np.all(self.bounded_below)
+        above = np.all(self.bounded_above)
+        if manner == "both":
+            return below and above
+        elif manner == "below":
+            return below
+        elif manner == "above":
+            return above
+        else:
+            raise ValueError("manner is not in {'below', 'above', 'both'}")
 
     def sample(self):
         """
@@ -63,8 +76,8 @@ class Box(Space):
         # Masking arrays which classify the coordinates according to interval
         # type
         unbounded   = ~self.bounded_below & ~self.bounded_above
-        low_bounded = ~self.bounded_below &  self.bounded_above
-        upp_bounded =  self.bounded_below & ~self.bounded_above
+        upp_bounded = ~self.bounded_below &  self.bounded_above
+        low_bounded =  self.bounded_below & ~self.bounded_above
         bounded     =  self.bounded_below &  self.bounded_above
         
 
@@ -72,11 +85,11 @@ class Box(Space):
         sample[unbounded] = self.np_random.normal(
                 size=unbounded[unbounded].shape)
 
-        sample[low_bounded] = -self.np_random.exponential(
-            size=low_bounded[low_bounded].shape) + self.high[low_bounded]
+        sample[low_bounded] = self.np_random.exponential(
+            size=low_bounded[low_bounded].shape) + self.low[low_bounded]
         
-        sample[upp_bounded] = self.np_random.exponential(
-            size=upp_bounded[upp_bounded].shape) - self.low[upp_bounded]
+        sample[upp_bounded] = -self.np_random.exponential(
+            size=upp_bounded[upp_bounded].shape) - self.high[upp_bounded]
         
         sample[bounded] = self.np_random.uniform(low=self.low[bounded], 
                                             high=high[bounded],

--- a/gym/spaces/tests/test_spaces.py
+++ b/gym/spaces/tests/test_spaces.py
@@ -9,6 +9,7 @@ from gym.spaces import Tuple, Box, Discrete, MultiDiscrete, MultiBinary, Dict
 
 @pytest.mark.parametrize("space", [
     Discrete(3),
+    Box(low=0., high=np.inf, shape=(2,2)),
     Tuple([Discrete(5), Discrete(10)]),
     Tuple([Discrete(5), Box(low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32)]),
     Tuple((Discrete(5), Discrete(2), Discrete(2))),
@@ -40,6 +41,7 @@ def test_roundtripping(space):
 @pytest.mark.parametrize("space", [
     Discrete(3),
     Box(low=np.array([-10, 0]), high=np.array([10, 10]), dtype=np.float32),
+    Box(low=-np.inf, high=np.inf, shape=(1,3)),
     Tuple([Discrete(5), Discrete(10)]),
     Tuple([Discrete(5), Box(low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32)]),
     Tuple((Discrete(5), Discrete(2), Discrete(2))),
@@ -60,6 +62,8 @@ def test_equality(space):
     (MultiBinary(8), MultiBinary(7)),
     (Box(low=np.array([-10, 0]), high=np.array([10, 10]), dtype=np.float32),
      Box(low=np.array([-10, 0]), high=np.array([10, 9]), dtype=np.float32)),
+    (Box(low=-np.inf,high=0., shape=(2,1)), 
+        Box(low=0., high=np.inf, shape=(2,1))),
     (Tuple([Discrete(5), Discrete(10)]), Tuple([Discrete(1), Discrete(10)])),
     (Dict({"position": Discrete(5)}), Dict({"position": Discrete(4)})),
     (Dict({"position": Discrete(5)}), Dict({"speed": Discrete(5)})),
@@ -72,13 +76,24 @@ def test_inequality(spaces):
 @pytest.mark.parametrize("space", [
     Discrete(5),
     Box(low=0, high=255, shape=(2,), dtype='uint8'),
+    Box(low=-np.inf, high=np.inf, shape=(3,3)),
+    Box(low=1., high=np.inf, shape=(3,3)),
+    Box(low=-np.inf, high=2., shape=(3,3)),
 ])
 def test_sample(space):
     space.seed(0)
     n_trials = 100
     samples = np.array([space.sample() for _ in range(n_trials)])
+    expected_mean = 0.
     if isinstance(space, Box):
-        expected_mean = (space.high + space.low) / 2
+        if space.is_bounded():
+            expected_mean = (space.high + space.low) / 2
+        elif space.is_bounded("below"):
+            expected_mean = 1 + space.low
+        elif space.is_bounded("above"):
+            expected_mean = -1 - space.high
+        else:
+            expected_mean = 0.
     elif isinstance(space, Discrete):
         expected_mean = space.n / 2
     else:
@@ -92,6 +107,8 @@ def test_sample(space):
     (Dict({"position": Discrete(5)}), Tuple([Discrete(5)])),
     (Dict({"position": Discrete(5)}), Discrete(5)),
     (Tuple((Discrete(5),)), Discrete(5)),
+    (Box(low=np.array([-np.inf,0.]), high=np.array([0., np.inf])),
+        Box(low=np.array([-np.inf, 1.]), high=np.array([0., np.inf])))
 ])
 def test_class_inequality(spaces):
     assert spaces[0] == spaces[0]


### PR DESCRIPTION
This pull request extends the definition of the `Box` class to allow possibly unbounded boxes.

## Current implementation

Currently, a `Box` object is specified by the Cartesian product of closed, bounded intervals, but it is possible to instantiate a `Box` object with unbounded intervals. For example,
```Python
nonnegative_orthant = Box(low=0., high=np.inf, shape=(5,))
```
is legal code. In addition to the constructor accepting this description, the `contains`, `to_jsonable`, `from_jsonable`, `__repr__`, and `__eq__` methods are compatible with such instances.

The above code is incompatible with the `sample` method, however. It raises an `OverflowError` on `nonnegative_orthant` because the current approach involves sampling a uniform distribution over the region specified by the `Box`. This is a reasonable choice for compact regions, but impossible for unbounded ones.

## Proposed changes

This pull request modifies `Box` to allow Cartesian products of intervals of the form `[a,b]`, `(-oo,b]`, `[a,oo)`, and `(oo,oo)`. As I mentioned above, no changes were needed to the majority of methods. The `sample` method is modified to sample according to the form of each interval:

* `[a,b]`: uniform distribution on `[a,b]` (no change from before),
* `(-oo, b]`: (reflected and shifted) exponential distribution,
* `[a, oo)`: (shifted) exponential distribution,
* `(-oo,oo)`: normal distribution.

These distributions are available from the seed associated with each instance of the class. The choices are, in a sense, natural. On the other hand, they are also arbitrary. If folks here strongly prefer correctly supported distributions as alternatives to these choices, I'm happy to adopt them.

The second change is to include an `is_bounded` method. This function takes a keyword parameter `manner` (default is `"both"`) and returns whether the `Box` is bounded according to `manner`. That is, `is_bounded(manner="below")` returns whether the `Box` is bounded from below, `is_bounded(manner="above")` returns whether the object is bounded from above, and `is_bounded(manner="both")` returns whether the object is bounded from both above and below. If one interval in the Cartesian product is unbounded (below or above, respectively), the entire `Box` is said to be unbounded (below or above, respectively). Any other value for `manner` raises a `ValueError`.

The third change is to provide descriptions for when the `assert` statements fail in the constructor method. Presently, not all of the `assert` statements come with descriptions of the failure.

Test cases have been added for unbounded `Box` instances in the relevant test file. There are also no visible changes to the behavior of `Box` instances whose endpoints are all bounded, although the internals of the `sample` method have been modified, so this should not break existing use cases.

## Rationale for the change

Some of my research involves MDPs with noncompact state/action spaces. Classical problems, including inventory control, naturally have unbounded states and actions. While in practice it is usually possible to simply choose large endpoints and simulate the problems in this fashion, I have found "large" to be a relative quantity, and I like adhering to realistic models for simulating problems. This change will allow myself and others to experiment with unbounded state/action spaces without concern about triggering undefined corner cases. For example, it will allow random agents to be defined on these problems in the same way they are for others.