### PR TITLE
Add episodic argument to VectorEnv

### DIFF
--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -48,12 +48,18 @@ class AsyncVectorEnv(VectorEnv):
         If `True`, then the `reset` and `step` methods return a copy of the
         observations.
 
+    episodic : bool (default: `False`)
+        If `True`, then the environments run for a single episode (until
+        `done=True`), and subsequent calls to `step` have an unexpected
+        behaviour. If `False`, then the environments call `reset` at the end of
+        each episode.
+
     context : str, optional
         Context for multiprocessing. If `None`, then the default context is used.
         Only available in Python 3.
     """
     def __init__(self, env_fns, observation_space=None, action_space=None,
-                 shared_memory=True, copy=True, context=None):
+                 shared_memory=True, copy=True, episodic=False, context=None):
         try:
             ctx = mp.get_context(context)
         except AttributeError:
@@ -63,6 +69,7 @@ class AsyncVectorEnv(VectorEnv):
         self.env_fns = env_fns
         self.shared_memory = shared_memory
         self.copy = copy
+        self.episodic = episodic
 
         if (observation_space is None) or (action_space is None):
             dummy_env = env_fns[0]()
@@ -92,7 +99,7 @@ class AsyncVectorEnv(VectorEnv):
                 process = ctx.Process(target=target,
                     name='Worker<{0}>-{1}'.format(type(self).__name__, idx),
                     args=(idx, CloudpickleWrapper(env_fn), child_pipe,
-                    parent_pipe, _obs_buffer, self.error_queue))
+                    parent_pipe, _obs_buffer, self.error_queue, self.episodic))
 
                 self.parent_pipes.append(parent_pipe)
                 self.processes.append(process)
@@ -339,20 +346,34 @@ class AsyncVectorEnv(VectorEnv):
                 self.close(terminate=True)
 
 
-def _worker(index, env_fn, pipe, parent_pipe, shared_memory, error_queue):
+def _worker(index, env_fn, pipe, parent_pipe, shared_memory, error_queue,
+            episodic):
     assert shared_memory is None
     env = env_fn()
+    _zero_observation = create_empty_array(env.observation_space, n=None,
+                                           fn=np.zeros)
+    episode_done = False
     parent_pipe.close()
     try:
         while True:
             command, data = pipe.recv()
             if command == 'reset':
                 observation = env.reset()
+                episode_done = False
                 pipe.send((observation, True))
             elif command == 'step':
-                observation, reward, done, info = env.step(data)
-                if done:
-                    observation = env.reset()
+                if episodic and episode_done:
+                    observation = _zero_observation
+                    reward, done, info = 0., True, {}
+                else:
+                    observation, reward, done, info = env.step(data)
+                    if done:
+                        if episodic:
+                            observation = _zero_observation
+                            episode_done = True
+                            info.update({'AsyncVectorEnv.end_episode': True})
+                        else:
+                            observation = env.reset()
                 pipe.send(((observation, reward, done, info), True))
             elif command == 'seed':
                 env.seed(data)
@@ -373,10 +394,13 @@ def _worker(index, env_fn, pipe, parent_pipe, shared_memory, error_queue):
         env.close()
 
 
-def _worker_shared_memory(index, env_fn, pipe, parent_pipe, shared_memory, error_queue):
+def _worker_shared_memory(index, env_fn, pipe, parent_pipe, shared_memory,
+                          error_queue, episodic):
     assert shared_memory is not None
     env = env_fn()
     observation_space = env.observation_space
+    _zero_observation = create_empty_array(observation_space, n=None, fn=np.zeros)
+    episode_done = False
     parent_pipe.close()
     try:
         while True:
@@ -385,11 +409,21 @@ def _worker_shared_memory(index, env_fn, pipe, parent_pipe, shared_memory, error
                 observation = env.reset()
                 write_to_shared_memory(index, observation, shared_memory,
                                        observation_space)
+                episode_done = False
                 pipe.send((None, True))
             elif command == 'step':
-                observation, reward, done, info = env.step(data)
-                if done:
-                    observation = env.reset()
+                if episodic and episode_done:
+                    observation = _zero_observation
+                    reward, done, info = 0., True, {}
+                else:
+                    observation, reward, done, info = env.step(data)
+                    if done:
+                        if episodic:
+                            observation = _zero_observation
+                            episode_done = True
+                            info.update({'AsyncVectorEnv.end_episode': True})
+                        else:
+                            observation = env.reset()
                 write_to_shared_memory(index, observation, shared_memory,
                                        observation_space)
                 pipe.send(((None, reward, done, info), True))

--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -27,13 +27,20 @@ class SyncVectorEnv(VectorEnv):
     copy : bool (default: `True`)
         If `True`, then the `reset` and `step` methods return a copy of the
         observations.
+
+    episodic : bool (default: `False`)
+        If `True`, then the environments run for a single episode (until
+        `done=True`), and subsequent calls to `step` have an unexpected
+        behaviour. If `False`, then the environments call `reset` at the end of
+        each episode.
     """
     def __init__(self, env_fns, observation_space=None, action_space=None,
-                 copy=True):
+                 copy=True, episodic=False):
         self.env_fns = env_fns
         self.envs = [env_fn() for env_fn in env_fns]
         self.copy = copy
