### PR TITLE
Importing wrappers in gym

### DIFF
--- a/gym/__init__.py
+++ b/gym/__init__.py
@@ -11,5 +11,6 @@ from gym.spaces import Space
 from gym.envs import make, spec, register
 from gym import logger
 from gym import vector
+from gym import wrappers
 
 __all__ = ["Env", "Space", "Wrapper", "make", "spec", "register"]


### PR DESCRIPTION
Otherwise, using gym.wrappers crashes code if only gym has been imported, e.g. [here](https://github.com/ray-project/ray/blob/9c2c9522626a7cfb168ce5634c9e3ea7ba60363d/rllib/rollout.py#L382)