### PR TITLE
Add call, get_attr and set_attr methods to VectorEnv

### DIFF
--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -83,6 +83,48 @@ class SyncVectorEnv(VectorEnv):
         return (deepcopy(self.observations) if self.copy else self.observations,
             np.copy(self._rewards), np.copy(self._dones), infos)
 
+    def call(self, name, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        name : string
+            Name of the method or property to call.
+
+        Returns
+        -------
+        results : list
+            List of the results of the individual calls to the method or
+            property for each environment.
+        """
+        results = []
+        for env in self.envs:
+            function = getattr(env, name)
+            if callable(function):
+                results.append(function(*args, **kwargs))
+            else:
+                results.append(function)
+
+        return tuple(results)
+
+    def set_attr(self, name, values):
+        """
+        Parameters
+        ----------
+        name : string
+            Name of the property to be set in each individual environment.
+
+        values : list or object
+            Values of the property to bet set to. If `values` is a list, then
+            it corresponds to the values for each individual environment,
+            otherwise a single value is set for all environments.
+        """
+        if not isinstance(values, list):
+            values = [values for _ in range(self.num_envs)]
+        assert len(values) == self.num_envs
+
+        for env, value in zip(self.envs, values):
+            setattr(env, name, value)
+
     def close_extras(self, **kwargs):
         [env.close() for env in self.envs]
 

--- a/gym/vector/tests/test_async_vector_env.py
+++ b/gym/vector/tests/test_async_vector_env.py
@@ -69,6 +69,42 @@ def test_step_async_vector_env(shared_memory, use_single_action_space):
 
 
 @pytest.mark.parametrize('shared_memory', [True, False])
+def test_call_async_vector_env(shared_memory):
+    env_fns = [make_env('CubeCrash-v0', i) for i in range(4)]
+    try:
+        env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)
+        observations = env.reset()
+        images = env.call('render', mode='rgb_array')
+        use_shaped_reward = env.call('use_shaped_reward')
+    finally:
+        env.close()
+
+    assert isinstance(images, tuple)
+    assert len(images) == 4
+    for i in range(4):
+        assert isinstance(images[i], np.ndarray)
+        assert np.all(images[i] == observations[i])
+
+    assert isinstance(use_shaped_reward, tuple)
+    assert len(use_shaped_reward) == 4
+    for i in range(4):
+        assert isinstance(use_shaped_reward[i], bool)
+        assert use_shaped_reward[i]
+
+
+@pytest.mark.parametrize('shared_memory', [True, False])
+def test_set_attr_async_vector_env(shared_memory):
+    env_fns = [make_env('CubeCrash-v0', i) for i in range(4)]
+    try:
+        env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)
+        env.set_attr('use_shaped_reward', [True, False, False, True])
+        use_shaped_reward = env.get_attr('use_shaped_reward')
+        assert use_shaped_reward == (True, False, False, True)
+    finally:
+        env.close()
+
+
+@pytest.mark.parametrize('shared_memory', [True, False])
 def test_copy_async_vector_env(shared_memory):
     env_fns = [make_env('CubeCrash-v0', i) for i in range(8)]
     try:

--- a/gym/vector/tests/test_sync_vector_env.py
+++ b/gym/vector/tests/test_sync_vector_env.py
@@ -62,6 +62,40 @@ def test_step_sync_vector_env(use_single_action_space):
     assert dones.size == 8
 
 
+def test_call_sync_vector_env():
+    env_fns = [make_env('CubeCrash-v0', i) for i in range(4)]
+    try:
+        env = SyncVectorEnv(env_fns)
+        observations = env.reset()
+        images = env.call('render', mode='rgb_array')
+        use_shaped_reward = env.call('use_shaped_reward')
+    finally:
+        env.close()
+
+    assert isinstance(images, tuple)
+    assert len(images) == 4
+    for i in range(4):
+        assert isinstance(images[i], np.ndarray)
+        assert np.all(images[i] == observations[i])
+
+    assert isinstance(use_shaped_reward, tuple)
+    assert len(use_shaped_reward) == 4
+    for i in range(4):
+        assert isinstance(use_shaped_reward[i], bool)
+        assert use_shaped_reward[i]
+
+
+def test_set_attr_sync_vector_env():
+    env_fns = [make_env('CubeCrash-v0', i) for i in range(4)]
+    try:
+        env = SyncVectorEnv(env_fns)
+        env.set_attr('use_shaped_reward', [True, False, False, True])
+        use_shaped_reward = env.get_attr('use_shaped_reward')
+        assert use_shaped_reward == (True, False, False, True)
+    finally:
+        env.close()
+
+
 def test_check_observations_sync_vector_env():
     # CubeCrash-v0 - observation_space: Box(40, 32, 3)
     env_fns = [make_env('CubeCrash-v0', i) for i in range(8)]

--- a/gym/vector/vector_env.py
+++ b/gym/vector/vector_env.py
@@ -91,6 +91,22 @@ class VectorEnv(gym.Env):
         self.step_async(actions)
         return self.step_wait()
 
+    def call_async(self, name, *args, **kwargs):
+        pass
+
+    def call_wait(self, **kwargs):
+        raise NotImplementedError()
+
+    def call(self, name, *args, **kwargs):
+        self.call_async(name, *args, **kwargs)
+        return self.call_wait()
+
+    def get_attr(self, name):
+        return self.call(name)
+
+    def set_attr(self, name, values):
+        raise NotImplementedError()
+
     def close_extras(self, **kwargs):
         r"""Clean up the extra resources e.g. beyond what's in this base class. """
         raise NotImplementedError()


### PR DESCRIPTION
As suggested in #1513, this PR adds 3 new methods to `VectorEnv`:
 - `call(name, *args, **kwargs)`, which calls `get_attr` in each individual environment, and returns either its property `name` (in which case `*args` and `**kwargs` are ignored), or the result of `name(*args, **kwargs)`.
 - `get_attr(name)`, which is syntactic sugar for a call to `call` to get a property of the individual environments.
 - `set_attr(name, values)`, which alls `setattr` on each individual environment.