-        
+        self.episodic = episodic
+
         if (observation_space is None) or (action_space is None):
             observation_space = observation_space or self.envs[0].observation_space
             action_space = action_space or self.envs[0].action_space
@@ -45,6 +52,8 @@ class SyncVectorEnv(VectorEnv):
             n=self.num_envs, fn=np.zeros)
         self._rewards = np.zeros((self.num_envs,), dtype=np.float64)
         self._dones = np.zeros((self.num_envs,), dtype=np.bool_)
+        self._zero_observation = create_empty_array(self.single_observation_space,
+            n=None, fn=np.zeros)
 
     def seed(self, seeds=None):
         """
@@ -105,9 +114,21 @@ class SyncVectorEnv(VectorEnv):
         """
         observations, infos = [], []
         for i, (env, action) in enumerate(zip(self.envs, actions)):
+
+            if self.episodic and self._dones[i]:
+                observations.append(self._zero_observation)
+                self._rewards[i] = 0.
+                infos.append({})
+                continue
+
             observation, self._rewards[i], self._dones[i], info = env.step(action)
             if self._dones[i]:
-                observation = env.reset()
+                if self.episodic:
+                    observation = self._zero_observation
+                    info.update({'SyncVectorEnv.end_episode': True})
+                else:
+                    observation = env.reset()
+
             observations.append(observation)
             infos.append(info)
         concatenate(observations, self.observations, self.single_observation_space)

--- a/gym/vector/tests/test_sync_vector_env.py
+++ b/gym/vector/tests/test_sync_vector_env.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 from gym.spaces import Box
-from gym.vector.tests.utils import make_env
+from gym.vector.tests.utils import make_env, make_slow_env
 
 from gym.vector.sync_vector_env import SyncVectorEnv
 
@@ -69,4 +69,62 @@ def test_check_observations_sync_vector_env():
     env_fns[1] = make_env('MemorizeDigits-v0', 1)
     with pytest.raises(RuntimeError):
         env = SyncVectorEnv(env_fns)
