### PR TITLE
Fix AsyncVectorEnv with spawn context and shared memory

### DIFF
--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -75,7 +75,7 @@ class AsyncVectorEnv(VectorEnv):
 
         if self.shared_memory:
             _obs_buffer = create_shared_memory(self.single_observation_space,
-                n=self.num_envs)
+                n=self.num_envs, ctx=ctx)
             self.observations = read_from_shared_memory(_obs_buffer,
                 self.single_observation_space, n=self.num_envs)
         else:

--- a/gym/vector/tests/test_shared_memory.py
+++ b/gym/vector/tests/test_shared_memory.py
@@ -1,6 +1,8 @@
 import pytest
+import sys
 import numpy as np
 
+import multiprocessing as mp
 from multiprocessing.sharedctypes import SynchronizedArray
 from multiprocessing import Array, Process
 from collections import OrderedDict
@@ -11,6 +13,8 @@ from gym.vector.tests.utils import spaces
 
 from gym.vector.utils.shared_memory import (create_shared_memory,
     read_from_shared_memory, write_to_shared_memory)
+
+is_python_2 = (sys.version_info < (3, 0))
 
 expected_types = [
     Array('d', 1), Array('f', 1), Array('f', 3), Array('f', 4), Array('B', 1), Array('B', 32 * 32 * 3),
@@ -29,7 +33,11 @@ expected_types = [
 @pytest.mark.parametrize('n', [1, 8])
 @pytest.mark.parametrize('space,expected_type', list(zip(spaces, expected_types)),
     ids=[space.__class__.__name__ for space in spaces])
-def test_create_shared_memory(space, expected_type, n):
+@pytest.mark.parametrize('ctx', [None,
+    pytest.param('fork', marks=pytest.mark.skipif(is_python_2, reason='Requires Python 3')),
+    pytest.param('spawn', marks=pytest.mark.skipif(is_python_2, reason='Requires Python 3'))],
+    ids=['default', 'fork', 'spawn'])
+def test_create_shared_memory(space, expected_type, n, ctx):
     def assert_nested_type(lhs, rhs, n):
         assert type(lhs) == type(rhs)
         if isinstance(lhs, (list, tuple)):
@@ -51,7 +59,8 @@ def test_create_shared_memory(space, expected_type, n):
         else:
             raise TypeError('Got unknown type `{0}`.'.format(type(lhs)))
 
-    shared_memory = create_shared_memory(space, n=n)
+    ctx = mp if (ctx is None) else mp.get_context(ctx)
+    shared_memory = create_shared_memory(space, n=n, ctx=ctx)
     assert_nested_type(shared_memory, expected_type, n=n)
 
 

--- a/gym/vector/utils/shared_memory.py
+++ b/gym/vector/utils/shared_memory.py
@@ -1,5 +1,5 @@
 import numpy as np
-from multiprocessing import Array
+import multiprocessing as mp
 from ctypes import c_bool
 from collections import OrderedDict
 
@@ -13,7 +13,7 @@ __all__ = [
     'write_to_shared_memory'
 ]
 
-def create_shared_memory(space, n=1):
+def create_shared_memory(space, n=1, ctx=mp):
     """Create a shared memory object, to be shared across processes. This
     eventually contains the observations from the vectorized environment.
 
@@ -26,32 +26,35 @@ def create_shared_memory(space, n=1):
         Number of environments in the vectorized environment (i.e. the number
         of processes).
 
+    ctx : `multiprocessing` context
+        Context for multiprocessing.
+
     Returns
     -------
     shared_memory : dict, tuple, or `multiprocessing.Array` instance
         Shared object across processes.
     """
     if isinstance(space, _BaseGymSpaces):
-        return create_base_shared_memory(space, n=n)
+        return create_base_shared_memory(space, n=n, ctx=ctx)
     elif isinstance(space, Tuple):
-        return create_tuple_shared_memory(space, n=n)
+        return create_tuple_shared_memory(space, n=n, ctx=ctx)
     elif isinstance(space, Dict):
-        return create_dict_shared_memory(space, n=n)
+        return create_dict_shared_memory(space, n=n, ctx=ctx)
     else:
         raise NotImplementedError()
 
-def create_base_shared_memory(space, n=1):
+def create_base_shared_memory(space, n=1, ctx=mp):
     dtype = space.dtype.char
     if dtype in '?':
         dtype = c_bool
-    return Array(dtype, n * int(np.prod(space.shape)))
+    return ctx.Array(dtype, n * int(np.prod(space.shape)))
 
-def create_tuple_shared_memory(space, n=1):
-    return tuple(create_shared_memory(subspace, n=n)
+def create_tuple_shared_memory(space, n=1, ctx=mp):
+    return tuple(create_shared_memory(subspace, n=n, ctx=ctx)
         for subspace in space.spaces)
 
-def create_dict_shared_memory(space, n=1):
-    return OrderedDict([(key, create_shared_memory(subspace, n=n))
+def create_dict_shared_memory(space, n=1, ctx=mp):
+    return OrderedDict([(key, create_shared_memory(subspace, n=n, ctx=ctx))
         for (key, subspace) in space.spaces.items()])
 
 


### PR DESCRIPTION
When testing further for #1556, I again ran into some issue regarding the `spawn` context (`EOFError`). This error was triggered when using shared memory and the `spawn` context, because the shared memory was created under a different context. I added the `ctx` argument to `create_shared_memory` to create the shared memory depending on the context from `AsyncVectorEnv`.

I also added tests for this function with different contexts. Unfortunately the other functions (`read` or `write`) cannot be tested because pytest doesn't seem to work properly for processes created with a context different from `fork`.