### PR TITLE
Fix BipedalWalker - now returns closest lidar trace instead of furthest

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -109,14 +109,14 @@ register(
 )
 
 register(
-    id='BipedalWalker-v2',
+    id='BipedalWalker-v3',
     entry_point='gym.envs.box2d:BipedalWalker',
     max_episode_steps=1600,
     reward_threshold=300,
 )
 
 register(
-    id='BipedalWalkerHardcore-v2',
+    id='BipedalWalkerHardcore-v3',
     entry_point='gym.envs.box2d:BipedalWalkerHardcore',
     max_episode_steps=2000,
     reward_threshold=300,

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -365,7 +365,7 @@ class BipedalWalker(gym.Env, EzPickle):
         class LidarCallback(Box2D.b2.rayCastCallback):
             def ReportFixture(self, fixture, point, normal, fraction):
                 if (fixture.filterData.categoryBits & 1) == 0:
-                    return 1
+                    return -1
                 self.p2 = point
                 self.fraction = fraction
                 return fraction

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -368,7 +368,7 @@ class BipedalWalker(gym.Env, EzPickle):
                     return 1
                 self.p2 = point
                 self.fraction = fraction
-                return 0
+                return fraction
         self.lidar = [LidarCallback() for _ in range(10)]
 
         return self.step(np.array([0,0,0,0]))[0]


### PR DESCRIPTION
Finding this bug makes me even more impressed anyone has solved BipedalWalkerHardcore-v2 - it seems the observations from lidar have been inconsistent and incorrect, returning the furthest hit result instead of closest.

In screenshots below, I've tweaked the lidar drawing routine to draw last (in front of terrain and objects), and draw every trace each frame to more clearly see what's happening.

Before fix - lidar traces through ground, and hits the side of a pit, giving the agent the impression of a "phantom canyon" in front of the pit, that only appears as it approaches the pit: https://i.imgur.com/XKPnRTR.png

After fix - lidar is stopped by terrain, even when another object is behind it: https://i.imgur.com/Gg8B5BD.png

It feels very counter-intuitive for Box2Ds raycast to return furthest point first, but when I (double) checked the PyBox2D docs, I found that is indeed how it works: https://github.com/pybox2d/pybox2d/wiki/manual

> ... By returning
    0, you set the ray length to zero. By returning the current fraction, you proceed
    to find the **closest point**.

@olegklimov Tagging you since your name pops up the most in relation to BipedalWalker-v2

I've just restarted my models training with this fix applied, and been watching the traces like a hawk - worth noting it still seems to be imperfect sometimes - slightly penetrating a surface, but still looks much more accurate.
 