### PR TITLE
Fix: FrozenLake-v0 | is_valid function | condition

### DIFF
--- a/gym/envs/toy_text/frozen_lake.py
+++ b/gym/envs/toy_text/frozen_lake.py
@@ -55,7 +55,7 @@ def generate_random_map(size=8, p=0.8):
                         continue
                     if res[r_new][c_new] == 'G':
                         return True
-                    if (res[r_new][c_new] not in '#H'):
+                    if (res[r_new][c_new] !='H'):
                         frontier.append((r_new, c_new))
         return False
 


### PR DESCRIPTION
The following conditional statement appears incorrect:
line 58: if (res[r_new][c_new] not in '#H'):

I expected 'H' not '#H'. My recommendation is:

line 58: if (res[r_new][c_new] != 'H'):
