### PR TITLE
replace data with get_data()

### DIFF
--- a/gym/envs/classic_control/rendering.py
+++ b/gym/envs/classic_control/rendering.py
@@ -102,7 +102,7 @@ class Viewer(object):
         if return_rgb_array:
             buffer = pyglet.image.get_buffer_manager().get_color_buffer()
             image_data = buffer.get_image_data()
-            arr = np.frombuffer(image_data.data, dtype=np.uint8)
+            arr = np.frombuffer(image_data.get_data(), dtype=np.uint8)
             # In https://github.com/openai/gym-http-api/issues/2, we
             # discovered that someone using Xmonad on Arch was having
             # a window of size 598 x 398, though a 600 x 400 window


### PR DESCRIPTION
Description:

The `env.render('rgb_array')` is broken.

Test code:

```py
import gym
env = gym.make('Pendulum-v0')
env.reset()
env.render('rgb_array')
```

Error:

```
AttributeError: 'ImageData' object has no attribute 'data'
```

I have `gym==0.13.0` and `pyglet==1.4.0b1`
