### PR TITLE
Recursively check for nested Dict in observation space

### DIFF
--- a/gym/wrappers/dict.py
+++ b/gym/wrappers/dict.py
@@ -12,6 +12,7 @@ class FlattenDictWrapper(gym.ObservationWrapper):
     def __init__(self, env, dict_keys):
         super(FlattenDictWrapper, self).__init__(env)
         self.dict_keys = dict_keys
+        self.dtype = None
 
         # Figure out observation_space dimension.
         size = self.get_dict_size(self.env.observation_space.spaces, dict_keys)
@@ -23,10 +24,31 @@ class FlattenDictWrapper(gym.ObservationWrapper):
             space = spaces[key]
             if isinstance(space, gym.spaces.Dict):
                 size += self.get_dict_size(space.spaces, space.spaces.keys())
+            elif isinstance(space, gym.spaces.Tuple):
+                size += self.get_tuple_size(space.spaces)
             else:
-                shape = space.shape
-                size += np.prod(shape, dtype=np.int64)
+                size += self.get_box_size(space)
         return size
+
+    def get_tuple_size(self, spaces):
+        size = 0
+        for space in spaces:
+            if isinstance(space, gym.spaces.Dict):
+                size += self.get_dict_size(space.spaces, space.spaces.keys())
+            elif isinstance(space, gym.spaces.Tuple):
+                size += self.get_tuple_size(space.spaces)
+            else:
+                size += self.get_box_size(space)
+        return size
+
+    def get_box_size(self, space):
+        assert isinstance(space, gym.spaces.Box), "Only spaces of type Box are supported."
+        if self.dtype is not None:
+            assert space.dtype == self.dtype, "All spaces must have the same dtype."
+        else:
+            self.dtype = space.dtype
+        shape = space.shape
+        return np.prod(shape, dtype=np.int64)
 
     def observation(self, observation):
         assert isinstance(observation, dict)

--- a/gym/wrappers/dict.py
+++ b/gym/wrappers/dict.py
@@ -14,11 +14,19 @@ class FlattenDictWrapper(gym.ObservationWrapper):
         self.dict_keys = dict_keys
 
         # Figure out observation_space dimension.
+        size = self.get_dict_size(self.env.observation_space.spaces, dict_keys)
+        self.observation_space = gym.spaces.Box(-np.inf, np.inf, shape=(size,), dtype='float32')
+
+    def get_dict_size(self, spaces, dict_keys):
         size = 0
         for key in dict_keys:
-            shape = self.env.observation_space.spaces[key].shape
-            size += np.prod(shape)
-        self.observation_space = gym.spaces.Box(-np.inf, np.inf, shape=(size,), dtype='float32')
+            space = spaces[key]
+            if isinstance(space, gym.spaces.Dict):
+                size += self.get_dict_size(space.spaces, space.spaces.keys())
+            else:
+                shape = space.shape
+                size += np.prod(shape, dtype=np.int64)
+        return size
 
     def observation(self, observation):
         assert isinstance(observation, dict)

