### PR TITLE
BlackJack-v0: Allow dealer to lose by going over...

### DIFF
--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -102,7 +102,10 @@ class BlackjackEnv(gym.Env):
             done = True
             while sum_hand(self.dealer) < 17:
                 self.dealer.append(draw_card(self.np_random))
-            reward = cmp(score(self.player), score(self.dealer))
+            if is_bust(self.dealer):
+                reward = 1.
+            else:
+                reward = cmp(score(self.player), score(self.dealer))
             if self.natural and is_natural(self.player) and reward == 1.:
                 reward = 1.5
         return self._get_obs(), reward, done, {}


### PR DESCRIPTION
Currently the dealer can go over 21 and still win. This patch fixes this by checking whether the dealer is bust after drawing