### PR TITLE
[gym.vector] Add BatchedVectorEnv, (chunking + flexible n_envs)

### DIFF
--- a/gym/vector/__init__.py
+++ b/gym/vector/__init__.py
@@ -3,11 +3,19 @@ try:
 except ImportError:
     Iterable = (tuple, list)
 
+from gym.vector.batched_vector_env import BatchedVectorEnv
 from gym.vector.async_vector_env import AsyncVectorEnv
 from gym.vector.sync_vector_env import SyncVectorEnv
 from gym.vector.vector_env import VectorEnv, VectorEnvWrapper
 
-__all__ = ["AsyncVectorEnv", "SyncVectorEnv", "VectorEnv", "VectorEnvWrapper", "make"]
+__all__ = [
+    "BatchedVectorEnv",
+    "AsyncVectorEnv",
+    "SyncVectorEnv",
+    "VectorEnv",
+    "VectorEnvWrapper",
+    "make",
+]
 
 
 def make(id, num_envs=1, asynchronous=True, wrappers=None, **kwargs):

--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -410,6 +410,7 @@ def _worker(index, env_fn, pipe, parent_pipe, shared_memory, error_queue):
         # reset the envs that are done if needed in the 'step' method and return
         # the initial observation instead of the final observation.
         if not isinstance(env, VectorEnv) and done:
+            # Add the final observation in the 'info' dict.
             if FINAL_STATE_KEY not in info:
                 info[FINAL_STATE_KEY] = observation
             observation = env.reset()
