### PR TITLE
Remove Python 2 compatibility in VectorEnv

### DIFF
--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -68,12 +68,7 @@ class AsyncVectorEnv(VectorEnv):
     """
     def __init__(self, env_fns, observation_space=None, action_space=None,
                  shared_memory=True, copy=True, context=None, daemon=True, worker=None):
-        try:
-            ctx = mp.get_context(context)
-        except AttributeError:
-            logger.warn('Context switching for `multiprocessing` is not '
-                'available in Python 2. Using the default context.')
-            ctx = mp
+        ctx = mp.get_context(context)
         self.env_fns = env_fns
         self.shared_memory = shared_memory
         self.copy = copy

--- a/gym/vector/tests/test_shared_memory.py
+++ b/gym/vector/tests/test_shared_memory.py
@@ -1,5 +1,4 @@
 import pytest
-import sys
 import numpy as np
 
 import multiprocessing as mp
@@ -14,7 +13,6 @@ from gym.vector.tests.utils import spaces
 from gym.vector.utils.shared_memory import (create_shared_memory,
     read_from_shared_memory, write_to_shared_memory)
 
-is_python_2 = (sys.version_info < (3, 0))
 
 expected_types = [
     Array('d', 1), Array('f', 1), Array('f', 3), Array('f', 4), Array('B', 1), Array('B', 32 * 32 * 3),
@@ -33,9 +31,7 @@ expected_types = [
 @pytest.mark.parametrize('n', [1, 8])
 @pytest.mark.parametrize('space,expected_type', list(zip(spaces, expected_types)),
     ids=[space.__class__.__name__ for space in spaces])
-@pytest.mark.parametrize('ctx', [None,
-    pytest.param('fork', marks=pytest.mark.skipif(is_python_2, reason='Requires Python 3')),
-    pytest.param('spawn', marks=pytest.mark.skipif(is_python_2, reason='Requires Python 3'))],
+@pytest.mark.parametrize('ctx', [None, 'fork', 'spawn'],
     ids=['default', 'fork', 'spawn'])
 def test_create_shared_memory(space, expected_type, n, ctx):
     def assert_nested_type(lhs, rhs, n):


### PR DESCRIPTION
 - Remove the check for Python 2 when changing multiprocessing context
 - Remove unused conditions on tests for Python 2