### PR TITLE
Avoid precision warning when creating gym.spaces.Box with scalar bounds

### DIFF
--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -9,13 +9,13 @@ class Box(Space):
     A (possibly unbounded) box in R^n. Specifically, a Box represents the
     Cartesian product of n closed intervals. Each interval has the form of one
     of [a, b], (-oo, b], [a, oo), or (-oo, oo).
-    
+
     There are two common use cases:
-    
+
     * Identical bound for each dimension::
         >>> Box(low=-1.0, high=2.0, shape=(3, 4), dtype=np.float32)
         Box(3, 4)
-        
+
     * Independent bound for each dimension::
         >>> Box(low=np.array([-1.0, -2.0]), high=np.array([2.0, 4.0]), dtype=np.float32)
         Box(2,)
@@ -33,8 +33,8 @@ class Box(Space):
         else:
             assert np.isscalar(low) and np.isscalar(high), 'box requires scalar bounds. '
             self.shape = tuple(shape)
-            self.low = np.full(self.shape, low)
-            self.high = np.full(self.shape, high)
+            self.low = np.full(self.shape, low, dtype=dtype)
+            self.high = np.full(self.shape, high, dtype=dtype)
 
         def _get_precision(dtype):
             if np.issubdtype(dtype, np.floating):
@@ -69,12 +69,12 @@ class Box(Space):
 
     def sample(self):
         """
-        Generates a single random sample inside of the Box. 
+        Generates a single random sample inside of the Box.
 
         In creating a sample of the box, each coordinate is sampled according to
         the form of the interval:
-        
-        * [a, b] : uniform distribution 
+
+        * [a, b] : uniform distribution
         * [a, oo) : shifted exponential distribution
         * (-oo, b] : shifted negative exponential distribution
         * (-oo, oo) : normal distribution
@@ -89,7 +89,7 @@ class Box(Space):
         upp_bounded = ~self.bounded_below &  self.bounded_above
         low_bounded =  self.bounded_below & ~self.bounded_above
         bounded     =  self.bounded_below &  self.bounded_above
-        
+
 
         # Vectorized sampling by interval type
         sample[unbounded] = self.np_random.normal(
@@ -97,18 +97,18 @@ class Box(Space):
 
         sample[low_bounded] = self.np_random.exponential(
             size=low_bounded[low_bounded].shape) + self.low[low_bounded]
-        
+
         sample[upp_bounded] = -self.np_random.exponential(
             size=upp_bounded[upp_bounded].shape) + self.high[upp_bounded]
-        
-        sample[bounded] = self.np_random.uniform(low=self.low[bounded], 
+
+        sample[bounded] = self.np_random.uniform(low=self.low[bounded],
                                             high=high[bounded],
                                             size=bounded[bounded].shape)
         if self.dtype.kind == 'i':
             sample = np.floor(sample)
 
         return sample.astype(self.dtype)
-        
+
     def contains(self, x):
         if isinstance(x, list):
             x = np.array(x)  # Promote list to array for contains check


### PR DESCRIPTION
Fixes #1844 
I can undo the white space trimming if that is preferred.