### PR TITLE
Fix bug in atari_preprocessing.py

### DIFF
--- a/gym/wrappers/atari_preprocessing.py
+++ b/gym/wrappers/atari_preprocessing.py
@@ -88,14 +88,14 @@ class AtariPreprocessing(gym.Wrapper):
                 break
             if t == self.frame_skip - 2:
                 if self.grayscale_obs:
-                    self.ale.getScreenGrayscale(self.obs_buffer[0])
-                else:
-                    self.ale.getScreenRGB2(self.obs_buffer[0])
-            elif t == self.frame_skip - 1:
-                if self.grayscale_obs:
                     self.ale.getScreenGrayscale(self.obs_buffer[1])
                 else:
                     self.ale.getScreenRGB2(self.obs_buffer[1])
+            elif t == self.frame_skip - 1:
+                if self.grayscale_obs:
+                    self.ale.getScreenGrayscale(self.obs_buffer[0])
+                else:
+                    self.ale.getScreenRGB2(self.obs_buffer[0])
         return self._get_obs(), R, done, info
 
     def reset(self, **kwargs):


### PR DESCRIPTION
Correct bug that prevents AtariPreprocessing from working with `frame_skip = 1`.

Previously, the last frame of the frame skip loop would be stored at index 1 of `self.obs_buffer`, but it is actually the frame at index 0 that is processed and returned. 