### PR TITLE
Add support for tuple input on MultiBinary space

### DIFF
--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -19,11 +19,13 @@ class MultiBinary(Space):
     '''
     
     def __init__(self, n):
-        if type(n) in [tuple, list] and len(n) != 1:
-            self.n = tuple(n)
+        self.n = n
+        if (type(n) in [tuple, list] and len(n) != 1) \
+            or (type(n) is np.ndarray and len(n.shape) != 1):
+            input_n = n
         else:
-            self.n = (n, )
-        super(MultiBinary, self).__init__(self.n, np.int8)
+            input_n = (n, )
+        super(MultiBinary, self).__init__(input_n, np.int8)
 
     def sample(self):
         return self.np_random.randint(low=0, high=2, size=self.n, dtype=self.dtype)
@@ -35,7 +37,7 @@ class MultiBinary(Space):
 
     def to_jsonable(self, sample_n):
         return np.array(sample_n).tolist()
-
+    
     def from_jsonable(self, sample_n):
         return [np.asarray(sample) for sample in sample_n]
 

--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -19,8 +19,11 @@ class MultiBinary(Space):
     '''
     
     def __init__(self, n):
-        self.n = n
-        super(MultiBinary, self).__init__((self.n,), np.int8)
+        if type(n) in [tuple, list] and len(n) != 1:
+            self.n = tuple(n)
+        else:
+            self.n = (n, )
+        super(MultiBinary, self).__init__(self.n, np.int8)
 
     def sample(self):
         return self.np_random.randint(low=0, high=2, size=self.n, dtype=self.dtype)

--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -4,9 +4,9 @@ from .space import Space
 
 class MultiBinary(Space):
     '''
-    An n-dimensional binary space. 
+    An n-shape binary space. 
 
-    The argument to MultiBinary defines n.
+    The argument to MultiBinary defines n, which could be a number or a `list` of numbers.
     
     Example Usage:
     
@@ -16,12 +16,18 @@ class MultiBinary(Space):
 
         array([0,1,0,1,0], dtype =int8)
 
+    >> self.observation_space = spaces.MultiBinary([3,2])
+
+    >> self.observation_space.sample()
+
+        array([[0, 0],
+               [0, 1],   
+               [1, 1]], dtype=int8)
+
     '''
-    
     def __init__(self, n):
         self.n = n
-        if (type(n) in [tuple, list] and len(n) != 1) \
-            or (type(n) is np.ndarray and len(n.shape) != 1):
+        if type(n) in [tuple, list, np.ndarray]:
             input_n = n
         else:
             input_n = (n, )
@@ -31,13 +37,15 @@ class MultiBinary(Space):
         return self.np_random.randint(low=0, high=2, size=self.n, dtype=self.dtype)
 
     def contains(self, x):
-        if isinstance(x, list):
+        if isinstance(x, list) or isinstance(x, tuple):
             x = np.array(x)  # Promote list to array for contains check
+        if self.shape != x.shape:
+            return False
         return ((x==0) | (x==1)).all()
 
     def to_jsonable(self, sample_n):
         return np.array(sample_n).tolist()
-    
+
     def from_jsonable(self, sample_n):
         return [np.asarray(sample) for sample in sample_n]
 


### PR DESCRIPTION
When I'm using [ray-project/ray](https://github.com/ray-project/ray), I've found out that when I'm using multi-dimensions space as the input n of `MultiBinary`, problem occurs on init part. After debugging, it appeared that the dealing way of n is not suitable for multi-dimensions input. 
Here's the issue in [ray-project/ray](https://github.com/ray-project/ray): [#10024 on ray](https://github.com/ray-project/ray/issues/10024).