### PR TITLE
made fetchenv sample goal flexible

### DIFF
--- a/gym/envs/robotics/fetch_env.py
+++ b/gym/envs/robotics/fetch_env.py
@@ -160,7 +160,7 @@ class FetchEnv(robot_env.RobotEnv):
             if self.target_in_the_air and self.np_random.uniform() < 0.5:
                 goal[2] += self.np_random.uniform(0, 0.45)
         else:
-            goal = self.initial_gripper_xpos[:3] + self.np_random.uniform(-0.15, 0.15, size=3)
+            goal = self.initial_gripper_xpos[:3] + self.np_random.uniform(-self.target_range, self.target_range, size=3)
         return goal.copy()
 
     def _is_success(self, achieved_goal, desired_goal):


### PR DESCRIPTION
I'm doing curriculum learning on FetchEnvs but found that the target range of FetchEnvs is set fixed here:
`goal = self.initial_gripper_xpos[:3] + self.np_random.uniform(-0.15, 0.15, size=3)`

It's better set to `goal = self.initial_gripper_xpos[:3] + self.np_random.uniform(-self.target_range, self.target_range, size=3)`, thus we can change the range of sample goals by initializing the environment. After updating this, the environment can be more compatible.

And I have also checked that HandEnvs don't have such problem.