+        env.close()
+
+
+def test_episodic_sync_vector_env():
+    episode_lengths = [2, 5, 3, 1, 3]
+    env_fns = [make_slow_env(0., i, length) for i, length
+               in enumerate(episode_lengths)]
+    try:
+        env = SyncVectorEnv(env_fns, episodic=True)
+        observations = env.reset()
+        # Step 1
+        actions = env.action_space.sample()
+        observations, rewards, dones, infos = env.step(actions)
+        assert dones[3]
+        assert np.all(observations[3] == 0)
+        assert 'SyncVectorEnv.end_episode' in infos[3]
+        assert infos[3]['SyncVectorEnv.end_episode']
+        assert not np.all(dones)
+        assert np.any(observations[0] != 0)
+
+        # Step 2
+        actions = env.action_space.sample()
+        observations, rewards, dones, infos = env.step(actions)
+        for j in [0, 3]:
+            assert dones[j]
+            assert np.all(observations[j] == 0)
+        assert 'SyncVectorEnv.end_episode' in infos[0]
+        assert infos[0]['SyncVectorEnv.end_episode']
+        assert not np.all(dones)
+        assert np.any(observations[2] != 0)
+
+        # Step 3
+        actions = env.action_space.sample()
+        observations, rewards, dones, infos = env.step(actions)
+        for j in [0, 2, 3, 4]:
+            assert dones[j]
+            assert np.all(observations[j] == 0)
+        assert 'SyncVectorEnv.end_episode' in infos[2]
+        assert infos[2]['SyncVectorEnv.end_episode']
+        assert not np.all(dones)
+        assert np.any(observations[1] != 0)
+
+        # Step 4
+        actions = env.action_space.sample()
+        observations, rewards, dones, infos = env.step(actions)
+        for j in [0, 2, 3, 4]:
+            assert dones[j]
+            assert np.all(observations[j] == 0)
+        assert 'SyncVectorEnv.end_episode' not in infos[2]
+        assert not np.all(dones)
+        assert np.any(observations[1] != 0)
+
+        # Step 5
+        actions = env.action_space.sample()
+        observations, rewards, dones, infos = env.step(actions)
+        assert np.all(dones)
+        assert np.all(observations == 0)
+    finally:
         env.close()

--- a/gym/vector/tests/utils.py
+++ b/gym/vector/tests/utils.py
@@ -29,22 +29,30 @@ spaces = [
 HEIGHT, WIDTH = 64, 64
 
 class UnittestSlowEnv(gym.Env):
-    def __init__(self, slow_reset=0.3):
+    def __init__(self, slow_reset=0.3, episode_length=1):
         super(UnittestSlowEnv, self).__init__()
         self.slow_reset = slow_reset
+        self.episode_length = episode_length
+        self._num_steps = 0
+
         self.observation_space = Box(low=0, high=255,
             shape=(HEIGHT, WIDTH, 3), dtype=np.uint8)
         self.action_space = Box(low=0., high=1., shape=(), dtype=np.float32)
 
     def reset(self):
+        self._num_steps = 0
         if self.slow_reset > 0:
             time.sleep(self.slow_reset)
         return self.observation_space.sample()
 
     def step(self, action):
+        if (action < 0.):
+            raise ValueError('The duration must be positive, got '
+                '`{0}`.'.format(action))
         time.sleep(action)
+        self._num_steps += 1
         observation = self.observation_space.sample()
-        reward, done = 0., False
+        reward, done = np.random.rand(), (self._num_steps >= self.episode_length)
         return observation, reward, done, {}
 
 def make_env(env_name, seed):
@@ -54,9 +62,10 @@ def make_env(env_name, seed):
         return env
     return _make
 
-def make_slow_env(slow_reset, seed):
+def make_slow_env(slow_reset, seed, episode_length=1):
     def _make():
-        env = UnittestSlowEnv(slow_reset=slow_reset)
+        env = UnittestSlowEnv(slow_reset=slow_reset,
+            episode_length=episode_length)
         env.seed(seed)
         return env
     return _make


### PR DESCRIPTION
This PR adds an "episodic" mode for `VectorEnv`. In episodic mode, the environment does not call automatically `reset` once the episode of an environment is `done=True`. The user is responsible to call `reset` herself. This would allow the following pattern:
```python
import gym
import numpy as np

def make_env():
    return gym.make('CartPole-v1')

env_fns = [make_env for _ in range(8)]
env = gym.vector.AsyncVectorEnv(env_fns, episodic=True)
observations = env.reset()
dones = np.zeros(env.num_envs, dtype=np.bool_)

while not dones.all():
    actions = env.action_space.sample()
    observations, rewards, dones, infos = env.step(actions)
```

The episodic mode is useful in case one wants to only sample a fixed amount of episodes, rather than continuously sample episodes. Once an episode is over, the environment adds a blank observation with 0 reward and `done=True`, to keep batches of observations/rewards/dones consistent. Note that the default behavior is `episodic=False`, where `reset` is called automatically.

I would like to discuss this PR in greater details before going with it.