### PR TITLE
Fix linux dependencies in Readme.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,8 +91,8 @@ see the composition of our CI-tested images.
 On Ubuntu 16.04 and 18.04:
 
 .. code:: shell
+    
     apt-get install -y libglu1-mesa-dev libgl1-mesa-dev libosmesa6-dev xvfb ffmpeg curl patchelf libglfw3 libglfw3-dev
-
 
 MuJoCo has a proprietary dependency we can't set up for you. Follow
 the

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ On Ubuntu 16.04 and 18.04:
 
 .. code:: shell
     
-    apt-get install -y libglu1-mesa-dev libgl1-mesa-dev libosmesa6-dev xvfb ffmpeg curl patchelf libglfw3 libglfw3-dev
+    apt-get install -y libglu1-mesa-dev libgl1-mesa-dev libosmesa6-dev xvfb ffmpeg curl patchelf libglfw3 libglfw3-dev cmake zlib1g zlib1g-dev swig
 
 MuJoCo has a proprietary dependency we can't set up for you. Follow
 the


### PR DESCRIPTION
Due to bad formatting the `apt-install ...` command is not readable on github.
Also a couple of dependencies for `atari-py` and `box2d-py` are missing: `cmake zlib1g zlib1g-dev swig`.