### PR TITLE
Add usage for MultiBinary space

### DIFF
--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -3,6 +3,17 @@ from .space import Space
 
 
 class MultiBinary(Space):
+    '''
+    An n-dimensional binary space. 
+
+    The argument to MultiBinary defines n.
+    
+    Example Usage:
+    
+    self.observation_space = spaces.MultiBinary(5)
+    
+
+    '''
     def __init__(self, n):
         self.n = n
         super(MultiBinary, self).__init__((self.n,), np.int8)

--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -10,10 +10,14 @@ class MultiBinary(Space):
     
     Example Usage:
     
-    self.observation_space = spaces.MultiBinary(5)
-    
+    >> self.observation_space = spaces.MultiBinary(5)
+
+    >> self.observation_space.sample()
+
+        array([0,1,0,1,0], dtype =int8)
 
     '''
+    
     def __init__(self, n):
         self.n = n
         super(MultiBinary, self).__init__((self.n,), np.int8)


### PR DESCRIPTION
All spaces come with a definition and an example usage except for Multibinary(). Adding usage provides uniformity in documentation and ease of understanding.