--- a/tests/gym/wrappers/nested_dict_test.py
+++ b/tests/gym/wrappers/nested_dict_test.py
@@ -1,0 +1,124 @@
+"""Tests for the filter observation wrapper."""
+
+
+import pytest
+import numpy as np
+
+import gym
+from gym.spaces import Dict, Box, Discrete, Tuple
+from gym.wrappers.dict import FlattenDictWrapper
+
+
+class FakeEnvironment(gym.Env):
+    def __init__(self, observation_space):
+        self.observation_space = observation_space
+        self.obs_keys = self.observation_space.spaces.keys()
+        self.action_space = Box(
+            shape=(1, ), low=-1, high=1, dtype=np.float32)
+
+    def render(self, width=32, height=32, *args, **kwargs):
+        del args
+        del kwargs
+        image_shape = (height, width, 3)
+        return np.zeros(image_shape, dtype=np.uint8)
+
+    def reset(self):
+        observation = self.observation_space.sample()
+        return observation
+
+    def step(self, action):
+        del action
+        observation = self.observation_space.sample()
+        reward, terminal, info = 0.0, False, {}
+        return observation, reward, terminal, info
+
+
+NESTED_DICT_TEST_CASES = (
+     (Dict({
+        "key1": Box(shape=(2, ), low=-1, high=1, dtype=np.float32),
+        "key2": Dict({
+            "subkey1": Box(shape=(2, ), low=-1, high=1, dtype=np.float32),
+            "subkey2": Box(shape=(2, ), low=-1, high=1, dtype=np.float32)
+        })
+     }), (6, )),
+     (Dict({
+         "key1": Box(shape=(2, 3), low=-1, high=1, dtype=np.float32),
+         "key2": Box(shape=(), low=-1, high=1, dtype=np.float32),
+         "key3": Box(shape=(2, ), low=-1, high=1, dtype=np.float32)
+     }), (9, )),
+     (Dict({
+         "key1": Tuple(
+             (Box(shape=(2, ), low=-1, high=1, dtype=np.float32),
+              Box(shape=(2, ), low=-1, high=1, dtype=np.float32))
+         ),
+         "key2": Box(shape=(), low=-1, high=1, dtype=np.float32),
+         "key3": Box(shape=(2, ), low=-1, high=1, dtype=np.float32)
+     }), (7, )),
+     (Dict({
+         "key1": Tuple(
+             (Box(shape=(2, ), low=-1, high=1, dtype=np.float32), )
+         ),
+         "key2": Box(shape=(), low=-1, high=1, dtype=np.float32),
+         "key3": Box(shape=(2, ), low=-1, high=1, dtype=np.float32)
+     }), (5, )),
+     (Dict({
+         "key1": Tuple(
+             (Dict({
+                 "key1": Box(shape=(2, ), low=-1, high=1, dtype=np.float32)
+             }), )
+         ),
+         "key2": Box(shape=(), low=-1, high=1, dtype=np.float32),
+         "key3": Box(shape=(2, ), low=-1, high=1, dtype=np.float32)
+     }), (5, )),
+)
+
+ERROR_TEST_CASES = (
+    (Dict({
+        "key1": Box(shape=(2, ), low=-1, high=1, dtype=np.float32),
+        "key2": Dict({
+            "subkey1": Discrete(n=2),
+            "subkey2": Box(shape=(2, ), low=-1, high=1, dtype=np.float32)
+        })
+    }), AssertionError, "Only spaces of type Box are supported."),
+    (Dict({
+        "key1": Box(shape=(2, ), low=-1, high=1, dtype=np.float32),
+        "key2": Dict({
+            "subkey1": Box(shape=(2, ), low=-1, high=1, dtype=np.float64)
+        })
+    }), AssertionError, "All spaces must have the same dtype."),
+    (Dict({
+        "key1": Tuple(
+            (Dict({
+                "key1": Discrete(n=2)
+            }), )
+        ),
+        "key2": Box(shape=(), low=-1, high=1, dtype=np.float32),
+        "key3": Box(shape=(2, ), low=-1, high=1, dtype=np.float32)
+    }), AssertionError, "Only spaces of type Box are supported.")
+)
+
+
+class TestNestedDictWrapper(object):
+    @pytest.mark.parametrize("observation_space, flat_shape",
+
+                             NESTED_DICT_TEST_CASES)
+    def test_nested_dicts(self, observation_space, flat_shape):
+        env = FakeEnvironment(observation_space=observation_space)
+
+        # Make sure we are testing the right environment for the test.
+        observation_space = env.observation_space
+        assert isinstance(observation_space, Dict)
+
+        wrapped_env = FlattenDictWrapper(env, env.obs_keys)
+        assert wrapped_env.observation_space.shape == flat_shape
+
+    @pytest.mark.parametrize("observation_space,error_type,error_match",
+                             ERROR_TEST_CASES)
+    def test_raises_with_incorrect_arguments(self,
+                                             observation_space,
+                                             error_type,
+                                             error_match):
+        env = FakeEnvironment(observation_space=observation_space)
+
+        with pytest.raises(error_type, match=error_match):
+            FlattenDictWrapper(env, env.obs_keys)


### PR DESCRIPTION
I've encountered observations of the following format:
```
Dict({
    "key1": "Box()",
    "key2": {
            "subkey1": "Box()",
            "subkey2": "Box()",
             ...
    }
})
```
and currently, the `FlattenDictWrapper` class is unable to handle such a case, since it assumes that all values in the root `Dict` have a `shape` field (`Box`, `Discrete`, etc).

The following changes recursively check each value to see if it's a nested `Dict`, and returns a size which is the aggregated sum of all valid `gym.Space` objects with a shape.

On line [28](https://github.com/openai/gym/compare/master...lbertge:nested-obs-space?expand=1#diff-db310eea40a35ab2276687acee3f20eaR28) I have to convert the result into `int64` because it's possible that sometimes the shape is `()` (a singleton?) and `np.prod(()) = 1.0`; the Box constructor does not like a shape like `(1.0, )`. So I'm not sure if this is an improvement, but I thought it'd be important to point out.
