### PR TITLE
include low, high, & dtype in spaces.Box.__repr__

### DIFF
--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -134,7 +134,7 @@ class Box(Space):
         return [np.asarray(sample) for sample in sample_n]
 
     def __repr__(self):
-        return f"Box({self.low.min()}, {self.high.max()}, {self.shape}, {self.dtype})"
+        return "Box({)}, {}, {}, {})".format(self.low.min(), self.high.max(), self.shape, self.dtype)
 
     def __eq__(self, other):
         return isinstance(other, Box) and (self.shape == other.shape) and np.allclose(self.low, other.low) and np.allclose(self.high, other.high)

--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -134,7 +134,7 @@ class Box(Space):
         return [np.asarray(sample) for sample in sample_n]
 
     def __repr__(self):
-        return "Box" + str(self.shape)
+        return f"Box({self.low.min()}, {self.high.max()}, {self.shape}, {self.dtype})"
 
     def __eq__(self, other):
         return isinstance(other, Box) and (self.shape == other.shape) and np.allclose(self.low, other.low) and np.allclose(self.high, other.high)

--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -134,7 +134,7 @@ class Box(Space):
         return [np.asarray(sample) for sample in sample_n]
 
     def __repr__(self):
-        return "Box({)}, {}, {}, {})".format(self.low.min(), self.high.max(), self.shape, self.dtype)
+        return "Box({}, {}, {}, {})".format(self.low.min(), self.high.max(), self.shape, self.dtype)
 
     def __eq__(self, other):
         return isinstance(other, Box) and (self.shape == other.shape) and np.allclose(self.low, other.low) and np.allclose(self.high, other.high)


### PR DESCRIPTION
multitask learners need a way to make a sensor for each space, and it's possible for two different Box spaces to have the same shape but different low/high/dtype, so this pull request just adds the minimum low value, maximum high value, and the dtype to `Box.__repr__` so we can use `str(box_space)` as a key in a ModuleDict of sensors (helps normalize inputs)