@@ -463,8 +464,9 @@ def _worker_shared_memory(index, env_fn, pipe, parent_pipe, shared_memory, error
         # Do nothing if the env is a VectorEnv, since it will automatically
         # reset the envs that are done if needed in the 'step' method and return
         # the initial observation instead of the final observation.
-        # NOTE: This 'final observation' isn't in the shared memory.
         if not isinstance(env, VectorEnv) and done:
+            # Add the final observation in the 'info' dict. 
+            # NOTE: This 'final observation' isn't in the shared memory.
             if FINAL_STATE_KEY not in info:
                 info[FINAL_STATE_KEY] = observation
             observation = env.reset()

--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -410,9 +410,6 @@ def _worker(index, env_fn, pipe, parent_pipe, shared_memory, error_queue):
         # reset the envs that are done if needed in the 'step' method and return
         # the initial observation instead of the final observation.
         if not isinstance(env, VectorEnv) and done:
-            # Add the final observation in the 'info' dict.
-            if FINAL_STATE_KEY not in info:
-                info[FINAL_STATE_KEY] = observation
             observation = env.reset()
         return observation, reward, done, info
 
@@ -422,15 +419,10 @@ def _worker(index, env_fn, pipe, parent_pipe, shared_memory, error_queue):
             if command == "reset":
                 observation = env.reset()
                 pipe.send((observation, True))
-<<<<<<< HEAD
             elif command == "step":
                 observation, reward, done, info = env.step(data)
                 if done:
                     observation = env.reset()
-=======
-            elif command == 'step':
-                observation, reward, done, info = step_fn(data)
->>>>>>> Add BatchedVectorEnv, (chunking + flexible n_envs)
                 pipe.send(((observation, reward, done, info), True))
             elif command == "seed":
                 env.seed(data)
@@ -465,10 +457,6 @@ def _worker_shared_memory(index, env_fn, pipe, parent_pipe, shared_memory, error
         # reset the envs that are done if needed in the 'step' method and return
         # the initial observation instead of the final observation.
         if not isinstance(env, VectorEnv) and done:
-            # Add the final observation in the 'info' dict. 
-            # NOTE: This 'final observation' isn't in the shared memory.
-            if FINAL_STATE_KEY not in info:
-                info[FINAL_STATE_KEY] = observation
             observation = env.reset()
         return observation, reward, done, info
 
@@ -481,7 +469,6 @@ def _worker_shared_memory(index, env_fn, pipe, parent_pipe, shared_memory, error
                     index, observation, shared_memory, observation_space
                 )
                 pipe.send((None, True))
-<<<<<<< HEAD
             elif command == "step":
                 observation, reward, done, info = env.step(data)
                 if done:
@@ -489,12 +476,6 @@ def _worker_shared_memory(index, env_fn, pipe, parent_pipe, shared_memory, error
                 write_to_shared_memory(
                     index, observation, shared_memory, observation_space
                 )
-=======
-            elif command == 'step':
-                observation, reward, done, info = step_fn(data)
-                write_to_shared_memory(index, observation, shared_memory,
-                                       observation_space)
->>>>>>> Add BatchedVectorEnv, (chunking + flexible n_envs)
                 pipe.send(((None, reward, done, info), True))
             elif command == "seed":
                 env.seed(data)

--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -471,7 +471,8 @@ def _worker_shared_memory(index, env_fn, pipe, parent_pipe, shared_memory, error
                 pipe.send((None, True))
             elif command == "step":
                 observation, reward, done, info = env.step(data)
-                if done:
+                # BUG: See PR #2104: Currently unable to nest VectorEnvs because of this
+                if (done if isinstance(done, bool) else all(done)):
                     observation = env.reset()
                 write_to_shared_memory(
                     index, observation, shared_memory, observation_space

--- a/gym/vector/batched_vector_env.py
+++ b/gym/vector/batched_vector_env.py
@@ -11,14 +11,15 @@ import gym
 import numpy as np
 from gym import spaces
 
-from .sync_vector_env import SyncVectorEnv
-from .async_vector_env import AsyncVectorEnv
+from gym.vector.vector_env import VectorEnv
+from gym.vector.sync_vector_env import SyncVectorEnv
+from gym.vector.async_vector_env import AsyncVectorEnv
 
 
 T = TypeVar("T")
 
 
-class BatchedVectorEnv(gym.Env):
+class BatchedVectorEnv(VectorEnv):
     """ Batched vectorized environment.
 
     Adds the following features, compared to using the vectorized Async and Sync
@@ -41,12 +42,14 @@ class BatchedVectorEnv(gym.Env):
         In the first environment (env_a), each env will contain
         ceil(n_envs / n_workers) each. If env_b is needed, then each of its envs
         will contain floor(n_envs / n_workers) environments.
-
+    
     The observations/actions/rewards are reshaped to be (n_envs, *shape), i.e.
     they don't have an extra 'chunk' dimension.
 
-    NOTE: In order to get this to work, I had to modify the `if done:` statement
-    in the worker to be `if done if isinstance(done, bool) else all(done):`.
+    -   When some environments have `done=True` while stepping, those
+        environments are reset, as was done previously. Additionally, the final
+        observation for those environments is placed in the info dict at key
+        FINAL_STATE_KEY (currently 'final_state').
     """
     def __init__(self,
                  env_fns,
@@ -54,7 +57,20 @@ class BatchedVectorEnv(gym.Env):
                  **kwargs):
         assert env_fns, "need at least one env_fn."
         self.batch_size: int = len(env_fns)
-        
+
+        # Use one of the env_fns to get the observation/action space.
+        with env_fns[0]() as temp_env:
+            single_observation_space = temp_env.observation_space
+            single_action_space = temp_env.action_space
+            self.reward_range = temp_env.reward_range
+        del temp_env
+
+        super().__init__(
+            num_envs=self.batch_size,
+            observation_space=single_observation_space,
+            action_space=single_action_space,
+        )
+
         if n_workers is None:
             n_workers = mp.cpu_count()
         self.n_workers: int = n_workers
@@ -66,16 +82,18 @@ class BatchedVectorEnv(gym.Env):
         groups = distribute(env_fns, self.n_workers)
 
         # Find the first index where the group has a different length.
-        self.chunk_a = len(groups[0])
-        self.chunk_b = 0
-        # First, assume there is no need for another environment, as all the
-        # groups have the same length.
+        self.chunk_length_a = len(groups[0])
+        self.chunk_length_b = 0
+
+        # First, assume there is no need for another environment (all the
+        # groups have the same length).
         self.start_index_b = self.n_workers
         for i, group in enumerate(groups):
-            if len(group) != self.chunk_a:
+            if len(group) != self.chunk_length_a:
                 self.start_index_b = i
-                self.chunk_b = len(group)
+                self.chunk_length_b = len(group)
                 break
+
         # Total number of envs in each environment.
         self.n_a = sum(map(len, groups[:self.start_index_b]))
         self.n_b = sum(map(len, groups[self.start_index_b:]))
@@ -93,91 +111,70 @@ class BatchedVectorEnv(gym.Env):
         if env_b_fns:
             self.env_b = AsyncVectorEnv(env_fns=env_b_fns, **kwargs)
 
-        self.observation_space: gym.Space  # type: ignore
-        self.action_space: gym.Space  # type: ignore
+        # Unbatch & join the observations/actions spaces.        
 
-        # Unbatch & join the observations/actions spaces.
-        flat_obs_a = remove_extra_batch_dim(self.env_a.observation_space)  # type: ignore
-        flat_act_a = remove_extra_batch_dim(self.env_a.action_space)  # type: ignore
+    def reset_async(self):
+        self.env_a.reset_async()
         if self.env_b:
-            flat_obs_b = remove_extra_batch_dim(self.env_b.observation_space)  # type: ignore
-            flat_act_b = remove_extra_batch_dim(self.env_b.action_space)  # type: ignore
-            
-            self.observation_space = concat_spaces(flat_obs_a, flat_obs_b)
-            self.action_space = concat_spaces(flat_act_a, flat_act_b)
-        else:
-            self.observation_space = flat_obs_a
-            self.action_space = flat_act_a
+            self.env_b.reset_async()
 
-        self.reward_range = self.env_a.reward_range
-
-    def reset(self):
-        obs_a = self.env_a.reset()
+    def reset_wait(self, timeout=None, **kwargs):
+        obs_a = self.env_a.reset_wait(timeout=timeout)
         if self.env_b:
-            obs_b = self.env_b.reset()
-            return self.unchunk(obs_a, obs_b)
-        return self.unchunk(obs_a)
-
-    def step(self, action: Sequence):
+            obs_b = self.env_b.reset_wait(timeout=timeout)
+            return unchunk(obs_a, obs_b)
+        return unchunk(obs_a)
+    
+    def step_async(self, action: Sequence):
         if self.env_b:
             flat_actions_a, flat_actions_b = action[:self.n_a], action[self.n_a:]
-            actions_a = self.chunk(flat_actions_a, self.chunk_a)
-            actions_b = self.chunk(flat_actions_b, self.chunk_b)
+            actions_a = chunk(flat_actions_a, self.chunk_length_a)
+            actions_b = chunk(flat_actions_b, self.chunk_length_b)
+            self.env_a.step_async(actions_a)
+            self.env_b.step_async(actions_b)
 
-            obs_a, rew_a, done_a, info_a = self.env_a.step(actions_a)
-            obs_b, rew_b, done_b, info_b = self.env_b.step(actions_b)
-
-            observations = self.unchunk(obs_a, obs_b)
-            rewards = self.unchunk(rew_a, rew_b)
-            done = self.unchunk(done_a, done_b)
-            info = self.unchunk(info_a, info_b)
         else:
-            action = self.chunk(action, self.chunk_a)
-            observations, rewards, done, info = self.env_a.step(action)
+            action = chunk(action, self.chunk_length_a)
+            self.env_a.step_async(action)
 
-            observations = self.unchunk(observations)
-            rewards = self.unchunk(rewards)
-            done = self.unchunk(done)
-            info = self.unchunk(info)
+    def step_wait(self, timeout: Union[int, float]=None):
+        if self.env_b:
+            obs_a, rew_a, done_a, info_a = self.env_a.step_wait(timeout)
+            obs_b, rew_b, done_b, info_b = self.env_b.step_wait(timeout)
+
+            observations = unchunk(obs_a, obs_b)
+            rewards = unchunk(rew_a, rew_b)
+            done = unchunk(done_a, done_b)
+            info = unchunk(info_a, info_b)
+        else:
+            observations, rewards, done, info = self.env_a.step_wait(timeout)
+
+            observations = unchunk(observations)
+            rewards = unchunk(rewards)
+            done = unchunk(done)
+            info = unchunk(info)
         return observations, rewards, done, info
 
-    def seed(self, seeds: Union[Optional[int], Sequence[Optional[int]]] = None):
+
+    def seed(self, seeds: Union[int, Sequence[Optional[int]]] = None):
         if seeds is None:
             seeds = [None for _ in range(self.batch_size)]
         if isinstance(seeds, int):
             seeds = [seeds + i for i in range(self.batch_size)]
         assert len(seeds) == self.batch_size
 
-        seeds_a = self.chunk(seeds[:self.n_a], self.chunk_a)
-        seeds_b = self.chunk(seeds[self.n_a:], self.chunk_b)
+        seeds_a = chunk(seeds[:self.n_a], self.chunk_length_a)
+        seeds_b = chunk(seeds[self.n_a:], self.chunk_length_b)
         self.env_a.seed(seeds_a)
         if self.env_b:
             self.env_b.seed(seeds_b)       
 
-    def close(self):
-        self.env_a.close()
+
+    def close_extras(self, **kwargs):
+        r"""Clean up the extra resources e.g. beyond what's in this base class. """
+        self.env_a.close_extras(**kwargs)
         if self.env_b:
-            self.env_b.close()
-
-    @staticmethod
-    def unchunk(*values: Sequence[Sequence[T]]) -> Sequence[T]:
-        """ Combine 'chunked' results coming from the envs into a single
-        batch.
-        """
-        all_values: List[T] = []
-        for sequence in values:
-            all_values.extend(itertools.chain.from_iterable(sequence))
-        if isinstance(values[0], np.ndarray):
-            return np.array(all_values)
-        return all_values
-
-    @staticmethod
-    def chunk(values: Sequence[T], chunk_length: int) -> Sequence[Sequence[T]]:
-        """ Add the 'chunk'/second batch dimension to the list of items. """
-        groups = list(n_consecutive(values, chunk_length))
-        if isinstance(values, np.ndarray):
-            groups = np.array(groups)
-        return groups
+            self.env_b.close_extras(**kwargs)
 
 
 def distribute(values: Sequence[T], n_groups: int) -> List[Sequence[T]]:
@@ -214,9 +211,30 @@ def distribute(values: Sequence[T], n_groups: int) -> List[Sequence[T]]:
     return groups
 
 
+def unchunk(*values: Sequence[Sequence[T]]) -> Sequence[T]:
+    """ Combine 'chunked' results coming from the envs into a single
+    batch.
+    """
+    all_values: List[T] = []
+    for sequence in values:
+        all_values.extend(itertools.chain.from_iterable(sequence))
+    if isinstance(values[0], np.ndarray):
+        return np.array(all_values)
+    return all_values
+
+
+def chunk(values: Sequence[T], chunk_length: int) -> Sequence[Sequence[T]]:
+    """ Add the 'chunk'/second batch dimension to the list of items. """
+    groups = list(n_consecutive(values, chunk_length))
+    if isinstance(values, np.ndarray):
+        groups = np.array(groups)
+    return groups
+
+
 def n_consecutive(items: Iterable[T], n: int=2, yield_last_batch=True) -> Iterable[Tuple[T, ...]]:
     """Collect data into chunks of up to `n` elements.
-    Adapted from the itertools recipes.
+    
+    (Adapted from the itertools recipes.)
 
     When `yield_last_batch` is True, the final chunk (which might have fewer
     than `n` items) will also be yielded.
@@ -232,63 +250,6 @@ def n_consecutive(items: Iterable[T], n: int=2, yield_last_batch=True) -> Iterab
             values.clear()
     if values and yield_last_batch:
         yield tuple(values)
-
-
-def concat_spaces(space_a: gym.Space, space_b: gym.Space) -> gym.Space:
-    """ Concatenate two gym spaces of the same types. """
-    if type(space_a) != type(space_b):
-        raise RuntimeError(f"Can only concat spaces of the same type: {space_a} {space_b}")
-    
-    if isinstance(space_a, spaces.Box):
-        assert isinstance(space_b, spaces.Box)
-
-        assert space_a.shape[1:] == space_b.shape[1:]
-        new_low = np.concatenate([space_a.low, space_b.low])
-        new_high = np.concatenate([space_a.high, space_b.high])
-        return spaces.Box(low=new_low, high=new_high, dtype=space_a.dtype)
-
-    if isinstance(space_a, spaces.Tuple):
-        assert isinstance(space_b, spaces.Tuple)
-
-        new_spaces = space_a.spaces + space_b.spaces
-        return spaces.Tuple(new_spaces)
-    
-    if isinstance(space_a, spaces.Dict):
-        assert isinstance(space_b, spaces.Dict)
-        new_spaces = {}
-        for key in space_a.spaces:
-            value_a = space_a[key]
-            value_b = space_b[key]
-            new_spaces[key] = concat_spaces(value_a, value_b)
-        return spaces.Dict(new_spaces)
-    
-    raise NotImplementedError(f"Unsupported spaces {space_a} {space_b}")
-
-
-def remove_extra_batch_dim(space: gym.Space):
-    if isinstance(space, spaces.Box):
-        dims = space.shape
-        assert len(space.shape) >= 2, space
-        new_shape = tuple([dims[0] * dims[1], *dims[2:]])
-        new_low = space.low.reshape(new_shape)
-        new_high = space.high.reshape(new_shape)
-        return spaces.Box(low=new_low, high=new_high, dtype=space.dtype)
-
-    if isinstance(space, spaces.Tuple):
-        assert len(space.spaces) and isinstance(space.spaces[0], spaces.Tuple)
-        all_spaces: List[gym.Space] = []
-        for sub_space in space.spaces:
-            all_spaces.extend(sub_space.spaces)
-        return spaces.Tuple(all_spaces)
-
-    if isinstance(space, spaces.Dict):
-        return spaces.Dict({
-            k: remove_extra_batch_dim(sub_space)
-            for k, sub_space in space.spaces.items()
-        })
-
-    raise NotImplementedError(f"Unsupported space {space}")
-
 
 
 if __name__ == "__main__":

--- a/gym/vector/batched_vector_env.py
+++ b/gym/vector/batched_vector_env.py
@@ -1,0 +1,296 @@
+""" Mix of AsyncVectorEnv and SyncVectorEnv, with support for 'chunking' and for
+where we have a series of environments on each worker.
+"""
+import math
+import multiprocessing as mp
+import itertools
+from functools import partial
+from typing import Any, Callable, Iterable, List, Sequence, Tuple, TypeVar, Union, Optional
+
+import gym
+import numpy as np
+from gym import spaces
+
+from .sync_vector_env import SyncVectorEnv
+from .async_vector_env import AsyncVectorEnv
+
+
+T = TypeVar("T")
+
+
+class BatchedVectorEnv(gym.Env):
+    """ Batched vectorized environment.
+
+    Adds the following features, compared to using the vectorized Async and Sync
+    VectorEnvs:
+
+    -   Chunking: Running more than one environment per worker. This is done by
+        passing `SyncVectorEnv`s as the env_fns to the `AsyncVectorEnv`.
+
+    -   Flexible batch size: Supports any number of environments, irrespective
+        of the number of workers or of CPUs. The number of environments will be
+        spread out as equally as possible between the workers.
+      
+        For example, if you want to have a batch_size of 17, and n_workers is 6,
+        then the number of environments per worker will be: [3, 3, 3, 3, 3, 2].
+
+        Internally, this works by creating up to two AsyncVectorEnvs, env_a and
+        env_b. If the number of envs (batch_size) isn't a multiple of the number
+        of workers, then we create the second AsyncVectorEnv (env_b).
+
+        In the first environment (env_a), each env will contain
+        ceil(n_envs / n_workers) each. If env_b is needed, then each of its envs
+        will contain floor(n_envs / n_workers) environments.
+
+    The observations/actions/rewards are reshaped to be (n_envs, *shape), i.e.
+    they don't have an extra 'chunk' dimension.
+
+    NOTE: In order to get this to work, I had to modify the `if done:` statement
+    in the worker to be `if done if isinstance(done, bool) else all(done):`.
+    """
+    def __init__(self,
+                 env_fns,
+                 n_workers: int = None,
+                 **kwargs):
+        assert env_fns, "need at least one env_fn."
+        self.batch_size: int = len(env_fns)
+        
+        if n_workers is None:
+            n_workers = mp.cpu_count()
+        self.n_workers: int = n_workers
+
+        if self.n_workers > self.batch_size:
+            self.n_workers = self.batch_size
+
+        # Divide the env_fns as evenly as possible between the workers.
+        groups = distribute(env_fns, self.n_workers)
+
+        # Find the first index where the group has a different length.
+        self.chunk_a = len(groups[0])
+        self.chunk_b = 0
+        # First, assume there is no need for another environment, as all the
+        # groups have the same length.
+        self.start_index_b = self.n_workers
+        for i, group in enumerate(groups):
+            if len(group) != self.chunk_a:
+                self.start_index_b = i
+                self.chunk_b = len(group)
+                break
+        # Total number of envs in each environment.
+        self.n_a = sum(map(len, groups[:self.start_index_b]))
+        self.n_b = sum(map(len, groups[self.start_index_b:]))
+
+        # Create a SyncVectorEnv per group.
+        chunk_env_fns: List[Callable[[], gym.Env]] = [
+            partial(SyncVectorEnv, env_fns_group) for env_fns_group in groups
+        ]
+        env_a_fns = chunk_env_fns[:self.start_index_b]
+        env_b_fns = chunk_env_fns[self.start_index_b:]
+        
+        # Create the AsyncVectorEnvs.
+        self.env_a = AsyncVectorEnv(env_fns=env_a_fns, **kwargs)
+        self.env_b: Optional[AsyncVectorEnv] = None
+        if env_b_fns:
+            self.env_b = AsyncVectorEnv(env_fns=env_b_fns, **kwargs)
+
+        self.observation_space: gym.Space  # type: ignore
+        self.action_space: gym.Space  # type: ignore
+
+        # Unbatch & join the observations/actions spaces.
+        flat_obs_a = remove_extra_batch_dim(self.env_a.observation_space)  # type: ignore
+        flat_act_a = remove_extra_batch_dim(self.env_a.action_space)  # type: ignore
+        if self.env_b:
+            flat_obs_b = remove_extra_batch_dim(self.env_b.observation_space)  # type: ignore
+            flat_act_b = remove_extra_batch_dim(self.env_b.action_space)  # type: ignore
+            
+            self.observation_space = concat_spaces(flat_obs_a, flat_obs_b)
+            self.action_space = concat_spaces(flat_act_a, flat_act_b)
+        else:
+            self.observation_space = flat_obs_a
+            self.action_space = flat_act_a
+
+        self.reward_range = self.env_a.reward_range
+
+    def reset(self):
+        obs_a = self.env_a.reset()
+        if self.env_b:
+            obs_b = self.env_b.reset()
+            return self.unchunk(obs_a, obs_b)
+        return self.unchunk(obs_a)
+
+    def step(self, action: Sequence):
+        if self.env_b:
+            flat_actions_a, flat_actions_b = action[:self.n_a], action[self.n_a:]
+            actions_a = self.chunk(flat_actions_a, self.chunk_a)
+            actions_b = self.chunk(flat_actions_b, self.chunk_b)
+
+            obs_a, rew_a, done_a, info_a = self.env_a.step(actions_a)
+            obs_b, rew_b, done_b, info_b = self.env_b.step(actions_b)
+
+            observations = self.unchunk(obs_a, obs_b)
+            rewards = self.unchunk(rew_a, rew_b)
+            done = self.unchunk(done_a, done_b)
+            info = self.unchunk(info_a, info_b)
+        else:
+            action = self.chunk(action, self.chunk_a)
+            observations, rewards, done, info = self.env_a.step(action)
+
+            observations = self.unchunk(observations)
+            rewards = self.unchunk(rewards)
+            done = self.unchunk(done)
+            info = self.unchunk(info)
+        return observations, rewards, done, info
+
+    def seed(self, seeds: Union[Optional[int], Sequence[Optional[int]]] = None):
+        if seeds is None:
+            seeds = [None for _ in range(self.batch_size)]
+        if isinstance(seeds, int):
+            seeds = [seeds + i for i in range(self.batch_size)]
+        assert len(seeds) == self.batch_size
+
+        seeds_a = self.chunk(seeds[:self.n_a], self.chunk_a)
+        seeds_b = self.chunk(seeds[self.n_a:], self.chunk_b)
+        self.env_a.seed(seeds_a)
+        if self.env_b:
+            self.env_b.seed(seeds_b)       
+
+    def close(self):
+        self.env_a.close()
+        if self.env_b:
+            self.env_b.close()
+
+    @staticmethod
+    def unchunk(*values: Sequence[Sequence[T]]) -> Sequence[T]:
+        """ Combine 'chunked' results coming from the envs into a single
+        batch.
+        """
+        all_values: List[T] = []
+        for sequence in values:
+            all_values.extend(itertools.chain.from_iterable(sequence))
+        if isinstance(values[0], np.ndarray):
+            return np.array(all_values)
+        return all_values
+
+    @staticmethod
+    def chunk(values: Sequence[T], chunk_length: int) -> Sequence[Sequence[T]]:
+        """ Add the 'chunk'/second batch dimension to the list of items. """
+        groups = list(n_consecutive(values, chunk_length))
+        if isinstance(values, np.ndarray):
+            groups = np.array(groups)
+        return groups
+
+
+def distribute(values: Sequence[T], n_groups: int) -> List[Sequence[T]]:
+    """ Distribute the values 'values' as evenly as possible into n_groups.
+
+    >>> distribute(list(range(14)), 5)
+    [[0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11], [12, 13]]
+    >>> distribute(list(range(9)), 4)
+    [[0, 1, 2], [3, 4], [5, 6], [7, 8]]
+    >>> import numpy as np
+    >>> distribute(np.arange(9), 4)
+    [array([0, 1, 2]), array([3, 4]), array([5, 6]), array([7, 8])]
+    """
+    n_values = len(values)
+    # Determine the final lengths of each group.
+    min_values_per_group = math.floor(n_values / n_groups)
+    max_values_per_group = math.ceil(n_values / n_groups)
+    remainder = n_values % n_groups
+    group_lengths = [
+        max_values_per_group if i < remainder else min_values_per_group
+        for i in range(n_groups)
+    ]
+    # Equivalent, but maybe a tiny bit slower:
+    # group_lengths: List[int] = [0 for _ in range(n_groups)]
+    # for i in range(len(values)):
+    #     group_lengths[i % n_groups] += 1
+    groups: List[Sequence[T]] = [[] for _ in range(n_groups)]
+
+    start_index = 0
+    for i, group_length in enumerate(group_lengths):
+        end_index = start_index + group_length
+        groups[i] = values[start_index:end_index]
+        start_index += group_length
+    return groups
+
+
+def n_consecutive(items: Iterable[T], n: int=2, yield_last_batch=True) -> Iterable[Tuple[T, ...]]:
+    """Collect data into chunks of up to `n` elements.
+    Adapted from the itertools recipes.
+
+    When `yield_last_batch` is True, the final chunk (which might have fewer
+    than `n` items) will also be yielded.
+    
+    >>> list(n_consecutive("ABCDEFG", 3))
+    [["A", "B", "C"], ["D", "E", "F"], ["G"]]
+    """
+    values: List[T] = []
+    for item in items:
+        values.append(item)
+        if len(values) == n:
+            yield tuple(values)
+            values.clear()
+    if values and yield_last_batch:
+        yield tuple(values)
+
+
+def concat_spaces(space_a: gym.Space, space_b: gym.Space) -> gym.Space:
+    """ Concatenate two gym spaces of the same types. """
+    if type(space_a) != type(space_b):
+        raise RuntimeError(f"Can only concat spaces of the same type: {space_a} {space_b}")
+    
+    if isinstance(space_a, spaces.Box):
+        assert isinstance(space_b, spaces.Box)
+
+        assert space_a.shape[1:] == space_b.shape[1:]
+        new_low = np.concatenate([space_a.low, space_b.low])
+        new_high = np.concatenate([space_a.high, space_b.high])
+        return spaces.Box(low=new_low, high=new_high, dtype=space_a.dtype)
+
+    if isinstance(space_a, spaces.Tuple):
+        assert isinstance(space_b, spaces.Tuple)
+
+        new_spaces = space_a.spaces + space_b.spaces
+        return spaces.Tuple(new_spaces)
+    
+    if isinstance(space_a, spaces.Dict):
+        assert isinstance(space_b, spaces.Dict)
+        new_spaces = {}
+        for key in space_a.spaces:
+            value_a = space_a[key]
+            value_b = space_b[key]
+            new_spaces[key] = concat_spaces(value_a, value_b)
+        return spaces.Dict(new_spaces)
+    
+    raise NotImplementedError(f"Unsupported spaces {space_a} {space_b}")
+
+
+def remove_extra_batch_dim(space: gym.Space):
+    if isinstance(space, spaces.Box):
+        dims = space.shape
+        assert len(space.shape) >= 2, space
+        new_shape = tuple([dims[0] * dims[1], *dims[2:]])
+        new_low = space.low.reshape(new_shape)
+        new_high = space.high.reshape(new_shape)
+        return spaces.Box(low=new_low, high=new_high, dtype=space.dtype)
+
+    if isinstance(space, spaces.Tuple):
+        assert len(space.spaces) and isinstance(space.spaces[0], spaces.Tuple)
+        all_spaces: List[gym.Space] = []
+        for sub_space in space.spaces:
+            all_spaces.extend(sub_space.spaces)
+        return spaces.Tuple(all_spaces)
+
+    if isinstance(space, spaces.Dict):
+        return spaces.Dict({
+            k: remove_extra_batch_dim(sub_space)
+            for k, sub_space in space.spaces.items()
+        })
+
+    raise NotImplementedError(f"Unsupported space {space}")
+
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/gym/vector/batched_vector_env.py
+++ b/gym/vector/batched_vector_env.py
@@ -202,14 +202,14 @@ class BatchedVectorEnv(VectorEnv):
         raise NotImplementedError(f"Render mode {mode} isn't implemented yet.")
 
         # NOTE: This is only here for illustration purposes.
-        if mode == "human":
-            # See PR #1624 for the tile_images function.
-            tiled_version = tile_images(image_batch)
-            if self.viewer is None:
-                from gym.envs.classic_control import rendering
-                self.viewer = rendering.SimpleImageViewer()
-            self.viewer.imshow(tiled_version)
-            return self.viewer.isopen
+        # if mode == "human":
+        #     See PR #1624 for the tile_images function.
+        #     tiled_version = tile_images(image_batch)
+        #     if self.viewer is None:
+        #         from gym.envs.classic_control import rendering
+        #         self.viewer = rendering.SimpleImageViewer()
+        #     self.viewer.imshow(tiled_version)
+        #     return self.viewer.isopen
 
 
 def distribute(values: Sequence[T], n_groups: int) -> List[Sequence[T]]:

--- a/gym/vector/batched_vector_env.py
+++ b/gym/vector/batched_vector_env.py
@@ -1,22 +1,26 @@
 """ Mix of AsyncVectorEnv and SyncVectorEnv, with support for 'chunking' and for
 where we have a series of environments on each worker.
 """
+import itertools
 import math
 import multiprocessing as mp
-import itertools
 from functools import partial
-from typing import Any, Callable, Iterable, List, Sequence, Tuple, TypeVar, Union, Optional
-
-import gym
+from typing import (Any, Callable, Dict, Iterable, List, Optional, Sequence,
+                    Tuple, TypeVar, Union)
 import numpy as np
-from gym import spaces
 
-from gym.vector.vector_env import VectorEnv
-from gym.vector.sync_vector_env import SyncVectorEnv
+
+from gym import spaces, Env, Space
+from gym.spaces.utils import flatten, unflatten
 from gym.vector.async_vector_env import AsyncVectorEnv
-
+from gym.vector.sync_vector_env import SyncVectorEnv
+from gym.vector.utils import batch_space, concatenate, create_empty_array
+from gym.vector.vector_env import VectorEnv
 
 T = TypeVar("T")
+K = TypeVar("K")
+V = TypeVar("V")
+M = TypeVar("M")
 
 
 class BatchedVectorEnv(VectorEnv):
@@ -99,12 +103,11 @@ class BatchedVectorEnv(VectorEnv):
         self.n_b = sum(map(len, groups[self.start_index_b:]))
 
         # Create a SyncVectorEnv per group.
-        chunk_env_fns: List[Callable[[], gym.Env]] = [
+        chunk_env_fns: List[Callable[[], Env]] = [
             partial(SyncVectorEnv, env_fns_group) for env_fns_group in groups
         ]
         env_a_fns = chunk_env_fns[:self.start_index_b]
         env_b_fns = chunk_env_fns[self.start_index_b:]
-        
         # Create the AsyncVectorEnvs.
         self.env_a = AsyncVectorEnv(env_fns=env_a_fns, **kwargs)
         self.env_b: Optional[AsyncVectorEnv] = None
@@ -120,12 +123,15 @@ class BatchedVectorEnv(VectorEnv):
 
     def reset_wait(self, timeout=None, **kwargs):
         obs_a = self.env_a.reset_wait(timeout=timeout)
+        obs_a = unroll(obs_a, item_space=self.single_observation_space)
+        obs_b = []
         if self.env_b:
             obs_b = self.env_b.reset_wait(timeout=timeout)
-            return unchunk(obs_a, obs_b)
-        return unchunk(obs_a)
-    
-    def step_async(self, action: Sequence):
+            obs_b = unroll(obs_b, item_space=self.single_observation_space)
+        observations = fuse_and_batch(self.single_observation_space, obs_a, obs_b, n_items = self.n_a + self.n_b)
+        return observations
+
+    def step_async(self, action: Sequence) -> None:
         if self.env_b:
             flat_actions_a, flat_actions_b = action[:self.n_a], action[self.n_a:]
             actions_a = chunk(flat_actions_a, self.chunk_length_a)
@@ -137,24 +143,29 @@ class BatchedVectorEnv(VectorEnv):
             action = chunk(action, self.chunk_length_a)
             self.env_a.step_async(action)
 
-    def step_wait(self, timeout: Union[int, float]=None):
+    def step_wait(self, timeout: Union[int, float] = None, **kwargs):
+        obs_a, rew_a, done_a, info_a = self.env_a.step_wait(timeout)
+        obs_a = unroll(obs_a, item_space=self.single_observation_space)
+        rew_a = unroll(rew_a)
+        done_a = unroll(done_a)
+        info_a = unroll(info_a)
+        obs_b = []
+        rew_b = []
+        done_b = []
+        info_b = []
         if self.env_b:
-            obs_a, rew_a, done_a, info_a = self.env_a.step_wait(timeout)
             obs_b, rew_b, done_b, info_b = self.env_b.step_wait(timeout)
-
-            observations = unchunk(obs_a, obs_b)
-            rewards = unchunk(rew_a, rew_b)
-            done = unchunk(done_a, done_b)
-            info = unchunk(info_a, info_b)
-        else:
-            observations, rewards, done, info = self.env_a.step_wait(timeout)
-
-            observations = unchunk(observations)
-            rewards = unchunk(rewards)
-            done = unchunk(done)
-            info = unchunk(info)
+            obs_b = unroll(obs_b, item_space=self.single_observation_space)
+            rew_b = unroll(rew_b)
+            done_b = unroll(done_b)
+            info_b = unroll(info_b)
+        observations = fuse_and_batch(self.single_observation_space, obs_a, obs_b, n_items = self.n_a + self.n_b)
+        rewards = np.array(rew_a + rew_b)
+        done = np.array(done_a + done_b)
+        # TODO: Should we batch the info dict? or just give back the list of
+        # 'info' dicts for each env, like so?
+        info = info_a + info_b
         return observations, rewards, done, info
-
 
     def seed(self, seeds: Union[int, Sequence[Optional[int]]] = None):
         if seeds is None:
@@ -169,12 +180,36 @@ class BatchedVectorEnv(VectorEnv):
         if self.env_b:
             self.env_b.seed(seeds_b)       
 
-
     def close_extras(self, **kwargs):
-        r"""Clean up the extra resources e.g. beyond what's in this base class. """
         self.env_a.close_extras(**kwargs)
         if self.env_b:
             self.env_b.close_extras(**kwargs)
+
+    def render(self, mode: str = "rgb_array"):
+        chunked_images_a = self.env_a.render(mode="rgb_array")
+        images_a: List[np.ndarray] = unroll(chunked_images_a)
+        images_b: List[np.ndarray] = []
+        
+        if self.env_b:
+            chunked_images_b = self.env_b.render(mode="rgb_array")
+            images_b = unroll(chunked_images_b)
+        
+        image_batch = np.stack(images_a + images_b)
+        
+        if mode == "rgb_array":
+            return image_batch
+        
+        raise NotImplementedError(f"Render mode {mode} isn't implemented yet.")
+
+        # NOTE: This is only here for illustration purposes.
+        if mode == "human":
+            # See PR #1624 for the tile_images function.
+            tiled_version = tile_images(image_batch)
+            if self.viewer is None:
+                from gym.envs.classic_control import rendering
+                self.viewer = rendering.SimpleImageViewer()
+            self.viewer.imshow(tiled_version)
+            return self.viewer.isopen
 
 
 def distribute(values: Sequence[T], n_groups: int) -> List[Sequence[T]]:
@@ -211,31 +246,112 @@ def distribute(values: Sequence[T], n_groups: int) -> List[Sequence[T]]:
     return groups
 
 
-def unchunk(*values: Sequence[Sequence[T]]) -> Sequence[T]:
-    """ Combine 'chunked' results coming from the envs into a single
-    batch.
-    """
-    all_values: List[T] = []
-    for sequence in values:
-        all_values.extend(itertools.chain.from_iterable(sequence))
-    if isinstance(values[0], np.ndarray):
-        return np.array(all_values)
-    return all_values
-
 
 def chunk(values: Sequence[T], chunk_length: int) -> Sequence[Sequence[T]]:
-    """ Add the 'chunk'/second batch dimension to the list of items. """
+    """ Add the 'chunk'/second batch dimension to the list of items.
+    
+    NOTE: I don't think this would work with tuples as inputs, but it hasn't
+    been a problem yet because the action/reward spaces haven't been tuples yet.
+    """
     groups = list(n_consecutive(values, chunk_length))
     if isinstance(values, np.ndarray):
         groups = np.array(groups)
     return groups
 
 
+def unroll(chunks: Sequence[Sequence[T]], item_space: Space = None) -> List[T]:
+    """ Unroll the given chunks, to get a list of individual items.
+
+    This is the inverse operation of 'chunk' above.
+    """
+    if isinstance(item_space, spaces.Tuple):
+        # 'flatten out' the chunks for each index. The returned value will be a
+        # tuple of lists of samples. 
+        chunked_items = list(zip(chunks))
+        return tuple([
+            unroll(chunk, item_space=chunk_item_space)
+            for chunk, chunk_item_space in zip(chunked_items, item_space.spaces)  
+        ])
+    if isinstance(chunks, np.ndarray):
+        return list(chunks.reshape([-1, *chunks.shape[2:]]))
+    
+    return list(itertools.chain.from_iterable(chunks))
+
+from functools import singledispatch
+
+
+@singledispatch
+def fuse_and_batch(item_space: spaces.Space, *sequences: Sequence[Sequence[T]], n_items: int) -> Sequence[T]:
+    # fuse the lists
+    # sequence_a, sequence_b = sequences
+    assert all(isinstance(sequence, list) for sequence in sequences)
+    
+    if len(sequences) == 1:
+        joined_sequence = sequences[0]
+    else:
+        joined_sequence = sum(sequences, [])
+    
+    # out = create_empty_array(item_space, n=n_items)
+    return np.concatenate([
+        np.asarray(v).reshape([-1, *item_space.shape])
+        for v in joined_sequence
+    ])
+    
+    # return concatenate(joined_sequence, out, item_space)
+
+    # TODO: This works temporarily. Would need to check that this would also work with sparse spaces.
+    return np.concatenate([
+        np.concatenate(sequence) if sequence.shape else np.stack(sequence)
+        for sequence in joined_sequence if len(sequence)
+    ])
+    
+    all_items = list(itertools.chain(*sequences))
+
+    if len(all_items) != n_items:
+        raise RuntimeError(
+            f"Expected to have {n_items} items in the batch, but we "
+            f"instead have {len(all_items)}! (items={sequences}, "
+            f"item_space={item_space})."
+        )
+    if item_space is None:
+        return all_items
+
+    empty_array = create_empty_array(item_space, n=n_items)
+    item_batch = concatenate(all_items, empty_array, item_space)
+    return item_batch
+
+
+@fuse_and_batch.register
+def fuse_and_batch_dicts(item_space: spaces.Dict, *sequences: Sequence[Dict[K, V]], n_items: int) -> Dict[K, Sequence[T]]:
+    values: Dict[K, List[V]] = {
+        k: [] for k in item_space.spaces.keys()
+    }
+    for sequence in sequences:
+        for item in sequence:
+            for k, v in item.items():
+                values[k].append(v)
+    return {
+        k: fuse_and_batch(item_space.spaces[k], values[k], n_items=n_items)
+        for k in values
+    }
+
+
+@fuse_and_batch.register
+def fuse_and_batch_tuples(item_space: spaces.Tuple, *sequences: Sequence[Tuple[T, ...]], n_items: int) -> Tuple[Sequence[T], ...]:
+    # Join the list of items for each subspace of the item_space Tuple.
+    joined_sequences: Sequence[List[T]] = [
+        sum(items, []) for items in itertools.zip_longest(*sequences, fillvalue=[])
+    ]
+    return tuple(
+        fuse_and_batch(space, sequence, n_items=n_items)
+        for space, sequence in zip(item_space.spaces, joined_sequences)
+        # np.concatenate(sequence) for sequence in joined_sequences
+    )
+
+
 def n_consecutive(items: Iterable[T], n: int=2, yield_last_batch=True) -> Iterable[Tuple[T, ...]]:
     """Collect data into chunks of up to `n` elements.
     
-    (Adapted from the itertools recipes.)
-
     When `yield_last_batch` is True, the final chunk (which might have fewer
     than `n` items) will also be yielded.
     
@@ -250,6 +366,18 @@ def n_consecutive(items: Iterable[T], n: int=2, yield_last_batch=True) -> Iterab
             values.clear()
     if values and yield_last_batch:
         yield tuple(values)
+
+
+def zip_dicts(*dicts: Dict[K, V],
+               missing: M = None) -> Iterable[Tuple[K, Tuple[Union[M, V], ...]]]:
+    """Iterator over the union of all keys, giving the value from each dict if
+    present, else `missing`.
+    """
+    # If any attributes are common to both the Experiment and the State,
+    # copy them over to the Experiment.
+    keys = set(itertools.chain(*dicts))
+    for key in keys:
+        yield (key, tuple(d.get(key, missing) for d in dicts))
 
 
 if __name__ == "__main__":

--- a/gym/vector/batched_vector_env.py
+++ b/gym/vector/batched_vector_env.py
@@ -291,7 +291,6 @@ def fuse_and_batch(item_space: spaces.Space, *sequences: Sequence[Sequence[T]], 
     """Concatenate two sequences of items, and then fuse them into a single
     batch.
     """
-    assert all(isinstance(sequence, list) for sequence in sequences)
     out = create_empty_array(item_space, n=n_items)
     # # Concatenate the (two) batches into a single batch of samples.
     items_batch = np.concatenate([

--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -85,18 +85,9 @@ class SyncVectorEnv(VectorEnv):
                 observation = env.reset()
             observations.append(observation)
             infos.append(info)
-<<<<<<< HEAD
-<<<<<<< HEAD
         self.observations = concatenate(
             observations, self.observations, self.single_observation_space
         )
-=======
-        concatenate(observations, self.observations, self.single_observation_space)
->>>>>>> Add BatchedVectorEnv, (chunking + flexible n_envs)
-=======
-        self.observations = concatenate(observations, self.observations, self.single_observation_space)
->>>>>>> Add support for Tuple observation spaces, fix test
-
         return (
             deepcopy(self.observations) if self.copy else self.observations,
             np.copy(self._rewards),

--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -67,10 +67,8 @@ class SyncVectorEnv(VectorEnv):
         for env in self.envs:
             observation = env.reset()
             observations.append(observation)
-        self.observations = concatenate(
-            observations, self.observations, self.single_observation_space
-        )
-
+        self.observations = concatenate(observations, self.observations,
+            self.single_observation_space)
         return deepcopy(self.observations) if self.copy else self.observations
 
     def step_async(self, actions):
@@ -90,12 +88,16 @@ class SyncVectorEnv(VectorEnv):
             observations.append(observation)
             infos.append(info)
 <<<<<<< HEAD
+<<<<<<< HEAD
         self.observations = concatenate(
             observations, self.observations, self.single_observation_space
         )
 =======
         concatenate(observations, self.observations, self.single_observation_space)
 >>>>>>> Add BatchedVectorEnv, (chunking + flexible n_envs)
+=======
+        self.observations = concatenate(observations, self.observations, self.single_observation_space)
+>>>>>>> Add support for Tuple observation spaces, fix test
 
         return (
             deepcopy(self.observations) if self.copy else self.observations,

--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -2,7 +2,7 @@ import numpy as np
 from copy import deepcopy
 
 from gym import logger
-from gym.vector.vector_env import VectorEnv, FINAL_STATE_KEY
+from gym.vector.vector_env import VectorEnv
 from gym.vector.utils import concatenate, create_empty_array
 
 __all__ = ["SyncVectorEnv"]
@@ -78,12 +78,10 @@ class SyncVectorEnv(VectorEnv):
         observations, infos = [], []
         for i, (env, action) in enumerate(zip(self.envs, self._actions)):
             observation, self._rewards[i], self._dones[i], info = env.step(action)
-            # Don't manually reset VectorEnvs, since they reset the right env
-            # themselves in `step`.
+            # Do nothing if the env is a VectorEnv, since it will automatically
+            # reset the envs that are done if needed in the 'step' method and
+            # return the initial observation instead of the final observation.
             if not isinstance(env, VectorEnv) and self._dones[i]:
-                # Save the final state in the info dict at key FINAL_STATE_KEY.
-                if FINAL_STATE_KEY not in info:
-                    info[FINAL_STATE_KEY] = observation
                 observation = env.reset()
             observations.append(observation)
             infos.append(info)

--- a/gym/vector/tests/test_batched_vector_env.py
+++ b/gym/vector/tests/test_batched_vector_env.py
@@ -1,0 +1,156 @@
+from functools import partial
+from multiprocessing import cpu_count
+from typing import Optional
+
+import gym
+import numpy as np
+import pytest
+from gym import spaces
+from gym.vector.batched_vector_env import BatchedVectorEnv
+
+N_CPUS = cpu_count()
+
+
+@pytest.mark.parametrize("batch_size", [1, 5, N_CPUS, 11, 24])
+@pytest.mark.parametrize("n_workers", [1, 3, N_CPUS])
+def test_right_shapes(batch_size: int, n_workers: Optional[int]):
+    env_fn = partial(gym.make, "CartPole-v0")
+    env_fns = [env_fn for _ in range(batch_size)]
+    env = BatchedVectorEnv(env_fns, n_workers=n_workers)
+    env.seed(123)
+    
+    assert env.observation_space.shape == (batch_size, 4)
+    assert isinstance(env.action_space, spaces.Tuple)
+    assert len(env.action_space) == batch_size
+    
+    obs = env.reset()
+    assert obs.shape == (batch_size, 4)
+
+    for i in range(3):
+        actions = env.action_space.sample()
+        assert actions in env.action_space
+        obs, rewards, done, info = env.step(actions)
+        assert obs.shape == (batch_size, 4)
+        assert len(rewards) == batch_size
+        assert len(done) == batch_size
+        assert len(info) == batch_size
+
+    env.close()
+
+
+class DummyEnvironment(gym.Env):
+    """ Dummy environment for testing.
+    
+    The reward is how close to the target value the state (a counter) is. The
+    actions are:
+    0:  keep the counter the same.
+    1:  Increment the counter.
+    2:  Decrement the counter.
+    """
+    def __init__(self, start: int = 0, max_value: int = 10, target: int = 5):
+        self.max_value = max_value
+        self.i = start
+        self.start = start
+        self.reward_range = (0, max_value)
+        self.action_space = gym.spaces.Discrete(n=3)  # type: ignore
+        self.observation_space = gym.spaces.Discrete(n=max_value)  # type: ignore
+
+        self.target = target
+        self.reward_range = (0, max(target, max_value - target))
+
+        self.done: bool = False
+        self._reset: bool = False
+
+    def step(self, action: int):
+        # The action modifies the state, producing a new state, and you get the
+        # reward associated with that transition.
+        if not self._reset:
+            raise RuntimeError("Need to reset before you can step.")
+        if action == 1:
+            self.i += 1
+        elif action == 2:
+            self.i -= 1
+        self.i %= self.max_value
+        done = (self.i == self.target)
+        reward = abs(self.i - self.target)
+        print(self.i, reward, done, action)
+        return self.i, reward, done, {}
+
+    def reset(self):
+        self._reset = True
+        self.i = self.start
+        return self.i
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 5, N_CPUS, 10, 24])
+def test_ordering_of_env_fns_preserved(batch_size):
+    """ Test that the order of the env_fns is also reproduced in the order of
+    the observations, and that the actions are sent to the right environments.
+    """
+    target = 50
+    env_fns = [
+        partial(DummyEnvironment, start=i, target=target, max_value=100)
+        for i in range(batch_size)
+    ]
+    env = BatchedVectorEnv(env_fns, n_workers=4)
+    env.seed(123)
+    obs = env.reset()
+    assert obs.tolist() == list(range(batch_size))
+
+    obs, reward, done, info = env.step(np.zeros(batch_size))
+    assert obs.tolist() == list(range(batch_size))
+    # Increment only the 'counters' at even indices.
+    actions = [
+        int(i % 2 == 0) for i in range(batch_size)
+    ]
+    obs, reward, done, info = env.step(actions)
+    even = np.arange(batch_size) % 2 == 0
+    odd = np.arange(batch_size) % 2 == 1
+    assert obs[even].tolist() == (np.arange(batch_size) + 1)[even].tolist()
+    assert obs[odd].tolist() == np.arange(batch_size)[odd].tolist(), (obs, obs[odd], actions)
+    assert reward.tolist() == (np.ones(batch_size) * target - obs).tolist()
+
+    env.close()
+
+
+# @pytest.mark.xfail(
+#     reason="TODO: Need to think a bit about the 'reset' behaviour of the "
+#     " 'worker', currently it resets for us and gives us the new initial "
+#     "observation when 'done'=True. "
+# )
+def test_done_reset_behaviour():
+    batch_size = 10
+    n_workers = 4
+    target = batch_size
+    starting_values = np.arange(batch_size)
+    env_fns = [
+        partial(DummyEnvironment, start=start_i, target=target, max_value=target * 2)
+        for start_i in starting_values
+    ]
+    env = BatchedVectorEnv(env_fns, n_workers=n_workers)
+    env.seed(123)
+    obs = env.reset()
+    assert obs.tolist() == list(range(batch_size))
+
+    # Increment all the counters.
+    obs, reward, done, info = env.step(np.ones(batch_size))
+    # Only the last env (at position batch_size-1) should have 'done=True',
+    # since it reached the 'target' value of batch_size + 1 
+    last_index = batch_size - 1
+    is_last = np.arange(batch_size) == batch_size - 1
+    
+    assert done[last_index]
+    assert all(done == is_last)
+    # The observation at the last index should be the new 'starting'
+    # observation.
+    assert obs[~done].tolist() == (np.arange(batch_size) + 1)[~done].tolist()
+    assert obs[done].tolist() == starting_values[done].tolist()
+
+    # TODO: This here wouldn't work with the `SyncVectorEnv` from gym.vector,
+    # because it doesn't keep the final observation at all, it just overwrites
+    # it. Would have been Nice for it to be kept in the 'info' dict at least..
+
+    # The 'info' dict should have the final state as an observation.
+    assert info[last_index]["final_state"] == target
+    assert all("final_state" not in info_i for info_i in info[:last_index])
+    env.close()

--- a/gym/vector/tests/test_batched_vector_env.py
+++ b/gym/vector/tests/test_batched_vector_env.py
@@ -11,34 +11,6 @@ from gym.vector.vector_env import FINAL_STATE_KEY
 
 N_CPUS = cpu_count()
 
-
-@pytest.mark.parametrize("batch_size", [1, 5, N_CPUS, 11, 24])
-@pytest.mark.parametrize("n_workers", [1, 3, N_CPUS])
-def test_right_shapes(batch_size: int, n_workers: Optional[int]):
-    env_fn = partial(gym.make, "CartPole-v0")
-    env_fns = [env_fn for _ in range(batch_size)]
-    env = BatchedVectorEnv(env_fns, n_workers=n_workers)
-    env.seed(123)
-    
-    assert env.observation_space.shape == (batch_size, 4)
-    assert isinstance(env.action_space, spaces.Tuple)
-    assert len(env.action_space) == batch_size
-    
-    obs = env.reset()
-    assert obs.shape == (batch_size, 4)
-
-    for i in range(3):
-        actions = env.action_space.sample()
-        assert actions in env.action_space
-        obs, rewards, done, info = env.step(actions)
-        assert obs.shape == (batch_size, 4)
-        assert len(rewards) == batch_size
-        assert len(done) == batch_size
-        assert len(info) == batch_size
-
-    env.close()
-
-
 class DummyEnvironment(gym.Env):
     """ Dummy environment for testing.
     
@@ -81,6 +53,85 @@ class DummyEnvironment(gym.Env):
         self._reset = True
         self.i = self.start
         return self.i
+
+
+class TupleObservationsWrapper(gym.Wrapper):
+    def __init__(self, env: gym.Env, second_space: gym.Space):
+        super().__init__(env)
+        self.observation_space: gym.Space = spaces.Tuple([
+            env.observation_space,
+            second_space,
+        ])
+    def step(self, action):
+        observation, reward, done, info = self.env.step(action)
+        return (observation, self.observation_space[1].sample()), reward, done, info
+
+    def reset(self):
+        observation = self.env.reset()
+        return (observation, self.observation_space[1].sample())
+
+
+@pytest.mark.parametrize("batch_size", [1, 5, 11, 24])
+@pytest.mark.parametrize("n_workers", [1, 3, None])
+def test_space_with_tuple_observations(batch_size: int, n_workers: Optional[int]):
+
+    def make_env():
+        env = gym.make("CartPole-v0")
+        env = TupleObservationsWrapper(env, spaces.Discrete(1))
+        return env
+    
+    env_fn = make_env
+    env_fns = [env_fn for _ in range(batch_size)]
+    env = BatchedVectorEnv(env_fns, n_workers=n_workers)
+    env.seed(123)
+    
+    assert env.single_observation_space[0].shape == (4,)
+    assert env.single_observation_space[1] == spaces.Discrete(1)
+
+    assert env.observation_space[0].shape == (batch_size, 4)
+    assert env.observation_space[1] == spaces.MultiDiscrete(np.ones(batch_size))
+    
+    obs = env.reset()
+    assert obs[0].shape == env.observation_space[0].shape 
+    assert obs[1].shape == env.observation_space[1].shape 
+    assert obs in env.observation_space
+    
+    actions = env.action_space.sample()
+    step_obs, rewards, done, info = env.step(actions)
+    assert step_obs in env.observation_space
+    
+    assert len(rewards) == batch_size
+    assert len(done) == batch_size
+    assert all([isinstance(v, bool) for v in done.tolist()]), [type(v) for v in done]
+    assert len(info) == batch_size
+
+
+@pytest.mark.parametrize("batch_size", [1, 5, N_CPUS, 11, 24])
+@pytest.mark.parametrize("n_workers", [1, 3, N_CPUS])
+def test_right_shapes(batch_size: int, n_workers: Optional[int]):
+    env_fn = partial(gym.make, "CartPole-v0")
+    env_fns = [env_fn for _ in range(batch_size)]
+    env = BatchedVectorEnv(env_fns, n_workers=n_workers)
+    env.seed(123)
+    
+    assert env.observation_space.shape == (batch_size, 4)
+    assert isinstance(env.action_space, spaces.Tuple)
+    assert len(env.action_space) == batch_size
+    
+    obs = env.reset()
+    assert obs.shape == (batch_size, 4)
+
+    for i in range(3):
+        actions = env.action_space.sample()
+        assert actions in env.action_space
+        obs, rewards, done, info = env.step(actions)
+        assert obs.shape == (batch_size, 4)
+        assert len(rewards) == batch_size
+        assert len(done) == batch_size
+        assert len(info) == batch_size
+
+    env.close()
+
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 5, N_CPUS, 10, 24])

--- a/gym/vector/vector_env.py
+++ b/gym/vector/vector_env.py
@@ -2,14 +2,7 @@ import gym
 from gym.spaces import Tuple
 from gym.vector.utils.spaces import batch_space
 
-<<<<<<< HEAD
 __all__ = ["VectorEnv"]
-=======
-FINAL_STATE_KEY = "final_state"
-
-__all__ = ['VectorEnv', 'FINAL_STATE_KEY']
-
->>>>>>> Add BatchedVectorEnv, (chunking + flexible n_envs)
 
 
 class VectorEnv(gym.Env):

--- a/gym/vector/vector_env.py
+++ b/gym/vector/vector_env.py
@@ -2,7 +2,14 @@ import gym
 from gym.spaces import Tuple
 from gym.vector.utils.spaces import batch_space
 
+<<<<<<< HEAD
 __all__ = ["VectorEnv"]
+=======
+FINAL_STATE_KEY = "final_state"
+
+__all__ = ['VectorEnv', 'FINAL_STATE_KEY']
+
+>>>>>>> Add BatchedVectorEnv, (chunking + flexible n_envs)
 
 
 class VectorEnv(gym.Env):


### PR DESCRIPTION
Adds the following features, compared to using the vectorized Async and Sync
VectorEnvs:

-   Chunking: Running more than one environment per worker. This is done by
    passing `SyncVectorEnv`s as the env_fns to the `AsyncVectorEnv`.

-   Flexible batch size: Supports any number of environments, irrespective
    of the number of workers or of CPUs. The number of environments will be
    spread out as equally as possible between the workers.

    For example, if you want to have a batch_size of 17, and n_workers is 6,
    then the number of environments per worker will be: [3, 3, 3, 3, 3, 2].

    Internally, this works by creating up to two AsyncVectorEnvs, env_a and
    env_b. If the number of envs (batch_size) isn't a multiple of the number
    of workers, then we create the second AsyncVectorEnv (env_b).

    In the first environment (env_a), each env will contain
    ceil(n_envs / n_workers) each. If env_b is needed, then each of its envs
    will contain floor(n_envs / n_workers) environments.

    The observations/actions/rewards are reshaped to be (n_envs, *shape), i.e.
    they don't have an extra 'chunk' dimension.


Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>