### PR TITLE
[Wrappers]: TimeStepEnv

### DIFF
--- a/gym/wrappers/__init__.py
+++ b/gym/wrappers/__init__.py
@@ -13,3 +13,4 @@ from gym.wrappers.transform_reward import TransformReward
 from gym.wrappers.resize_observation import ResizeObservation
 from gym.wrappers.clip_action import ClipAction
 from gym.wrappers.record_episode_statistics import RecordEpisodeStatistics
+from gym.wrappers.timestep_env import TimeStepEnv

--- a/gym/wrappers/test_timestep_env.py
+++ b/gym/wrappers/test_timestep_env.py
@@ -1,0 +1,38 @@
+import pytest
+
+import numpy as np
+
+import gym
+from gym.wrappers import TimeStepEnv
+
+
+@pytest.mark.parametrize('env_id', ['CartPole-v1', 'Pendulum-v0'])
+def test_timestep_env(env_id):
+    env = gym.make(env_id)
+    wrapped_env = TimeStepEnv(gym.make(env_id))
+
+    env.seed(0)
+    wrapped_env.seed(0)
+
+    obs = env.reset()
+    timestep = wrapped_env.reset()
+    assert timestep.first()
+    assert np.allclose(timestep.observation, obs)
+
+    for t in range(env.spec.max_episode_steps):
+        action = env.action_space.sample()
+        obs, reward, done, info = env.step(action)
+        timestep = wrapped_env.step(action)
+        assert np.allclose(timestep.observation, obs)
+        assert timestep.reward == reward
+        assert timestep.done == done
+        assert timestep.info == info
+        if done:
+            assert timestep.last()
+            if 'TimeLimit.truncated' in info and info['TimeLimit.truncated']:
+                assert timestep.time_limit()
+            else:
+                assert timestep.terminal()
+            break
+        else:
+            assert timestep.mid()

--- a/gym/wrappers/timestep_env.py
+++ b/gym/wrappers/timestep_env.py
@@ -1,0 +1,58 @@
+from enum import IntEnum
+from dataclasses import dataclass
+
+import gym
+
+
+class StepType(IntEnum):
+    FIRST = 0
+    MID = 1
+    LAST = 2
+
+
+@dataclass
+class TimeStep:
+    step_type: StepType
+    observation: object
+    reward: float
+    done: bool
+    info: dict
+
+    def __getitem__(self, key):
+        return self.info[key]
+
+    def first(self):
+        if self.step_type == StepType.FIRST:
+            assert all([x is None for x in [self.reward, self.done, self.info]])
+        return self.step_type == StepType.FIRST
+
+    def mid(self):
+        if self.step_type == StepType.MID:
+            assert not self.first() and not self.last()
+        return self.step_type == StepType.MID
+
+    def last(self):
+        if self.step_type == StepType.LAST:
+            assert self.done is not None and self.done
+        return self.step_type == StepType.LAST
+
+    def time_limit(self):
+        return self.last() and self.info.get('TimeLimit.truncated', False)
+
+    def terminal(self):
+        return self.last() and not self.time_limit()
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({self.step_type.name})'
+
+
+class TimeStepEnv(gym.Wrapper):
+    def step(self, action):
+        observation, reward, done, info = self.env.step(action)
+        step_type = StepType.LAST if done else StepType.MID
+        timestep = TimeStep(step_type=step_type, observation=observation, reward=reward, done=done, info=info)
+        return timestep
+
+    def reset(self, **kwargs):
+        observation = self.env.reset(**kwargs)
+        return TimeStep(StepType.FIRST, observation=observation, reward=None, done=None, info=None)


### PR DESCRIPTION
It might be helpful to support this wrapper to enforce output consistency between `step` and `reset`. Implemented as a wrapper in order not to break the current gym API. 

Some discussions in #1683
@christopherhesse @keskival