### PR TITLE
Made observation spaces Dict iterable

### DIFF
--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -62,6 +62,10 @@ class Dict(Space):
 
     def __getitem__(self, key):
         return self.spaces[key]
+        
+    def __iter__(self):
+        for key in self.spaces:
+            yield key
 
     def __repr__(self):
         return "Dict(" + ", ". join([str(k) + ":" + str(s) for k, s in self.spaces.items()]) + ")"


### PR DESCRIPTION
So far, the Dict in gym.spaces was crashing when one tries to iterate through it. This happened because it had a __getitem__() method defined, but no __iter__(). Hence:
```
for key in Dict():
```
lead to 
```
for key in Dict():
  File "/opt/anaconda/lib/python3.7/site-packages/gym/spaces/dict.py", line 64, in __getitem__
    return self.spaces[key]
KeyError: 0
```

I fixed this by adding a __iter__ method to Dict. Now it is iterable.