### PR TITLE
fix escape sequence DeprecationWarning

### DIFF
--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -3,12 +3,12 @@ from .space import Space
 
 
 class Discrete(Space):
-    """A discrete space in :math:`\{ 0, 1, \dots, n-1 \}`. 
-    
+    r"""A discrete space in :math:`\{ 0, 1, \\dots, n-1 \}`. 
+
     Example::
-    
+
         >>> Discrete(2)
-        
+
     """
     def __init__(self, n):
         assert n >= 0


### PR DESCRIPTION
simple warning in the pytest output. This fixes it in a way that preserves the readability of the docstring in the file and when rendered.

I looked at the other pytest warnings, but they're mostly generated by `python-future` module and we'll have to wait for a resolution there.