### PR TITLE
Updated registration.py for registering custom task_env registration

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -15,7 +15,7 @@ env_id_re = re.compile(r'^(?:[\w:-]+\/)?([\w:.-]+)-v(\d+)$')
 def load(name):
     mod_name, attr_name = name.split(":")
     mod = importlib.import_module(mod_name)
-    fn = getattr(mod, attr_name)
+    fn = reduce(getattr, attr_name.split("."), mod)
     return fn
 
 


### PR DESCRIPTION
Previously the load function was giving attribute errors on recursive import calls of task environments such as:
AttributeError: 'module' object has no attribute 'task_envs.turtlebot3.turtlebot3_world.TurtleBot3WorldEnv'.
The update simply allows the registration of the task environment TurtleBot3WorldEnv with consecutive getattr() calls.