### PR TITLE
Set default image color to white

### DIFF
--- a/gym/envs/classic_control/rendering.py
+++ b/gym/envs/classic_control/rendering.py
@@ -321,6 +321,7 @@ class Line(Geom):
 class Image(Geom):
     def __init__(self, fname, width, height):
         Geom.__init__(self)
+        self.set_color(1.0, 1.0, 1.0)
         self.width = width
         self.height = height
         img = pyglet.image.load(fname)


### PR DESCRIPTION
In gym.envs.classic_control.rendering, Geom has a color attribute, [which is initialized as black](https://github.com/openai/gym/blob/2ec4881c22b129d1f06173d136529477c0d8d975/gym/envs/classic_control/rendering.py#L175). This is a good default for most Geom subclasses, such as lines and circles. However, in the case of Image instances, this causes images to be rendered as black, which seems undesirable; in particular, if the image does not have transparency, the rendered result is a black rectangle.

This has been shown to cause confusion amongst users:
https://stackoverflow.com/questions/59410495/python-pyglet-rgb-image-is-just-black
https://stackoverflow.com/questions/61024893/how-can-i-load-my-own-picture-in-openai-gym

This can be easily fixed by setting the default color for Image instances as white, which causes images to be displayed normally.

Example code and before/after results:

```python
from gym.envs.classic_control import rendering

viewer = rendering.Viewer(800, 600)
viewer.set_bounds(-110, 110, -110, 110)
image = rendering.Image('soccer-field.jpg', 200, 200)
viewer.add_geom(image)
viewer.render()

```

Before:
![soccer-field-black-square](https://user-images.githubusercontent.com/11532313/82718883-70b32600-9c5a-11ea-82e0-9845a126addc.png)

After:
![soccer-field-visible](https://user-images.githubusercontent.com/11532313/82718890-81fc3280-9c5a-11ea-8abc-a9022b7450aa.png)
