### PR TITLE
Changed repr of Dict space so that it supports non-string keys.

### DIFF
--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -64,7 +64,7 @@ class Dict(Space):
         return self.spaces[key]
 
     def __repr__(self):
-        return "Dict(" + ", ". join([k + ":" + str(s) for k, s in self.spaces.items()]) + ")"
+        return "Dict(" + ", ". join([str(k) + ":" + str(s) for k, s in self.spaces.items()]) + ")"
 
     def to_jsonable(self, sample_n):
         # serialize as dict-repr of vectors


### PR DESCRIPTION
Currently, attempting to print the Dict space fails if it uses keys which cannot be directly `+`'d to a string.

I don't see any reason that Dict spaces should not support non-string keys. If Dict spaces shouldn't support non-string keys, it should fail in the constructor rather than in the `__repr__()`.