### PR TITLE
Discrete contains may not handle numpy types correctly

### DIFF
--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -21,7 +21,7 @@ class Discrete(Space):
     def contains(self, x):
         if isinstance(x, int):
             as_int = x
-        elif isinstance(x, (np.generic, np.ndarray)) and (x.dtype.kind in np.typecodes['AllInteger'] and x.shape == ()):
+        elif isinstance(x, (np.generic, np.ndarray)) and (x.dtype.char in np.typecodes['AllInteger'] and x.shape == ()):
             as_int = int(x)
         else:
             return False


### PR DESCRIPTION
```
np.uint8(0).dtype.kind in np.typecodes['AllInteger'] == False
np.uint8(0).dtype.char in np.typecodes['AllInteger'] == True
```

```
dtype.kind	A character code (one of ‘biufcmMOSUV’) identifying the general kind of data.
dtype.char	A unique character code for each of the 21 different built-in types.
```