### PR TITLE
Make reward always return a float number

### DIFF
--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -94,16 +94,16 @@ class BlackjackEnv(gym.Env):
             self.player.append(draw_card(self.np_random))
             if is_bust(self.player):
                 done = True
-                reward = -1
+                reward = -1.
             else:
                 done = False
-                reward = 0
+                reward = 0.
         else:  # stick: play out the dealers hand, and score
             done = True
             while sum_hand(self.dealer) < 17:
                 self.dealer.append(draw_card(self.np_random))
             reward = cmp(score(self.player), score(self.dealer))
-            if self.natural and is_natural(self.player) and reward == 1:
+            if self.natural and is_natural(self.player) and reward == 1.:
                 reward = 1.5
         return self._get_obs(), reward, done, {}
 


### PR DESCRIPTION
https://github.com/openai/gym/issues/1858

In the current implementation, `reward` sometimes returns integer values, and other times returns float values.

The example below corresponds to three random episodes and showcases how reward contains both `-1.0` and `-1` values.

```
[((13, 1, False), 0, -1.0)]
[((18, 10, False), 1, -1)]
[((5, 10, False), 1, 0), ((8, 10, False), 1, 0), ((18, 10, False), 1, 0), ((20, 10, False), 0, -1.0)]

```
This change tries to fix the above, guaranteeing that a float value is always returned.

Hope it helps!
Miguel