### PR TITLE
Typo: enviroment --> environment

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -58,7 +58,7 @@ class EnvSpec(object):
             cls = load(self.entry_point)
             env = cls(**_kwargs)
 
-        # Make the enviroment aware of which spec it came from.
+        # Make the environment aware of which spec it came from.
         env.unwrapped.spec = self
 
         return env

--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -217,7 +217,7 @@ class AsyncVectorEnv(VectorEnv):
             A vector whose entries indicate whether the episode has ended.
 
         infos : list of dict
-            A list of auxiliary diagnostic informations.
+            A list of auxiliary diagnostic information.
         """
         self._assert_is_running()
         if self._state != AsyncState.WAITING_STEP:


### PR DESCRIPTION
Fix a typo discovered via [codespell](https://github.com/codespell-project/codespell).