### PR TITLE
Expose entry_point on EnvSpec

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -42,6 +42,7 @@ class EnvSpec(object):
         self.reward_threshold = reward_threshold
         # Environment properties
         self.nondeterministic = nondeterministic
+        self.entry_point = entry_point
 
         if tags is None:
             tags = {}
@@ -57,19 +58,18 @@ class EnvSpec(object):
         if not match:
             raise error.Error('Attempted to register malformed environment ID: {}. (Currently all IDs must be of the form {}.)'.format(id, env_id_re.pattern))
         self._env_name = match.group(1)
-        self._entry_point = entry_point
         self._kwargs = {} if kwargs is None else kwargs
 
     def make(self, **kwargs):
         """Instantiates an instance of the environment with appropriate kwargs"""
-        if self._entry_point is None:
+        if self.entry_point is None:
             raise error.Error('Attempting to make deprecated env {}. (HINT: is there a newer registered version of this env?)'.format(self.id))
         _kwargs = self._kwargs.copy()
         _kwargs.update(kwargs)
-        if callable(self._entry_point):
-            env = self._entry_point(**_kwargs)
+        if callable(self.entry_point):
+            env = self.entry_point(**_kwargs)
         else:
-            cls = load(self._entry_point)
+            cls = load(self.entry_point)
             env = cls(**_kwargs)
 
         # Make the enviroment aware of which spec it came from.

--- a/gym/envs/tests/spec_list.py
+++ b/gym/envs/tests/spec_list.py
@@ -11,7 +11,7 @@ if not skip_mujoco:
 def should_skip_env_spec_for_tests(spec):
     # We skip tests for envs that require dependencies or are otherwise
     # troublesome to run frequently
-    ep = spec._entry_point
+    ep = spec.entry_point
     # Skip mujoco tests for pull request CI
     if skip_mujoco and (ep.startswith('gym.envs.mujoco') or ep.startswith('gym.envs.robotics:')):
         return True
@@ -34,4 +34,4 @@ def should_skip_env_spec_for_tests(spec):
         return True
     return False
 
-spec_list = [spec for spec in sorted(envs.registry.all(), key=lambda x: x.id) if spec._entry_point is not None and not should_skip_env_spec_for_tests(spec)]
+spec_list = [spec for spec in sorted(envs.registry.all(), key=lambda x: x.id) if spec.entry_point is not None and not should_skip_env_spec_for_tests(spec)]

--- a/scripts/generate_json.py
+++ b/scripts/generate_json.py
@@ -66,7 +66,7 @@ def update_rollout_dict(spec, rollout_dict):
     return True
 
 def add_new_rollouts(spec_ids, overwrite):
-    environments = [spec for spec in envs.registry.all() if spec._entry_point is not None]
+    environments = [spec for spec in envs.registry.all() if spec.entry_point is not None]
     if spec_ids:
         environments = [spec for spec in environments if spec.id in spec_ids]
         assert len(environments) == len(spec_ids), "Some specs not found"


### PR DESCRIPTION
There may be some use cases where exposing `entry_point` could be useful. For example, verifying the environment is a valid Atari environment by checking if `entry_point` starts with `gym.envs.atari`.

This makes the access of `entry_point` not feel as nasty as calling `spec._entry_point`.