### PR TITLE
Fix Box sampling bug

### DIFF
--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -99,7 +99,7 @@ class Box(Space):
             size=low_bounded[low_bounded].shape) + self.low[low_bounded]
         
         sample[upp_bounded] = -self.np_random.exponential(
-            size=upp_bounded[upp_bounded].shape) - self.high[upp_bounded]
+            size=upp_bounded[upp_bounded].shape) + self.high[upp_bounded]
         
         sample[bounded] = self.np_random.uniform(low=self.low[bounded], 
                                             high=high[bounded],

--- a/gym/spaces/tests/test_spaces.py
+++ b/gym/spaces/tests/test_spaces.py
@@ -91,7 +91,7 @@ def test_sample(space):
         elif space.is_bounded("below"):
             expected_mean = 1 + space.low
         elif space.is_bounded("above"):
-            expected_mean = -1 - space.high
+            expected_mean = -1 + space.high
         else:
             expected_mean = 0.
     elif isinstance(space, Discrete):


### PR DESCRIPTION
In case of up-bounded `(-oo, b]` sampling the shifted negative exponential distribution had expected mean value equal to `-1-b` but we want the mean value to have been expected equal to `b-1` in this case