### PR TITLE
Rewrite LazyFrames.__getitem__ to only decompress if needed

### DIFF
--- a/gym/wrappers/test_frame_stack.py
+++ b/gym/wrappers/test_frame_stack.py
@@ -34,6 +34,3 @@ def test_frame_stack(env_id, num_stack, lz4_compress):
     for i in range(1, num_stack - 1):
         assert np.allclose(obs[i - 1], obs[i])
     assert not np.allclose(obs[-1], obs[-2])
-
-    obs, _, _, _ = env.step(env.action_space.sample())
-    assert np.allclose(obs.last_frame, obs[-1])

--- a/gym/wrappers/test_frame_stack.py
+++ b/gym/wrappers/test_frame_stack.py
@@ -34,3 +34,6 @@ def test_frame_stack(env_id, num_stack, lz4_compress):
     for i in range(1, num_stack - 1):
         assert np.allclose(obs[i - 1], obs[i])
     assert not np.allclose(obs[-1], obs[-2])
+
+    obs, _, _, _ = env.step(env.action_space.sample())
+    assert np.allclose(obs.last_frame, obs[-1])


### PR DESCRIPTION
This is a relatively small PR. It adds the `LazyFrames.last_frame` property for efficient extraction of the last frame contained in a `LazyFrames` frame stack.

This is particularly useful when you want to insert frames into an experience-replay buffer without duplication.

A counter-argument against adding this property might be to say that this functionality is already covered by `__getitem__`, e.g. `lazy_frames[-1]`. The added benefit of using `last_frame` instead is that it skips the `__array__` call.

Oh and I also added some lines of documentation for `lz4_compress`.