### PR TITLE
Update stored spec object with kwargs

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -1,4 +1,5 @@
 import re
+import copy
 import importlib
 import warnings
 
@@ -59,7 +60,9 @@ class EnvSpec(object):
             env = cls(**_kwargs)
 
         # Make the environment aware of which spec it came from.
-        env.unwrapped.spec = self
+        spec = copy.deepcopy(self)
+        spec._kwargs = _kwargs
+        env.unwrapped.spec = spec
 
         return env
 

--- a/gym/envs/tests/test_registration.py
+++ b/gym/envs/tests/test_registration.py
@@ -44,6 +44,11 @@ def test_spec():
     spec = envs.spec('CartPole-v0')
     assert spec.id == 'CartPole-v0'
 
+def test_spec_with_kwargs():
+    map_name_value = '8x8'
+    env = gym.make('FrozenLake-v0', map_name=map_name_value)
+    assert env.spec._kwargs['map_name'] == map_name_value
+
 def test_missing_lookup():
     registry = registration.EnvRegistry()
     registry.register(id='Test-v0', entry_point=None)


### PR DESCRIPTION
Let's consider a registered environment with kwargs:

https://github.com/openai/gym/blob/54f22cf4db2e43063093a1b15d968a57a32b6e90/gym/envs/__init__.py#L150-L156

When users create environment with `gym.make`, they can pass extra options that override the values of the default kwargs:

```python
>>> import gym
>>> env = gym.make('FrozenLake-v0', map_name='8x8')
```

The environment is constructed with the updated kwargs, however the current logic [1] does not update the `env.spec` attribute of the resulting `env` object. In fact:

```python
>>> env.spec._kwargs
{'map_name': '4x4'}
``` 

This PR updates the logic of the `EnvSpec.make` method to store the `spec` object that was actually used for constructing the environment.

---

[1] Current logic: the `_kwargs` variable modified with the `**kwargs` option is not part of the `self` instance that is stored in the `spec` attribute of the environment.

https://github.com/openai/gym/blob/54f22cf4db2e43063093a1b15d968a57a32b6e90/gym/envs/registration.py#L49-L64