### PR TITLE
only support mujoco-py <2.0

### DIFF
--- a/py.Dockerfile
+++ b/py.Dockerfile
@@ -7,17 +7,13 @@ RUN \
     mkdir /root/.mujoco && \
     cd /root/.mujoco  && \
     curl -O https://www.roboti.us/download/mjpro150_linux.zip  && \
-    unzip mjpro150_linux.zip && \
-    curl -O https://www.roboti.us/download/mujoco200_linux.zip && \
-    unzip mujoco200_linux.zip && \
-    mv mujoco200_linux mujoco200
+    unzip mjpro150_linux.zip
 
 ARG MUJOCO_KEY
 ARG PYTHON_VER
 ENV MUJOCO_KEY=$MUJOCO_KEY
 
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mjpro150/bin
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mujoco200/bin
 RUN echo $MUJOCO_KEY | base64 --decode > /root/.mujoco/mjkey.txt
 RUN pip install pytest pytest-forked lz4
 

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ extras = {
   'atari': ['atari_py~=0.2.0', 'Pillow', 'opencv-python'],
   'box2d': ['box2d-py~=2.3.5'],
   'classic_control': [],
-  'mujoco': ['mujoco_py>=1.50, <2.1', 'imageio'],
-  'robotics': ['mujoco_py>=1.50, <2.1', 'imageio'],
+  'mujoco': ['mujoco_py>=1.50, <2.0', 'imageio'],
+  'robotics': ['mujoco_py>=1.50, <2.0', 'imageio'],
 }
 
 # Meta dependency groups.


### PR DESCRIPTION
It looks like we upgraded to mujoco-py 2.0 without testing it: https://github.com/openai/gym/pull/1401 unlike the upgrade to 1.5: https://github.com/openai/gym/pull/834

Perhaps as a result we have some issue with missing contact forces: https://github.com/openai/gym/issues/1541

For now, we can downgrade to only supporting mujoco-py <2.0 until there is a compelling reason to upgrade to 2.0 and some testing is done.