### PR TITLE
Remove Python 3.5 support, travis and setup.py maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
-dist: xenial
+dist: focal
 language: python
 python:
   - "3.7"
 services:
   - docker
 env:
-  - PY_VER=3.5.6
-  - PY_VER=3.6.8
-  - PY_VER=3.7.3
-  - PY_VER=3.8.1
-
+  - PY_VER=3.6.12
+  - PY_VER=3.7.9
+  - PY_VER=3.8.6
 
 install: "" # so travis doesn't do pip install requirements.txt
 script:
@@ -22,4 +20,4 @@ deploy:
     password: $TWINE_PASSWORD
     on:
         tags: true
-        condition: $PY_VER = 3.5.6
+        condition: $PY_VER = 3.6.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 language: python
 python:
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: focal
+dist: xenial
 language: python
 python:
   - "3.7"

--- a/gym/wrappers/monitoring/video_recorder.py
+++ b/gym/wrappers/monitoring/video_recorder.py
@@ -300,10 +300,7 @@ class ImageEncoder(object):
         if frame.dtype != np.uint8:
             raise error.InvalidFrame("Your frame has data type {}, but we require uint8 (i.e. RGB values from 0-255).".format(frame.dtype))
 
-        if distutils.version.LooseVersion(np.__version__) >= distutils.version.LooseVersion('1.9.0'):
             self.proc.stdin.write(frame.tobytes())
-        else:
-            self.proc.stdin.write(frame.tostring())
 
     def close(self):
         self.proc.stdin.close()

--- a/py.Dockerfile
+++ b/py.Dockerfile
@@ -19,7 +19,7 @@ RUN pip install pytest pytest-forked lz4
 
 COPY . /usr/local/gym/
 WORKDIR /usr/local/gym/
-RUN [ "$PYTHON_VER" != "3.8.1" ] && pip install .[all] || pip install .
+RUN pip install .[all] || pip install .
 
 ENTRYPOINT ["/usr/local/gym/bin/docker_entrypoint"]
 CMD ["pytest","--forked"]

--- a/py.Dockerfile
+++ b/py.Dockerfile
@@ -1,7 +1,7 @@
 # A Dockerfile that sets up a full Gym install with test dependencies
 ARG PYTHON_VER
 FROM python:$PYTHON_VER
-RUN apt-get -y update && apt-get install -y unzip libglu1-mesa-dev libgl1-mesa-dev libosmesa6-dev xvfb patchelf ffmpeg cmake
+RUN apt-get -y update && apt-get install -y unzip libglu1-mesa-dev libgl1-mesa-dev libosmesa6-dev xvfb patchelf ffmpeg cmake swig
 RUN \ 
 # Download mujoco
     mkdir /root/.mujoco && \

--- a/py.Dockerfile
+++ b/py.Dockerfile
@@ -1,7 +1,7 @@
 # A Dockerfile that sets up a full Gym install with test dependencies
 ARG PYTHON_VER
 FROM python:$PYTHON_VER
-RUN apt-get -y update && apt-get install -y unzip libglu1-mesa-dev libgl1-mesa-dev libosmesa6-dev xvfb patchelf ffmpeg
+RUN apt-get -y update && apt-get install -y unzip libglu1-mesa-dev libgl1-mesa-dev libosmesa6-dev xvfb patchelf ffmpeg cmake
 RUN \ 
 # Download mujoco
     mkdir /root/.mujoco && \

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from version import VERSION
 
 # Environment-specific dependencies.
 extras = {
-  'atari': ['atari_py~=0.2.0', 'Pillow>=6.2.1', 'opencv-python>=3.'],
+  'atari': ['atari_py~=0.2.0', 'Pillow', 'opencv-python>=3.'],
   'box2d': ['box2d-py~=2.3.5'],
   'classic_control': [],
   'mujoco': ['mujoco_py>=1.50, <2.0', 'imageio'],

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,9 @@ setup(name='gym',
         'envs/robotics/assets/textures/*.png']
       },
       tests_require=['pytest', 'mock'],
-      python_requires='>=3.5',
+      python_requires='>=3.6',
       classifiers=[
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from version import VERSION
 
 # Environment-specific dependencies.
 extras = {
-  'atari': ['atari_py~=0.2.0', 'Pillow', 'opencv-python'],
+  'atari': ['atari_py~=0.2.0', 'Pillow>=6.2.1', 'opencv-python>=3.'],
   'box2d': ['box2d-py~=2.3.5'],
   'classic_control': [],
   'mujoco': ['mujoco_py>=1.50, <2.0', 'imageio'],


### PR DESCRIPTION
In this PR:

-Removed Python 3.5. It's no longer supported, included with any supported Linux distro, or supported by NumPy/SciPy/etc.
-Bumped Ubuntu version used for tests to current LTS
-Bumped Python subversions used for tests to current ones
-Added max version to Pillow. Pyglet depends on it for certain functions, and the range you've chosen isn't compatible with the newest version (8.0.0, released Oct 14)
-All tests run on all Python versions now (this seems to have been accidentally disabled in the Python 2.7 deprecation?)
-Added the minimum version of OpenCV needed to properly function to setup.py
-Removes an unused failover I found chasing down the pillow problem that was supposed to be removed with issue #28