### PR TITLE
Populate TimeLimit.truncated on every step

### DIFF
--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -15,8 +15,9 @@ class TimeLimit(gym.Wrapper):
         assert self._elapsed_steps is not None, "Cannot call env.step() before calling reset()"
         observation, reward, done, info = self.env.step(action)
         self._elapsed_steps += 1
-        if self._elapsed_steps >= self._max_episode_steps:
-            info['TimeLimit.truncated'] = not done
+        info['TimeLimit.truncated'] = False
+        if self._elapsed_steps >= self._max_episode_steps and not done:
+            info['TimeLimit.truncated'] = True
             done = True
         return observation, reward, done, info
 


### PR DESCRIPTION
Writing samplers which use the `info` return from `Env.step()` is much easier if the keys in `info` are stable.

This PR populates `info['TimeLimit.truncated']` on every step of training, not just on truncated steps. This allows samplers to test for timeouts without having to test for key existence first.