### PR TITLE
Pick up a newer version of cloudpickle.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='gym',
                 if package.startswith('gym')],
       zip_safe=False,
       install_requires=[
-          'scipy', 'numpy>=1.10.4', 'six', 'pyglet>=1.4.0,<=1.5.0', 'cloudpickle~=1.2.0',
+          'scipy', 'numpy>=1.10.4', 'six', 'pyglet>=1.4.0,<=1.5.0', 'cloudpickle~=1.3.0',
           'enum34~=1.1.6;python_version<"3.4"',
       ],
       extras_require=extras,


### PR DESCRIPTION
Early versions of cloudpickle have an inconvenient side-effect that makes `cloudpickle<1.3.0`, and libraries that depend on these versions, hard to use together with libraries that use different picklers.

See: https://github.com/cloudpipe/cloudpickle/issues/82
