### PR TITLE
Added render() to gym.vector environments

### DIFF
--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -115,6 +115,9 @@ class SyncVectorEnv(VectorEnv):
         return (deepcopy(self.observations) if self.copy else self.observations,
             np.copy(self._rewards), np.copy(self._dones), infos)
 
+    def get_images(self):
+        return [env.render('rgb_array') for env in self.envs]
+
     def close(self):
         if self.closed:
             return

--- a/gym/vector/utils/tile_images.py
+++ b/gym/vector/utils/tile_images.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+def tile_images(img_nhwc):
+    """
+    Tile N images into one big PxQ image
+    (P,Q) are chosen to be as close as possible, and if N
+    is square, then P=Q.
+    input: img_nhwc, list or array of images, ndim=4 once turned into array
+        n = batch index, h = height, w = width, c = channel
+    returns:
+        bigim_HWc, ndarray with ndim=3
+    """
+    img_nhwc = np.asarray(img_nhwc)
+    N, h, w, c = img_nhwc.shape
+    H = int(np.ceil(np.sqrt(N)))
+    W = int(np.ceil(float(N)/H))
+    img_nhwc = np.array(list(img_nhwc) + [img_nhwc[0]*0 for _ in range(N, H*W)])
+    img_HWhwc = img_nhwc.reshape(H, W, h, w, c)
+    img_HhWwc = img_HWhwc.transpose(0, 2, 1, 3, 4)
+    img_Hh_Ww_c = img_HhWwc.reshape(H*h, W*w, c)
+    return img_Hh_Ww_c

--- a/gym/vector/vector_env.py
+++ b/gym/vector/vector_env.py
@@ -1,6 +1,7 @@
 import gym
 from gym.spaces import Tuple
 from gym.vector.utils.spaces import batch_space
+from gym.vector.utils.tile_images import tile_images
 
 __all__ = ['VectorEnv']
 
@@ -52,6 +53,26 @@ class VectorEnv(gym.Env):
     def step(self, actions):
         self.step_async(actions)
         return self.step_wait()
+
+    def render(self, mode='human'):
+        imgs = self.get_images()
+        bigimg = tile_images(imgs)
+        if mode == 'human':
+            self.get_viewer().imshow(bigimg)
+            return self.get_viewer().isopen
+        elif mode == 'rgb_array':
+            return bigimg
+        else:
+            raise NotImplementedError
+
+    def get_images(self):
+        raise NotImplementedError
+
+    def get_viewer(self):
+        if self.viewer is None:
+            from gym.envs.classic_control import rendering
+            self.viewer = rendering.SimpleImageViewer()
+        return self.viewer
 
     def __del__(self):
         if hasattr(self, 'closed'):


### PR DESCRIPTION
This PR adds rendering capability to vectorized environments (`gym.vector`) via `env.render()`, where the rendered images are tiled to be shown in a single window (the same as in [baseline](https://github.com/openai/baselines/tree/master/baselines/common/vec_env)).

![gym_vector_env_render](https://user-images.githubusercontent.com/9257771/62097879-06a23e00-b24e-11e9-885e-7bfed15db2d2.png)
