### PR TITLE
Update classical_control Rendering for Pyglet API

### DIFF
--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -403,7 +403,11 @@ class CarRacing(gym.Env, EzPickle):
             return self.viewer.isopen
 
         image_data = pyglet.image.get_buffer_manager().get_color_buffer().get_image_data()
-        arr = np.fromstring(image_data.data, dtype=np.uint8, sep='')
+        if hasattr(image_data, 'data'):
+            # Support for pyglet versions before 1.4.0
+            arr = np.fromstring(image_data.data, dtype=np.uint8, sep='')
+        else:
+            arr = np.fromstring(image_data.get_data(), dtype=np.uint8, sep='')
         arr = arr.reshape(VP_H, VP_W, 4)
         arr = arr[::-1, :, 0:3]
 

--- a/gym/envs/classic_control/rendering.py
+++ b/gym/envs/classic_control/rendering.py
@@ -148,7 +148,11 @@ class Viewer(object):
         self.window.flip()
         image_data = pyglet.image.get_buffer_manager().get_color_buffer().get_image_data()
         self.window.flip()
-        arr = np.fromstring(image_data.data, dtype=np.uint8, sep='')
+        if hasattr(image_data, 'data'):
+            # Support for pyglet versions before 1.4.0
+            arr = np.fromstring(image_data.data, dtype=np.uint8, sep='')
+        else:
+            arr = np.fromstring(image_data.get_data(), dtype=np.uint8, sep='')
         arr = arr.reshape(self.height, self.width, 4)
         return arr[::-1,:,0:3]
 

--- a/gym/envs/classic_control/rendering.py
+++ b/gym/envs/classic_control/rendering.py
@@ -102,7 +102,11 @@ class Viewer(object):
         if return_rgb_array:
             buffer = pyglet.image.get_buffer_manager().get_color_buffer()
             image_data = buffer.get_image_data()
-            arr = np.frombuffer(image_data.data, dtype=np.uint8)
+            if hasattr(image_data, 'data'):
+                # Support for pyglet versions before 1.4.0
+                arr = np.frombuffer(image_data.data, dtype=np.uint8)
+            else:
+                arr = np.frombuffer(image_data.get_data(), dtype=np.uint8)
             # In https://github.com/openai/gym-http-api/issues/2, we
             # discovered that someone using Xmonad on Arch was having
             # a window of size 598 x 398, though a 600 x 400 window


### PR DESCRIPTION
This commit fixes issue #1438 and #1588 by adding support for
pre-1.4.0 and 1.4.0+ versions of Pyglet.