### PR TITLE
Remove dependency from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(name='gym',
       zip_safe=False,
       install_requires=[
           'scipy', 'numpy>=1.10.4', 'pyglet>=1.4.0,<=1.5.0', 'cloudpickle>=1.2.0,<1.4.0',
-          'enum34~=1.1.6;python_version<"3.4"',
       ],
       extras_require=extras,
       package_data={'gym': [


### PR DESCRIPTION
Python 3.4 was dropped, so enum34 is no longer required.