### PR TITLE
Fixed close() method for Viewer to be consistent with SimpleImageViewer

### DIFF
--- a/gym/envs/classic_control/rendering.py
+++ b/gym/envs/classic_control/rendering.py
@@ -78,7 +78,10 @@ class Viewer(object):
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
 
     def close(self):
-        self.window.close()
+        if self.isopen and sys.meta_path:
+            # ^^^ check sys.meta_path to avoid 'ImportError: sys.meta_path is None, Python is likely shutting down'
+            self.window.close()
+            self.isopen = False
 
     def window_closed_by_user(self):
         self.isopen = False


### PR DESCRIPTION
Small fix for close() method for Viewer to be consistent with SimpleImageViewer, otherwise I get the same error:

```
Exception ignored in: <bound method Viewer.__del__ of <gym.envs.classic_control.rendering.Viewer object at 0x112ea2f60>>
Traceback (most recent call last):
  File "/Users/hadavid/anaconda/lib/python3.6/site-packages/gym/envs/classic_control/rendering.py", line 162, in __del__
  File "/Users/hadavid/anaconda/lib/python3.6/site-packages/gym/envs/classic_control/rendering.py", line 81, in close
  File "/Users/hadavid/anaconda/lib/python3.6/site-packages/pyglet/window/cocoa/__init__.py", line 277, in close
  File "/Users/hadavid/anaconda/lib/python3.6/site-packages/pyglet/window/__init__.py", line 820, in close
ImportError: sys.meta_path is None, Python is likely shutting down
```