### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ env:
   - PY_VER=3.6.12
   - PY_VER=3.7.9
   - PY_VER=3.8.6
+  - PY_VER=3.9.0
 
 install: "" # so travis doesn't do pip install requirements.txt
 script:
   - docker build -f py.Dockerfile --build-arg MUJOCO_KEY=$MUJOCO_KEY --build-arg PYTHON_VER=$PY_VER -t gym-test .
-  - docker run gym-test 
+  - docker run gym-test
 
 deploy:
     provider: pypi

--- a/gym/wrappers/pixel_observation.py
+++ b/gym/wrappers/pixel_observation.py
@@ -2,12 +2,9 @@
 
 import collections
 import copy
-try:
-    from collections.abc import MutableMapping
-except ImportError:
-    from collections import MutableMapping
 
 import numpy as np
+from six.moves.collections_abc import MutableMapping
 
 from gym import spaces
 from gym import ObservationWrapper

--- a/gym/wrappers/pixel_observation.py
+++ b/gym/wrappers/pixel_observation.py
@@ -2,6 +2,10 @@
 
 import collections
 import copy
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 import numpy as np
 
@@ -60,7 +64,7 @@ class PixelObservationWrapper(ObservationWrapper):
             self._observation_is_dict = False
             invalid_keys = set([STATE_KEY])
         elif isinstance(wrapped_observation_space,
-                        (spaces.Dict, collections.MutableMapping)):
+                        (spaces.Dict, MutableMapping)):
             self._observation_is_dict = True
             invalid_keys = set(wrapped_observation_space.spaces.keys())
         else:

--- a/gym/wrappers/pixel_observation.py
+++ b/gym/wrappers/pixel_observation.py
@@ -2,9 +2,9 @@
 
 import collections
 import copy
+from collections.abc import MutableMapping
 
 import numpy as np
-from six.moves.collections_abc import MutableMapping
 
 from gym import spaces
 from gym import ObservationWrapper


### PR DESCRIPTION
Fixes #1798 