### PR TITLE
Update README to reflect MuJoCo version support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,9 @@ On Ubuntu 16.04 and 18.04:
 MuJoCo has a proprietary dependency we can't set up for you. Follow
 the
 `instructions <https://github.com/openai/mujoco-py#obtaining-the-binaries-and-license-key>`_
-in the ``mujoco-py`` package for help.  As an alternative to ``mujoco-py``, consider `PyBullet <https://github.com/openai/gym/blob/master/docs/environments.md#pybullet-robotics-environments>`_ which uses the open source Bullet physics engine and has no license requirement.
+in the ``mujoco-py`` package for help. Note that we currently do not support MuJoCo 2.0, so you will need to install the version of mujoco-py which is built
+for MuJoCo 1.5 (like ``mujoco-py-1.50.1.0``).
+As an alternative to ``mujoco-py``, consider `PyBullet <https://github.com/openai/gym/blob/master/docs/environments.md#pybullet-robotics-environments>`_ which uses the open source Bullet physics engine and has no license requirement.
 
 Once you're ready to install everything, run ``pip install -e '.[all]'`` (or ``pip install 'gym[all]'``).
 

--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,8 @@ On Ubuntu 16.04 and 18.04:
 MuJoCo has a proprietary dependency we can't set up for you. Follow
 the
 `instructions <https://github.com/openai/mujoco-py#obtaining-the-binaries-and-license-key>`_
-in the ``mujoco-py`` package for help. Note that we currently do not support MuJoCo 2.0, so you will need to install the version of mujoco-py which is built
-for MuJoCo 1.5 (like ``mujoco-py-1.50.1.0``).
+in the ``mujoco-py`` package for help. Note that we currently do not support MuJoCo 2.0 and above, so you will need to install a version of mujoco-py which is built
+for a lower version of MuJoCo like MuJoCo 1.5 (example - ``mujoco-py-1.50.1.0``).
 As an alternative to ``mujoco-py``, consider `PyBullet <https://github.com/openai/gym/blob/master/docs/environments.md#pybullet-robotics-environments>`_ which uses the open source Bullet physics engine and has no license requirement.
 
 Once you're ready to install everything, run ``pip install -e '.[all]'`` (or ``pip install 'gym[all]'``).


### PR DESCRIPTION
An older version of mujoco-py needs to be installed with openai-gym, than what is available in master of mujoco-py repo. It is helpful to make a note here till openai-gym starts supporting >= MuJoCo 2.0 again.

This is related to #1883, https://github.com/openai/baselines/issues/1055