### PR TITLE
Add gym-jiminy in the third-party environments doc

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -243,3 +243,9 @@ Learn more here: https://github.com/aigagror/GymGo
 An environment for simulating a wide variety of electric drives taking into account different types of electric motors and converters. Control schemes can be continuous, yielding a voltage duty cycle, or discrete, determining converter switching states directly.
 
 Learn more here: https://github.com/upb-lea/gym-electric-motor
+
+### gym-jiminy: training Robots in Jiminy
+
+gym-jiminy presents an extension of the initial OpenAI gym for robotics using Jiminy, an extremely fast and light weight simulator for poly-articulated systems using Pinocchio for physics evaluation and Meshcat for web-based 3D rendering.
+
+Learn more here: https://github.com/Wandercraft/jiminy


### PR DESCRIPTION
I have developed a new open source simulator for poly-articulated system called Jiminy. It relies on the powerful rigid body dynamics framework Pinocchio for the physics evaluation, and meshcat for real-time visualization.
I think the project is now mature enough for everyone to use it, despite being partially undocumented. The library has been designed for fast prototyping of control algorithms and machine learning. It is easy to use and several examples of classical control theory and machine learning are available (cartpole, double and simple pendulums).