### PR TITLE
Make various 'space' functions easier to extend for custom Spaces

### DIFF
--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -6,8 +6,7 @@ from typing import Union
 
 import numpy as np
 from gym.error import CustomSpaceError
-from gym.spaces import (Box, Dict, Discrete, MultiBinary, MultiDiscrete, Space,
-                        Tuple)
+from gym.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Space, Tuple
 
 
 @singledispatch

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -9,15 +9,18 @@ from gym.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Space, T
 
 
 def _space_as_first_positional_argument(fn):
-    """ Wrapper that passes the space as a positional argument, so that the
+    """Wrapper that passes the space as a positional argument, so that the
     singledispatch callable can be used even when passing all values with kwargs.
     """
+
     @wraps(fn)
     def wrapped(space: Space, *args, **kwargs):
         return fn(space, *args, **kwargs)
+
     return wrapped
 
 
+@_space_as_first_positional_argument
 @singledispatch
 def flatdim(space: Space) -> int:
     """Return the number of dimensions a flattened equivalent of this space
@@ -65,8 +68,9 @@ def flatten(space, x):
     network, which only understands flat arrays of floats.
 
     Accepts a space and a point from that space. Always returns a 1D array.
-    Raises a ``CustomSpaceError`` if the space is not defined in
-    ``gym.spaces`` and if there isn't a function registered for that type.
+    Raises ``NotImplementedError`` if the space is not defined in
+    ``gym.spaces`` and doesn't have a registered
+    function.
     """
     raise NotImplementedError(f"Unknown space: `{space}`")
 
@@ -113,9 +117,8 @@ def unflatten(space, x):
     that the ``space`` argument is the same as for the ``flatten()`` call.
 
     Accepts a space and a flattened point. Returns a point with a structure
-    that matches the space.
-    Raises a ``CustomSpaceError`` if the space is not defined in
-    ``gym.spaces`` and if there isn't a function registered for that type.
+    that matches the space. Raises ``NotImplementedError`` if the space is not
+    defined in ``gym.spaces`` and doesn't have a registered function.
     """
     raise NotImplementedError(f"Unknown space: `{space}`")
 
@@ -166,33 +169,33 @@ def unflatten_dict(space, x):
 def flatten_space(space):
     """Flatten a space into a single ``Box``.
 
-     This is equivalent to ``flatten()``, but operates on the space itself. The
-     result always is a `Box` with flat boundaries. The box has exactly
-     ``flatdim(space)`` dimensions. Flattening a sample of the original space
-     has the same effect as taking a sample of the flattenend space.
+    This is equivalent to ``flatten()``, but operates on the space itself. The
+    result always is a `Box` with flat boundaries. The box has exactly
+    ``flatdim(space)`` dimensions. Flattening a sample of the original space
+    has the same effect as taking a sample of the flattenend space.
 
-     Raises a ``CustomSpaceError`` if the space is not defined in
-     ``gym.spaces`` and if there isn't a function registered for that type.
+    Raises ``NotImplementedError`` if the space is not defined in
+    ``gym.spaces` and doesn't have a registered function.
 
-     Example::
+    Example::
 
-         >>> box = Box(0.0, 1.0, shape=(3, 4, 5))
-         >>> box
-         Box(3, 4, 5)
-         >>> flatten_space(box)
-         Box(60,)
-         >>> flatten(box, box.sample()) in flatten_space(box)
-         True
+        >>> box = Box(0.0, 1.0, shape=(3, 4, 5))
+        >>> box
+        Box(3, 4, 5)
+        >>> flatten_space(box)
+        Box(60,)
+        >>> flatten(box, box.sample()) in flatten_space(box)
+        True
 
-     Example that flattens a discrete space::
+    Example that flattens a discrete space::
 
-         >>> discrete = Discrete(5)
-         >>> flatten_space(discrete)
-         Box(5,)
-         >>> flatten(box, box.sample()) in flatten_space(box)
-         True
+        >>> discrete = Discrete(5)
+        >>> flatten_space(discrete)
+        Box(5,)
+        >>> flatten(box, box.sample()) in flatten_space(box)
+        True
 
-     Example that recursively flattens a dict::
+    Example that recursively flattens a dict::
 
         >>> space = Dict({"position": Discrete(2),
         ...               "velocity": Box(0, 1, shape=(2, 2))})

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -2,14 +2,13 @@ from collections import OrderedDict
 from functools import singledispatch, reduce, wraps
 import numpy as np
 import operator as op
-from typing import Union
 
 import numpy as np
 from gym.error import CustomSpaceError
 from gym.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Space, Tuple
 
 
-def pass_space_as_first_positional_argument(fn):
+def _space_as_first_positional_argument(fn):
     """ Wrapper that passes the space as a positional argument, so that the
     singledispatch callable can be used even when passing all values with kwargs.
     """
@@ -19,7 +18,6 @@ def pass_space_as_first_positional_argument(fn):
     return wrapped
 
 
-@pass_space_as_first_positional_argument
 @singledispatch
 def flatdim(space: Space) -> int:
     """Return the number of dimensions a flattened equivalent of this space
@@ -58,7 +56,7 @@ def flatdim_dict(space):
     return sum([flatdim(s) for s in space.spaces.values()])
 
 
-@pass_space_as_first_positional_argument
+@_space_as_first_positional_argument
 @singledispatch
 def flatten(space, x):
     """Flatten a data point from a space.
@@ -106,7 +104,7 @@ def flatten_dict(space, x):
     return np.concatenate([flatten(s, x[key]) for key, s in space.spaces.items()])
 
 
-@pass_space_as_first_positional_argument
+@_space_as_first_positional_argument
 @singledispatch
 def unflatten(space, x):
     """Unflatten a data point from a space.
@@ -163,7 +161,7 @@ def unflatten_dict(space, x):
     )
 
 
-@pass_space_as_first_positional_argument
+@_space_as_first_positional_argument
 @singledispatch
 def flatten_space(space):
     """Flatten a space into a single ``Box``.

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -2,8 +2,6 @@ from collections import OrderedDict
 from functools import singledispatch, reduce, wraps
 import numpy as np
 import operator as op
-
-import numpy as np
 from gym.error import CustomSpaceError
 from gym.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Space, Tuple
 
@@ -14,8 +12,11 @@ def _space_as_first_positional_argument(fn):
     """
 
     @wraps(fn)
-    def wrapped(space: Space, *args, **kwargs):
-        return fn(space, *args, **kwargs)
+    def wrapped(*args, **kwargs):
+        if "space" in kwargs:
+            space = kwargs.pop("space")
+            return fn(space, *args, **kwargs)
+        return fn(*args, **kwargs)
 
     return wrapped
 

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -2,22 +2,22 @@ from collections import OrderedDict
 from functools import singledispatch, reduce
 import numpy as np
 import operator as op
+from typing import Union
 
-from gym.spaces import Box
-from gym.spaces import Discrete
-from gym.spaces import MultiDiscrete
-from gym.spaces import MultiBinary
-from gym.spaces import Tuple
-from gym.spaces import Dict
+import numpy as np
+from gym.error import CustomSpaceError
+from gym.spaces import (Box, Dict, Discrete, MultiBinary, MultiDiscrete, Space,
+                        Tuple)
 
 
 @singledispatch
-def flatdim(space):
+def flatdim(space: Space) -> int:
     """Return the number of dimensions a flattened equivalent of this space
     would have.
 
     Accepts a space and returns an integer. Raises ``NotImplementedError`` if
-    the space is not defined in ``gym.spaces``.
+    the space is not defined in ``gym.spaces`` and doesn't have a registered
+    function.
     """
     raise NotImplementedError(f"Unknown space: `{space}`")
 
@@ -56,8 +56,8 @@ def flatten(space, x):
     network, which only understands flat arrays of floats.
 
     Accepts a space and a point from that space. Always returns a 1D array.
-    Raises ``NotImplementedError`` if the space is not defined in
-    ``gym.spaces``.
+    Raises a ``CustomSpaceError`` if the space is not defined in
+    ``gym.spaces`` and if there isn't a function registered for that type.
     """
     raise NotImplementedError(f"Unknown space: `{space}`")
 
@@ -103,8 +103,9 @@ def unflatten(space, x):
     that the ``space`` argument is the same as for the ``flatten()`` call.
 
     Accepts a space and a flattened point. Returns a point with a structure
-    that matches the space. Raises ``NotImplementedError`` if the space is not
-    defined in ``gym.spaces``.
+    that matches the space.
+    Raises a ``CustomSpaceError`` if the space is not defined in
+    ``gym.spaces`` and if there isn't a function registered for that type.
     """
     raise NotImplementedError(f"Unknown space: `{space}`")
 
@@ -154,33 +155,33 @@ def unflatten_dict(space, x):
 def flatten_space(space):
     """Flatten a space into a single ``Box``.
 
-    This is equivalent to ``flatten()``, but operates on the space itself. The
-    result always is a `Box` with flat boundaries. The box has exactly
-    ``flatdim(space)`` dimensions. Flattening a sample of the original space
-    has the same effect as taking a sample of the flattenend space.
+     This is equivalent to ``flatten()``, but operates on the space itself. The
+     result always is a `Box` with flat boundaries. The box has exactly
+     ``flatdim(space)`` dimensions. Flattening a sample of the original space
+     has the same effect as taking a sample of the flattenend space.
 
-    Raises ``NotImplementedError`` if the space is not defined in
-    ``gym.spaces``.
+     Raises a ``CustomSpaceError`` if the space is not defined in
+     ``gym.spaces`` and if there isn't a function registered for that type.
 
-    Example::
+     Example::
 
-        >>> box = Box(0.0, 1.0, shape=(3, 4, 5))
-        >>> box
-        Box(3, 4, 5)
-        >>> flatten_space(box)
-        Box(60,)
-        >>> flatten(box, box.sample()) in flatten_space(box)
-        True
+         >>> box = Box(0.0, 1.0, shape=(3, 4, 5))
+         >>> box
+         Box(3, 4, 5)
+         >>> flatten_space(box)
+         Box(60,)
+         >>> flatten(box, box.sample()) in flatten_space(box)
+         True
 
-    Example that flattens a discrete space::
+     Example that flattens a discrete space::
 
-        >>> discrete = Discrete(5)
-        >>> flatten_space(discrete)
-        Box(5,)
-        >>> flatten(box, box.sample()) in flatten_space(box)
-        True
+         >>> discrete = Discrete(5)
+         >>> flatten_space(discrete)
+         Box(5,)
+         >>> flatten(box, box.sample()) in flatten_space(box)
+         True
 
-    Example that recursively flattens a dict::
+     Example that recursively flattens a dict::
 
         >>> space = Dict({"position": Discrete(2),
         ...               "velocity": Box(0, 1, shape=(2, 2))})

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from functools import singledispatch, reduce
+from functools import singledispatch, reduce, wraps
 import numpy as np
 import operator as op
 from typing import Union
@@ -9,6 +9,17 @@ from gym.error import CustomSpaceError
 from gym.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Space, Tuple
 
 
+def pass_space_as_first_positional_argument(fn):
+    """ Wrapper that passes the space as a positional argument, so that the
+    singledispatch callable can be used even when passing all values with kwargs.
+    """
+    @wraps(fn)
+    def wrapped(space: Space, *args, **kwargs):
+        return fn(space, *args, **kwargs)
+    return wrapped
+
+
+@pass_space_as_first_positional_argument
 @singledispatch
 def flatdim(space: Space) -> int:
     """Return the number of dimensions a flattened equivalent of this space
@@ -47,6 +58,7 @@ def flatdim_dict(space):
     return sum([flatdim(s) for s in space.spaces.values()])
 
 
+@pass_space_as_first_positional_argument
 @singledispatch
 def flatten(space, x):
     """Flatten a data point from a space.
@@ -94,6 +106,7 @@ def flatten_dict(space, x):
     return np.concatenate([flatten(s, x[key]) for key, s in space.spaces.items()])
 
 
+@pass_space_as_first_positional_argument
 @singledispatch
 def unflatten(space, x):
     """Unflatten a data point from a space.
@@ -150,6 +163,7 @@ def unflatten_dict(space, x):
     )
 
 
+@pass_space_as_first_positional_argument
 @singledispatch
 def flatten_space(space):
     """Flatten a space into a single ``Box``.

--- a/gym/vector/utils/numpy_utils.py
+++ b/gym/vector/utils/numpy_utils.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from functools import singledispatch
+from functools import singledispatch, wraps
 from typing import Callable, Sequence, Union
 
 import numpy as np
@@ -7,10 +7,12 @@ import numpy as np
 from gym import spaces
 from gym.spaces import Space, Box, Discrete, MultiBinary, MultiDiscrete
 from gym.vector.utils.spaces import _BaseGymSpaces
+from gym.spaces.utils import pass_space_as_first_positional_argument
 
 __all__ = ["concatenate", "create_empty_array"]
 
 
+@pass_space_as_first_positional_argument
 @singledispatch
 def concatenate(
     space: Space, items: Sequence, out: Union[tuple, dict, np.ndarray]
@@ -94,6 +96,7 @@ def _concatenate_custom(
     return tuple(items)
 
 
+@pass_space_as_first_positional_argument
 @singledispatch
 def create_empty_array(
     space: Space, n: int = 1, fn: Callable = np.zeros

--- a/gym/vector/utils/numpy_utils.py
+++ b/gym/vector/utils/numpy_utils.py
@@ -59,14 +59,14 @@ def concatenate(
 @concatenate.register(spaces.Discrete)
 @concatenate.register(spaces.MultiDiscrete)
 @concatenate.register(spaces.MultiBinary)
-def concatenate_base(
+def _concatenate_base(
     space: Space, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray]
 ) -> np.ndarray:
     return np.stack(items, axis=0, out=out)
 
 
 @concatenate.register(spaces.Tuple)
-def concatenate_tuple(
+def _concatenate_tuples(
     space: spaces.Tuple, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray]
 ) -> tuple:
     return tuple(
@@ -76,7 +76,7 @@ def concatenate_tuple(
 
 
 @concatenate.register(spaces.Dict)
-def concatenate_dict(
+def _concatenate_dicts(
     space: spaces.Dict, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray]
 ) -> OrderedDict:
     return OrderedDict(
@@ -88,7 +88,7 @@ def concatenate_dict(
 
 
 @concatenate.register(spaces.Space)
-def concatenate_custom(
+def _concatenate_custom(
     space: Space, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray]
 ) -> Union[tuple, dict, np.ndarray]:
     return tuple(items)
@@ -140,7 +140,7 @@ def create_empty_array(
 @create_empty_array.register(spaces.Discrete)
 @create_empty_array.register(spaces.MultiDiscrete)
 @create_empty_array.register(spaces.MultiBinary)
-def create_empty_array_base(
+def _create_empty_array_base(
     space: Space, n: int = 1, fn: Callable = np.zeros
 ) -> Union[tuple, dict, np.ndarray]:
     shape = space.shape if (n is None) else (n,) + space.shape
@@ -148,14 +148,14 @@ def create_empty_array_base(
 
 
 @create_empty_array.register(spaces.Tuple)
-def create_empty_array_tuple(
+def _create_empty_array_tuple(
     space: spaces.Tuple, n: int = 1, fn: Callable = np.zeros
 ) -> tuple:
     return tuple(create_empty_array(subspace, n=n, fn=fn) for subspace in space.spaces)
 
 
 @create_empty_array.register(spaces.Dict)
-def create_empty_array_dict(
+def _create_empty_array_dict(
     space: spaces.Dict, n: int = 1, fn: Callable = np.zeros
 ) -> OrderedDict:
     return OrderedDict(
@@ -167,7 +167,7 @@ def create_empty_array_dict(
 
 
 @create_empty_array.register(Space)
-def create_empty_array_custom(
+def _create_empty_array_custom(
     space: Space, n: int = 1, fn: Callable = np.zeros
 ) -> tuple:
     return ()

--- a/gym/vector/utils/numpy_utils.py
+++ b/gym/vector/utils/numpy_utils.py
@@ -12,9 +12,9 @@ __all__ = ["concatenate", "create_empty_array"]
 
 
 @singledispatch
-def concatenate(space: Space,
-                items: Sequence,
-                out: Union[tuple, dict, np.ndarray]) -> Union[tuple, dict, np.ndarray]:
+def concatenate(
+    space: Space, items: Sequence, out: Union[tuple, dict, np.ndarray]
+) -> Union[tuple, dict, np.ndarray]:
     """Concatenate multiple samples from space into a single object.
 
     Parameters
@@ -50,47 +50,54 @@ def concatenate(space: Space,
         return concatenate(space, items, out)
 
     assert isinstance(items, (list, tuple)), items
-    raise ValueError(f'Space of type `{0}` is not a valid `gym.Space` instance.'
-                     .format(type(space)))
+    raise ValueError(
+        f"Space of type `{0}` is not a valid `gym.Space` instance.".format(type(space))
+    )
 
 
 @concatenate.register(spaces.Box)
 @concatenate.register(spaces.Discrete)
 @concatenate.register(spaces.MultiDiscrete)
 @concatenate.register(spaces.MultiBinary)
-def concatenate_base(space: Space,
-                     items: Union[list, tuple],
-                     out: Union[tuple, dict, np.ndarray]) -> np.ndarray:
+def concatenate_base(
+    space: Space, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray]
+) -> np.ndarray:
     return np.stack(items, axis=0, out=out)
 
 
 @concatenate.register(spaces.Tuple)
-def concatenate_tuple(space: spaces.Tuple,
-                      items: Union[list, tuple],
-                      out: Union[tuple, dict, np.ndarray]) -> tuple:
-    return tuple(concatenate([item[i] for item in items],
-                             out[i], subspace) for (i, subspace) in enumerate(space.spaces))
+def concatenate_tuple(
+    space: spaces.Tuple, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray]
+) -> tuple:
+    return tuple(
+        concatenate(subspace, [item[i] for item in items], out=out[i])
+        for (i, subspace) in enumerate(space.spaces)
+    )
 
 
 @concatenate.register(spaces.Dict)
-def concatenate_dict(space: spaces.Dict,
-                     items: Union[list, tuple],
-                     out: Union[tuple, dict, np.ndarray]) -> OrderedDict:
-    return OrderedDict([(key, concatenate([item[key] for item in items],
-                                          out[key], subspace)) for (key, subspace) in space.spaces.items()])
+def concatenate_dict(
+    space: spaces.Dict, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray]
+) -> OrderedDict:
+    return OrderedDict(
+        [
+            (key, concatenate(subspace, [item[key] for item in items], out=out[key]))
+            for (key, subspace) in space.spaces.items()
+        ]
+    )
 
 
 @concatenate.register(spaces.Space)
-def concatenate_custom(space: Space,
-                       items: Union[list, tuple],
-                       out: Union[tuple, dict, np.ndarray]) -> Union[tuple, dict, np.ndarray]:
+def concatenate_custom(
+    space: Space, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray]
+) -> Union[tuple, dict, np.ndarray]:
     return tuple(items)
 
 
 @singledispatch
-def create_empty_array(space: Space,
-                       n: int = 1,
-                       fn: Callable = np.zeros) -> Union[tuple, dict, np.ndarray]:
+def create_empty_array(
+    space: Space, n: int = 1, fn: Callable = np.zeros
+) -> Union[tuple, dict, np.ndarray]:
     """Create an empty (possibly nested) numpy array.
 
     Parameters
@@ -123,31 +130,44 @@ def create_empty_array(space: Space,
                  ('velocity', array([[0., 0.],
                                      [0., 0.]], dtype=float32))])
     """
-    raise ValueError('Space of type `{0}` is not a valid `gym.Space` '
-                     'instance.'.format(type(space)))
+    raise ValueError(
+        "Space of type `{0}` is not a valid `gym.Space` "
+        "instance.".format(type(space))
+    )
 
 
 @create_empty_array.register(spaces.Box)
 @create_empty_array.register(spaces.Discrete)
 @create_empty_array.register(spaces.MultiDiscrete)
 @create_empty_array.register(spaces.MultiBinary)
-def create_empty_array_base(space: Space, n: int = 1, fn: Callable = np.zeros) -> Union[tuple, dict, np.ndarray]:
+def create_empty_array_base(
+    space: Space, n: int = 1, fn: Callable = np.zeros
+) -> Union[tuple, dict, np.ndarray]:
     shape = space.shape if (n is None) else (n,) + space.shape
     return fn(shape, dtype=space.dtype)
 
 
 @create_empty_array.register(spaces.Tuple)
-def create_empty_array_tuple(space: spaces.Tuple, n: int = 1, fn: Callable = np.zeros) -> tuple:
-    return tuple(create_empty_array(subspace, n=n, fn=fn)
-                 for subspace in space.spaces)
+def create_empty_array_tuple(
+    space: spaces.Tuple, n: int = 1, fn: Callable = np.zeros
+) -> tuple:
+    return tuple(create_empty_array(subspace, n=n, fn=fn) for subspace in space.spaces)
 
 
 @create_empty_array.register(spaces.Dict)
-def create_empty_array_dict(space: spaces.Dict, n: int = 1, fn: Callable = np.zeros) -> OrderedDict:
-    return OrderedDict([(key, create_empty_array(subspace, n=n, fn=fn))
-                        for (key, subspace) in space.spaces.items()])
+def create_empty_array_dict(
+    space: spaces.Dict, n: int = 1, fn: Callable = np.zeros
+) -> OrderedDict:
+    return OrderedDict(
+        [
+            (key, create_empty_array(subspace, n=n, fn=fn))
+            for (key, subspace) in space.spaces.items()
+        ]
+    )
 
 
 @create_empty_array.register(Space)
-def create_empty_array_custom(space: Space, n: int = 1, fn: Callable = np.zeros) -> tuple:
+def create_empty_array_custom(
+    space: Space, n: int = 1, fn: Callable = np.zeros
+) -> tuple:
     return ()

--- a/gym/vector/utils/numpy_utils.py
+++ b/gym/vector/utils/numpy_utils.py
@@ -7,12 +7,12 @@ import numpy as np
 from gym import spaces
 from gym.spaces import Space, Box, Discrete, MultiBinary, MultiDiscrete
 from gym.vector.utils.spaces import _BaseGymSpaces
-from gym.spaces.utils import pass_space_as_first_positional_argument
+from gym.spaces.utils import _space_as_first_positional_argument
 
 __all__ = ["concatenate", "create_empty_array"]
 
 
-@pass_space_as_first_positional_argument
+@_space_as_first_positional_argument
 @singledispatch
 def concatenate(
     space: Space, items: Sequence, out: Union[tuple, dict, np.ndarray]
@@ -96,7 +96,7 @@ def _concatenate_custom(
     return tuple(items)
 
 
-@pass_space_as_first_positional_argument
+@_space_as_first_positional_argument
 @singledispatch
 def create_empty_array(
     space: Space, n: int = 1, fn: Callable = np.zeros

--- a/gym/vector/utils/numpy_utils.py
+++ b/gym/vector/utils/numpy_utils.py
@@ -62,14 +62,14 @@ def concatenate(
 @concatenate.register(spaces.MultiDiscrete)
 @concatenate.register(spaces.MultiBinary)
 def _concatenate_base(
-    space: Space, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray]
+    space: Space, items: Union[list, tuple], out: np.ndarray,
 ) -> np.ndarray:
     return np.stack(items, axis=0, out=out)
 
 
 @concatenate.register(spaces.Tuple)
 def _concatenate_tuples(
-    space: spaces.Tuple, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray]
+    space: spaces.Tuple, items: Union[list, tuple], out: Union[tuple, np.ndarray],
 ) -> tuple:
     return tuple(
         concatenate(subspace, [item[i] for item in items], out=out[i])
@@ -79,11 +79,11 @@ def _concatenate_tuples(
 
 @concatenate.register(spaces.Dict)
 def _concatenate_dicts(
-    space: spaces.Dict, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray]
+    space: spaces.Dict, items: Union[list, tuple], out: dict,
 ) -> OrderedDict:
     return OrderedDict(
         [
-            (key, concatenate(subspace, [item[key] for item in items], out=out[key]))
+            (key, concatenate(subspace, [item[key] for item in items], out=out[key]),)
             for (key, subspace) in space.spaces.items()
         ]
     )
@@ -91,7 +91,7 @@ def _concatenate_dicts(
 
 @concatenate.register(spaces.Space)
 def _concatenate_custom(
-    space: Space, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray]
+    space: Space, items: Union[list, tuple], out: Union[tuple, dict, np.ndarray],
 ) -> Union[tuple, dict, np.ndarray]:
     return tuple(items)
 

--- a/gym/vector/utils/shared_memory.py
+++ b/gym/vector/utils/shared_memory.py
@@ -49,7 +49,7 @@ def create_shared_memory(space: Space, n: int = 1, ctx=mp):
 @create_shared_memory.register(spaces.Discrete)
 @create_shared_memory.register(spaces.MultiDiscrete)
 @create_shared_memory.register(spaces.MultiBinary)
-def create_base_shared_memory(space: Space, n: int = 1, ctx=mp) -> mp.Array:
+def _create_base_shared_memory(space: Space, n: int = 1, ctx=mp) -> mp.Array:
     dtype = space.dtype.char
     if dtype in "?":
         dtype = c_bool
@@ -57,13 +57,13 @@ def create_base_shared_memory(space: Space, n: int = 1, ctx=mp) -> mp.Array:
 
 
 @create_shared_memory.register(spaces.Tuple)
-def create_tuple_shared_memory(space: spaces.Tuple, n: int = 1, ctx=mp) -> tuple:
+def _create_tuple_shared_memory(space: spaces.Tuple, n: int = 1, ctx=mp) -> tuple:
     return tuple(create_shared_memory(subspace, n=n, ctx=ctx)
         for subspace in space.spaces)
 
 
 @create_shared_memory.register(spaces.Dict)
-def create_dict_shared_memory(space: spaces.Dict, n: int = 1, ctx=mp) -> OrderedDict:
+def _create_dict_shared_memory(space: spaces.Dict, n: int = 1, ctx=mp) -> OrderedDict:
     return OrderedDict([(key, create_shared_memory(subspace, n=n, ctx=ctx))
         for (key, subspace) in space.spaces.items()])
 
@@ -117,7 +117,7 @@ def read_from_shared_memory(space: Space,
 @read_from_shared_memory.register(spaces.Discrete)
 @read_from_shared_memory.register(spaces.MultiDiscrete)
 @read_from_shared_memory.register(spaces.MultiBinary)
-def read_base_from_shared_memory(space: Space,
+def _read_base_from_shared_memory(space: Space,
                                  shared_memory: mp.Array,
                                  n: int = 1) -> np.ndarray:
     return np.frombuffer(shared_memory.get_obj(),
@@ -125,7 +125,7 @@ def read_base_from_shared_memory(space: Space,
 
 
 @read_from_shared_memory.register(spaces.Tuple)
-def read_tuple_from_shared_memory(space: spaces.Tuple,
+def _read_tuple_from_shared_memory(space: spaces.Tuple,
                                   shared_memory: tuple,
                                   n: int = 1) -> tuple:
     return tuple(read_from_shared_memory(memory, subspace, n=n)
@@ -133,7 +133,7 @@ def read_tuple_from_shared_memory(space: spaces.Tuple,
 
 
 @read_from_shared_memory.register(spaces.Dict)
-def read_dict_from_shared_memory(space: spaces.Dict,
+def _read_dict_from_shared_memory(space: spaces.Dict,
                                  shared_memory: dict,
                                  n: int = 1) -> OrderedDict:
     return OrderedDict([(key, read_from_shared_memory(shared_memory[key],
@@ -184,7 +184,7 @@ def write_to_shared_memory(space: Space,
 @write_to_shared_memory.register(spaces.Box)
 @write_to_shared_memory.register(spaces.MultiDiscrete)
 @write_to_shared_memory.register(spaces.MultiBinary)
-def write_base_to_shared_memory(space: Space,
+def _write_base_to_shared_memory(space: Space,
                                 index: int,
                                 value,
                                 shared_memory: mp.Array) -> None:
@@ -198,7 +198,7 @@ def write_base_to_shared_memory(space: Space,
 
 
 @write_to_shared_memory.register(spaces.Tuple)
-def write_tuple_to_shared_memory(space: spaces.Tuple,
+def _write_tuple_to_shared_memory(space: spaces.Tuple,
                                  index: int,
                                  values: Iterable,
                                  shared_memory: tuple) -> None:
@@ -207,7 +207,7 @@ def write_tuple_to_shared_memory(space: spaces.Tuple,
 
 
 @write_to_shared_memory.register(spaces.Dict)
-def write_dict_to_shared_memory(space: spaces.Dict,
+def _write_dict_to_shared_memory(space: spaces.Dict,
                                 index: int,
                                 values: dict,
                                 shared_memory: dict) -> None:

--- a/gym/vector/utils/shared_memory.py
+++ b/gym/vector/utils/shared_memory.py
@@ -1,17 +1,21 @@
-import numpy as np
 import multiprocessing as mp
-from ctypes import c_bool
 from collections import OrderedDict
+from ctypes import c_bool
+from functools import singledispatch
+from typing import Union, Iterable
 
-from gym import logger
-from gym.spaces import Tuple, Dict
+import numpy as np
+
+from gym import logger, spaces
 from gym.error import CustomSpaceError
+from gym.spaces import Space
 from gym.vector.utils.spaces import _BaseGymSpaces
 
 __all__ = ["create_shared_memory", "read_from_shared_memory", "write_to_shared_memory"]
 
 
-def create_shared_memory(space, n=1, ctx=mp):
+@singledispatch
+def create_shared_memory(space: Space, n: int = 1, ctx=mp):
     """Create a shared memory object, to be shared across processes. This
     eventually contains the observations from the vectorized environment.
 
@@ -32,55 +36,52 @@ def create_shared_memory(space, n=1, ctx=mp):
     shared_memory : dict, tuple, or `multiprocessing.Array` instance
         Shared object across processes.
     """
-    if isinstance(space, _BaseGymSpaces):
-        return create_base_shared_memory(space, n=n, ctx=ctx)
-    elif isinstance(space, Tuple):
-        return create_tuple_shared_memory(space, n=n, ctx=ctx)
-    elif isinstance(space, Dict):
-        return create_dict_shared_memory(space, n=n, ctx=ctx)
-    else:
-        raise CustomSpaceError(
-            "Cannot create a shared memory for space with "
-            "type `{0}`. Shared memory only supports "
-            "default Gym spaces (e.g. `Box`, `Tuple`, "
-            "`Dict`, etc...), and does not support custom "
-            "Gym spaces.".format(type(space))
-        )
+    raise CustomSpaceError(
+        f"Cannot create a shared memory for space with type `{type(space)}`. "
+        f"Shared memory only supports default Gym spaces (e.g. `Box`, `Tuple`, "
+        f"`Dict`, etc...) out-of-the-box. To use custom spaces, register a "
+        f"function to use for spaces of type {type(space)} by decorating it "
+        f" with `create_shared_memory.register({type(space).__name__})`."
+    )
 
 
-def create_base_shared_memory(space, n=1, ctx=mp):
+@create_shared_memory.register(spaces.Box)
+@create_shared_memory.register(spaces.Discrete)
+@create_shared_memory.register(spaces.MultiDiscrete)
+@create_shared_memory.register(spaces.MultiBinary)
+def create_base_shared_memory(space: Space, n: int = 1, ctx=mp) -> mp.Array:
     dtype = space.dtype.char
     if dtype in "?":
         dtype = c_bool
     return ctx.Array(dtype, n * int(np.prod(space.shape)))
 
 
-def create_tuple_shared_memory(space, n=1, ctx=mp):
-    return tuple(
-        create_shared_memory(subspace, n=n, ctx=ctx) for subspace in space.spaces
-    )
+@create_shared_memory.register(spaces.Tuple)
+def create_tuple_shared_memory(space: spaces.Tuple, n: int = 1, ctx=mp) -> tuple:
+    return tuple(create_shared_memory(subspace, n=n, ctx=ctx)
+        for subspace in space.spaces)
 
 
-def create_dict_shared_memory(space, n=1, ctx=mp):
-    return OrderedDict(
-        [
-            (key, create_shared_memory(subspace, n=n, ctx=ctx))
-            for (key, subspace) in space.spaces.items()
-        ]
-    )
+@create_shared_memory.register(spaces.Dict)
+def create_dict_shared_memory(space: spaces.Dict, n: int = 1, ctx=mp) -> OrderedDict:
+    return OrderedDict([(key, create_shared_memory(subspace, n=n, ctx=ctx))
+        for (key, subspace) in space.spaces.items()])
 
 
-def read_from_shared_memory(shared_memory, space, n=1):
+@singledispatch
+def read_from_shared_memory(space: Space,
+                            shared_memory: Union[dict, tuple, mp.Array],
+                            n: int = 1) -> Union[dict, tuple, mp.Array]:
     """Read the batch of observations from shared memory as a numpy array.
 
     Parameters
     ----------
+    space : `gym.spaces.Space` instance
+        Observation space of a single environment in the vectorized environment.
+
     shared_memory : dict, tuple, or `multiprocessing.Array` instance
         Shared object across processes. This contains the observations from the
         vectorized environment. This object is created with `create_shared_memory`.
-
-    space : `gym.spaces.Space` instance
-        Observation space of a single environment in the vectorized environment.
 
     n : int
         Number of environments in the vectorized environment (i.e. the number
@@ -97,49 +98,60 @@ def read_from_shared_memory(shared_memory, space, n=1):
     memory of `shared_memory`. Any changes to `shared_memory` are forwarded
     to `observations`, and vice-versa. To avoid any side-effect, use `np.copy`.
     """
-    if isinstance(space, _BaseGymSpaces):
-        return read_base_from_shared_memory(shared_memory, space, n=n)
-    elif isinstance(space, Tuple):
-        return read_tuple_from_shared_memory(shared_memory, space, n=n)
-    elif isinstance(space, Dict):
-        return read_dict_from_shared_memory(shared_memory, space, n=n)
-    else:
-        raise CustomSpaceError(
-            "Cannot read from a shared memory for space with "
-            "type `{0}`. Shared memory only supports "
-            "default Gym spaces (e.g. `Box`, `Tuple`, "
-            "`Dict`, etc...), and does not support custom "
-            "Gym spaces.".format(type(space))
-        )
+    if isinstance(shared_memory, Space):
+        # Re-order the positional arguments to keep this backward-compatible.
+        shared_memory, space, n = space, shared_memory, n  # type: ignore
+        return read_from_shared_memory(space, shared_memory, n)
 
-
-def read_base_from_shared_memory(shared_memory, space, n=1):
-    return np.frombuffer(shared_memory.get_obj(), dtype=space.dtype).reshape(
-        (n,) + space.shape
+    raise CustomSpaceError(
+        f"Cannot read from a shared memory for space with type "
+        f"`{type(space)}`. Shared memory only supports default Gym spaces "
+        f"(e.g. `Box`, `Tuple`, `Dict`, etc...) out-of-the-box. To use custom "
+        f"spaces, register a function to use for spaces of type {type(space)} "
+        f"by decorating it with "
+        f"`read_from_shared_memory.register({type(space).__name__})`."
     )
 
 
-def read_tuple_from_shared_memory(shared_memory, space, n=1):
-    return tuple(
-        read_from_shared_memory(memory, subspace, n=n)
-        for (memory, subspace) in zip(shared_memory, space.spaces)
-    )
+@read_from_shared_memory.register(spaces.Box)
+@read_from_shared_memory.register(spaces.Discrete)
+@read_from_shared_memory.register(spaces.MultiDiscrete)
+@read_from_shared_memory.register(spaces.MultiBinary)
+def read_base_from_shared_memory(space: Space,
+                                 shared_memory: mp.Array,
+                                 n: int = 1) -> np.ndarray:
+    return np.frombuffer(shared_memory.get_obj(),
+        dtype=space.dtype).reshape((n,) + space.shape)
 
 
-def read_dict_from_shared_memory(shared_memory, space, n=1):
-    return OrderedDict(
-        [
-            (key, read_from_shared_memory(shared_memory[key], subspace, n=n))
-            for (key, subspace) in space.spaces.items()
-        ]
-    )
+@read_from_shared_memory.register(spaces.Tuple)
+def read_tuple_from_shared_memory(space: spaces.Tuple,
+                                  shared_memory: tuple,
+                                  n: int = 1) -> tuple:
+    return tuple(read_from_shared_memory(memory, subspace, n=n)
+        for (memory, subspace) in zip(shared_memory, space.spaces))
 
 
-def write_to_shared_memory(index, value, shared_memory, space):
+@read_from_shared_memory.register(spaces.Dict)
+def read_dict_from_shared_memory(space: spaces.Dict,
+                                 shared_memory: dict,
+                                 n: int = 1) -> OrderedDict:
+    return OrderedDict([(key, read_from_shared_memory(shared_memory[key],
+        subspace, n=n)) for (key, subspace) in space.spaces.items()])
+
+
+@singledispatch
+def write_to_shared_memory(space: Space,
+                           index: int,
+                           value,
+                           shared_memory: Union[dict, tuple, mp.Array]) -> None:
     """Write the observation of a single environment into shared memory.
 
     Parameters
     ----------
+    space : `gym.spaces.Space` instance
+        Observation space of a single environment in the vectorized environment.
+
     index : int
         Index of the environment (must be in `[0, num_envs)`).
 
@@ -150,30 +162,32 @@ def write_to_shared_memory(index, value, shared_memory, space):
         Shared object across processes. This contains the observations from the
         vectorized environment. This object is created with `create_shared_memory`.
 
-    space : `gym.spaces.Space` instance
-        Observation space of a single environment in the vectorized environment.
-
     Returns
     -------
     `None`
     """
-    if isinstance(space, _BaseGymSpaces):
-        write_base_to_shared_memory(index, value, shared_memory, space)
-    elif isinstance(space, Tuple):
-        write_tuple_to_shared_memory(index, value, shared_memory, space)
-    elif isinstance(space, Dict):
-        write_dict_to_shared_memory(index, value, shared_memory, space)
-    else:
-        raise CustomSpaceError(
-            "Cannot write to a shared memory for space with "
-            "type `{0}`. Shared memory only supports "
-            "default Gym spaces (e.g. `Box`, `Tuple`, "
-            "`Dict`, etc...), and does not support custom "
-            "Gym spaces.".format(type(space))
-        )
+    if isinstance(space, int) and isinstance(shared_memory, Space):
+        # Reorder the arguments, to keep this backward compatible.
+        index, value, shared_memory, space = space, index, value, shared_memory  # type: ignore
+        return write_to_shared_memory(space, index, value, shared_memory)
+    
+    raise CustomSpaceError(
+        f"Cannot write to a shared memory for space with type `{type(space)}`. "
+        f"Shared memory only supports default Gym spaces (e.g. `Box`, `Tuple`, "
+        f"`Dict`, etc...) out-of-the-box. To use custom spaces, register a "
+        f"function to use for spaces of type {type(space)} by decorating it "
+        f" with `write_to_shared_memory.register({type(space).__name__})`."
+    )
 
 
-def write_base_to_shared_memory(index, value, shared_memory, space):
+@write_to_shared_memory.register(spaces.Discrete)
+@write_to_shared_memory.register(spaces.Box)
+@write_to_shared_memory.register(spaces.MultiDiscrete)
+@write_to_shared_memory.register(spaces.MultiBinary)
+def write_base_to_shared_memory(space: Space,
+                                index: int,
+                                value,
+                                shared_memory: mp.Array) -> None:
     size = int(np.prod(space.shape))
     destination = np.frombuffer(shared_memory.get_obj(), dtype=space.dtype)
     np.copyto(
@@ -182,11 +196,20 @@ def write_base_to_shared_memory(index, value, shared_memory, space):
     )
 
 
-def write_tuple_to_shared_memory(index, values, shared_memory, space):
+
+@write_to_shared_memory.register(spaces.Tuple)
+def write_tuple_to_shared_memory(space: spaces.Tuple,
+                                 index: int,
+                                 values: Iterable,
+                                 shared_memory: tuple) -> None:
     for value, memory, subspace in zip(values, shared_memory, space.spaces):
         write_to_shared_memory(index, value, memory, subspace)
 
 
-def write_dict_to_shared_memory(index, values, shared_memory, space):
+@write_to_shared_memory.register(spaces.Dict)
+def write_dict_to_shared_memory(space: spaces.Dict,
+                                index: int,
+                                values: dict,
+                                shared_memory: dict) -> None:
     for key, subspace in space.spaces.items():
         write_to_shared_memory(index, values[key], shared_memory[key], subspace)

--- a/gym/vector/utils/shared_memory.py
+++ b/gym/vector/utils/shared_memory.py
@@ -9,13 +9,13 @@ import numpy as np
 from gym import logger, spaces
 from gym.error import CustomSpaceError
 from gym.spaces import Space
-from gym.spaces.utils import pass_space_as_first_positional_argument
+from gym.spaces.utils import _space_as_first_positional_argument
 from gym.vector.utils.spaces import _BaseGymSpaces
 
 __all__ = ["create_shared_memory", "read_from_shared_memory", "write_to_shared_memory"]
 
 
-@pass_space_as_first_positional_argument
+@_space_as_first_positional_argument
 @singledispatch
 def create_shared_memory(space: Space, n: int = 1, ctx=mp):
     """Create a shared memory object, to be shared across processes. This
@@ -70,7 +70,7 @@ def _create_dict_shared_memory(space: spaces.Dict, n: int = 1, ctx=mp) -> Ordere
         for (key, subspace) in space.spaces.items()])
 
 
-@pass_space_as_first_positional_argument
+@_space_as_first_positional_argument
 @singledispatch
 def read_from_shared_memory(space: Space,
                             shared_memory: Union[dict, tuple, mp.Array],
@@ -143,7 +143,7 @@ def _read_dict_from_shared_memory(space: spaces.Dict,
         subspace, n=n)) for (key, subspace) in space.spaces.items()])
 
 
-@pass_space_as_first_positional_argument
+@_space_as_first_positional_argument
 @singledispatch
 def write_to_shared_memory(space: Space,
                            index: int,

--- a/gym/vector/utils/spaces.py
+++ b/gym/vector/utils/spaces.py
@@ -4,12 +4,12 @@ from functools import singledispatch
 
 from gym import spaces
 from gym.spaces import Space, Box, Discrete, MultiDiscrete, MultiBinary, Tuple, Dict
-
+from gym.spaces.utils import pass_space_as_first_positional_argument
 _BaseGymSpaces = (Box, Discrete, MultiDiscrete, MultiBinary)
 __all__ = ["_BaseGymSpaces", "batch_space"]
 
 
-
+@pass_space_as_first_positional_argument
 @singledispatch
 def batch_space(space: Space, n: int = 1) -> Space:
     """Create a (batched) space, containing multiple copies of a single space.

--- a/gym/vector/utils/spaces.py
+++ b/gym/vector/utils/spaces.py
@@ -4,12 +4,12 @@ from functools import singledispatch
 
 from gym import spaces
 from gym.spaces import Space, Box, Discrete, MultiDiscrete, MultiBinary, Tuple, Dict
-from gym.spaces.utils import pass_space_as_first_positional_argument
+from gym.spaces.utils import _space_as_first_positional_argument
 _BaseGymSpaces = (Box, Discrete, MultiDiscrete, MultiBinary)
 __all__ = ["_BaseGymSpaces", "batch_space"]
 
 
-@pass_space_as_first_positional_argument
+@_space_as_first_positional_argument
 @singledispatch
 def batch_space(space: Space, n: int = 1) -> Space:
     """Create a (batched) space, containing multiple copies of a single space.

--- a/gym/vector/utils/spaces.py
+++ b/gym/vector/utils/spaces.py
@@ -38,8 +38,10 @@ def batch_space(space: Space, n: int = 1) -> Space:
     >>> batch_space(space, n=5)
     Dict(position:Box(5, 3), velocity:Box(5, 2))
     """
-    raise ValueError('Cannot batch space with type `{0}`. The space must '
-                     'be a valid `gym.Space` instance.'.format(type(space)))
+    raise ValueError(
+        "Cannot batch space with type `{0}`. The space must "
+        "be a valid `gym.Space` instance.".format(type(space))
+    )
 
 
 @batch_space.register(Box)
@@ -73,8 +75,14 @@ def _batch_tuple_space(space: spaces.Tuple, n: int = 1) -> spaces.Tuple:
 
 @batch_space.register(spaces.Dict)
 def _batch_dict_space(space: spaces.Dict, n: int = 1) -> spaces.Dict:
-    return Dict(OrderedDict([(key, batch_space(subspace, n=n))
-        for (key, subspace) in space.spaces.items()]))
+    return Dict(
+        OrderedDict(
+            [
+                (key, batch_space(subspace, n=n))
+                for (key, subspace) in space.spaces.items()
+            ]
+        )
+    )
 
 
 @batch_space.register(Space)

--- a/gym/vector/utils/spaces.py
+++ b/gym/vector/utils/spaces.py
@@ -43,40 +43,40 @@ def batch_space(space: Space, n: int = 1) -> Space:
 
 
 @batch_space.register(Box)
-def batch_space_Box(space: Box, n: int = 1) -> Box:
+def _batch_box_space(space: Box, n: int = 1) -> Box:
     repeats = tuple([n] + [1] * space.low.ndim)
     low, high = np.tile(space.low, repeats), np.tile(space.high, repeats)
     return Box(low=low, high=high, dtype=space.dtype)
 
 
 @batch_space.register(Discrete)
-def batch_space_Discrete(space: Discrete, n: int = 1) -> MultiDiscrete:
+def _batch_discrete_space(space: Discrete, n: int = 1) -> MultiDiscrete:
     return MultiDiscrete(np.full((n,), space.n, dtype=space.dtype))
 
 
 @batch_space.register(MultiDiscrete)
-def batch_space_multi_discrete(space: MultiDiscrete, n: int = 1) -> Box:
+def _batch_multi_discrete_space(space: MultiDiscrete, n: int = 1) -> Box:
     repeats = tuple([n] + [1] * space.nvec.ndim)
     high = np.tile(space.nvec, repeats) - 1
     return Box(low=np.zeros_like(high), high=high, dtype=space.dtype)
 
 
 @batch_space.register(MultiBinary)
-def batch_space_multi_binary(space: MultiBinary, n: int = 1) -> Box:
+def _batch_multi_binary_space(space: MultiBinary, n: int = 1) -> Box:
     return Box(low=0, high=1, shape=(n,) + space.shape, dtype=space.dtype)
 
 
 @batch_space.register(spaces.Tuple)
-def batch_space_tuple(space: spaces.Tuple, n: int = 1) -> spaces.Tuple:
+def _batch_tuple_space(space: spaces.Tuple, n: int = 1) -> spaces.Tuple:
     return Tuple(tuple(batch_space(subspace, n=n) for subspace in space.spaces))
 
 
 @batch_space.register(spaces.Dict)
-def batch_space_dict(space: spaces.Dict, n: int = 1) -> spaces.Dict:
+def _batch_dict_space(space: spaces.Dict, n: int = 1) -> spaces.Dict:
     return Dict(OrderedDict([(key, batch_space(subspace, n=n))
         for (key, subspace) in space.spaces.items()]))
 
 
 @batch_space.register(Space)
-def batch_space_custom(space: Space, n: int = 1) -> Space:
+def _batch_custom_space(space: Space, n: int = 1) -> Space:
     return spaces.Tuple(tuple(space for _ in range(n)))

--- a/gym/vector/utils/spaces.py
+++ b/gym/vector/utils/spaces.py
@@ -1,13 +1,17 @@
 import numpy as np
 from collections import OrderedDict
+from functools import singledispatch
 
+from gym import spaces
 from gym.spaces import Space, Box, Discrete, MultiDiscrete, MultiBinary, Tuple, Dict
 
 _BaseGymSpaces = (Box, Discrete, MultiDiscrete, MultiBinary)
 __all__ = ["_BaseGymSpaces", "batch_space"]
 
 
-def batch_space(space, n=1):
+
+@singledispatch
+def batch_space(space: Space, n: int = 1) -> Space:
     """Create a (batched) space, containing multiple copies of a single space.
 
     Parameters
@@ -34,56 +38,45 @@ def batch_space(space, n=1):
     >>> batch_space(space, n=5)
     Dict(position:Box(5, 3), velocity:Box(5, 2))
     """
-    if isinstance(space, _BaseGymSpaces):
-        return batch_space_base(space, n=n)
-    elif isinstance(space, Tuple):
-        return batch_space_tuple(space, n=n)
-    elif isinstance(space, Dict):
-        return batch_space_dict(space, n=n)
-    elif isinstance(space, Space):
-        return batch_space_custom(space, n=n)
-    else:
-        raise ValueError(
-            "Cannot batch space with type `{0}`. The space must "
-            "be a valid `gym.Space` instance.".format(type(space))
-        )
+    raise ValueError('Cannot batch space with type `{0}`. The space must '
+                     'be a valid `gym.Space` instance.'.format(type(space)))
 
 
-def batch_space_base(space, n=1):
-    if isinstance(space, Box):
-        repeats = tuple([n] + [1] * space.low.ndim)
-        low, high = np.tile(space.low, repeats), np.tile(space.high, repeats)
-        return Box(low=low, high=high, dtype=space.dtype)
-
-    elif isinstance(space, Discrete):
-        return MultiDiscrete(np.full((n,), space.n, dtype=space.dtype))
-
-    elif isinstance(space, MultiDiscrete):
-        repeats = tuple([n] + [1] * space.nvec.ndim)
-        high = np.tile(space.nvec, repeats) - 1
-        return Box(low=np.zeros_like(high), high=high, dtype=space.dtype)
-
-    elif isinstance(space, MultiBinary):
-        return Box(low=0, high=1, shape=(n,) + space.shape, dtype=space.dtype)
-
-    else:
-        raise ValueError("Space type `{0}` is not supported.".format(type(space)))
+@batch_space.register(Box)
+def batch_space_Box(space: Box, n: int = 1) -> Box:
+    repeats = tuple([n] + [1] * space.low.ndim)
+    low, high = np.tile(space.low, repeats), np.tile(space.high, repeats)
+    return Box(low=low, high=high, dtype=space.dtype)
 
 
-def batch_space_tuple(space, n=1):
+@batch_space.register(Discrete)
+def batch_space_Discrete(space: Discrete, n: int = 1) -> MultiDiscrete:
+    return MultiDiscrete(np.full((n,), space.n, dtype=space.dtype))
+
+
+@batch_space.register(MultiDiscrete)
+def batch_space_multi_discrete(space: MultiDiscrete, n: int = 1) -> Box:
+    repeats = tuple([n] + [1] * space.nvec.ndim)
+    high = np.tile(space.nvec, repeats) - 1
+    return Box(low=np.zeros_like(high), high=high, dtype=space.dtype)
+
+
+@batch_space.register(MultiBinary)
+def batch_space_multi_binary(space: MultiBinary, n: int = 1) -> Box:
+    return Box(low=0, high=1, shape=(n,) + space.shape, dtype=space.dtype)
+
+
+@batch_space.register(spaces.Tuple)
+def batch_space_tuple(space: spaces.Tuple, n: int = 1) -> spaces.Tuple:
     return Tuple(tuple(batch_space(subspace, n=n) for subspace in space.spaces))
 
 
-def batch_space_dict(space, n=1):
-    return Dict(
-        OrderedDict(
-            [
-                (key, batch_space(subspace, n=n))
-                for (key, subspace) in space.spaces.items()
-            ]
-        )
-    )
+@batch_space.register(spaces.Dict)
+def batch_space_dict(space: spaces.Dict, n: int = 1) -> spaces.Dict:
+    return Dict(OrderedDict([(key, batch_space(subspace, n=n))
+        for (key, subspace) in space.spaces.items()]))
 
 
-def batch_space_custom(space, n=1):
-    return Tuple(tuple(space for _ in range(n)))
+@batch_space.register(Space)
+def batch_space_custom(space: Space, n: int = 1) -> Space:
+    return spaces.Tuple(tuple(space for _ in range(n)))

--- a/tests/vector/test_numpy_utils.py
+++ b/tests/vector/test_numpy_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from collections import OrderedDict
 
-from gym.spaces import Tuple, Dict
+from gym.spaces import Tuple, Dict, Space
 from gym.vector.utils.spaces import _BaseGymSpaces
 from tests.vector.utils import spaces
 
@@ -13,7 +13,9 @@ from gym.vector.utils.numpy_utils import concatenate, create_empty_array
 @pytest.mark.parametrize(
     "space", spaces, ids=[space.__class__.__name__ for space in spaces]
 )
-def test_concatenate(space):
+@pytest.mark.parametrize("space_arg_first", [True, False])
+@pytest.mark.parametrize("use_all_kwargs", [True, False])
+def test_concatenate(space: Space, space_arg_first: bool, use_all_kwargs: bool):
     def assert_type(lhs, rhs, n):
         # Special case: if rhs is a list of scalars, lhs must be an np.ndarray
         if np.isscalar(rhs[0]):
@@ -46,7 +48,15 @@ def test_concatenate(space):
 
     samples = [space.sample() for _ in range(8)]
     array = create_empty_array(space, n=8)
-    concatenated = concatenate(samples, array, space)
+    if space_arg_first:
+        if use_all_kwargs:
+            concatenated = concatenate(items=samples, out=array, space=space)
+        else:
+            concatenated = concatenate(samples, array, space)
+    elif use_all_kwargs:
+        concatenated = concatenate(space=space, items=samples, out=array)
+    else:
+        concatenated = concatenate(space, samples, array)
 
     assert np.all(concatenated == array)
     assert_nested_equal(array, samples, n=8)
@@ -56,7 +66,8 @@ def test_concatenate(space):
 @pytest.mark.parametrize(
     "space", spaces, ids=[space.__class__.__name__ for space in spaces]
 )
-def test_create_empty_array(space, n):
+@pytest.mark.parametrize("use_all_kwargs", [True, False])
+def test_create_empty_array(space: Space, n: int, use_all_kwargs: bool):
     def assert_nested_type(arr, space, n):
         if isinstance(space, _BaseGymSpaces):
             assert isinstance(arr, np.ndarray)
@@ -78,7 +89,10 @@ def test_create_empty_array(space, n):
         else:
             raise TypeError("Got unknown type `{0}`.".format(type(arr)))
 
-    array = create_empty_array(space, n=n, fn=np.empty)
+    if use_all_kwargs:
+        array = create_empty_array(space=space, n=n, fn=np.empty)
+    else:
+        array = create_empty_array(space, n=n, fn=np.empty)
     assert_nested_type(array, space, n=n)
 
 
@@ -86,7 +100,8 @@ def test_create_empty_array(space, n):
 @pytest.mark.parametrize(
     "space", spaces, ids=[space.__class__.__name__ for space in spaces]
 )
-def test_create_empty_array_zeros(space, n):
+@pytest.mark.parametrize("use_all_kwargs", [True, False])
+def test_create_empty_array_zeros(space: Space, n: int, use_all_kwargs: bool):
     def assert_nested_type(arr, space, n):
         if isinstance(space, _BaseGymSpaces):
             assert isinstance(arr, np.ndarray)
@@ -109,14 +124,18 @@ def test_create_empty_array_zeros(space, n):
         else:
             raise TypeError("Got unknown type `{0}`.".format(type(arr)))
 
-    array = create_empty_array(space, n=n, fn=np.zeros)
+    if use_all_kwargs:
+        array = create_empty_array(space=space, n=n, fn=np.zeros)
+    else:
+        array = create_empty_array(space, n=n, fn=np.zeros)
     assert_nested_type(array, space, n=n)
 
 
 @pytest.mark.parametrize(
     "space", spaces, ids=[space.__class__.__name__ for space in spaces]
 )
-def test_create_empty_array_none_shape_ones(space):
+@pytest.mark.parametrize("use_all_kwargs", [True, False])
+def test_create_empty_array_none_shape_ones(space: Space, use_all_kwargs: bool):
     def assert_nested_type(arr, space):
         if isinstance(space, _BaseGymSpaces):
             assert isinstance(arr, np.ndarray)
@@ -139,5 +158,8 @@ def test_create_empty_array_none_shape_ones(space):
         else:
             raise TypeError("Got unknown type `{0}`.".format(type(arr)))
 
-    array = create_empty_array(space, n=None, fn=np.ones)
+    if use_all_kwargs:
+        array = create_empty_array(space=space, n=None, fn=np.ones)
+    else:
+        array = create_empty_array(space, n=None, fn=np.ones)
     assert_nested_type(array, space)

--- a/tests/vector/test_shared_memory.py
+++ b/tests/vector/test_shared_memory.py
@@ -95,9 +95,8 @@ def test_create_shared_memory(space, expected_type, n, ctx, n_pos_args: int):
     "ctx", [None, "fork", "spawn"], ids=["default", "fork", "spawn"]
 )
 @pytest.mark.parametrize("space", custom_spaces)
-@pytest.mark.parametrize("use_all_kwargs", [True, False])
 def test_create_shared_memory_custom_space(
-    n: int, ctx: Optional[str], space: Space, use_all_kwargs: bool
+    n: int, ctx: Optional[str], space: Space
 ):
     ctx = mp if (ctx is None) else mp.get_context(ctx)
     with pytest.raises(CustomSpaceError):

--- a/tests/vector/test_spaces.py
+++ b/tests/vector/test_spaces.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from gym.spaces import Box, MultiDiscrete, Tuple, Dict
+from gym.spaces import Box, MultiDiscrete, Tuple, Dict, Space
 from tests.vector.utils import spaces, custom_spaces, CustomSpace
 
 from gym.vector.utils.spaces import batch_space
@@ -90,8 +90,12 @@ expected_custom_batch_spaces_4 = [
     list(zip(spaces, expected_batch_spaces_4)),
     ids=[space.__class__.__name__ for space in spaces],
 )
-def test_batch_space(space, expected_batch_space_4):
-    batch_space_4 = batch_space(space, n=4)
+@pytest.mark.parametrize("use_all_kwargs", [True, False])
+def test_batch_space(space: Space, expected_batch_space_4: Space, use_all_kwargs: bool):
+    if use_all_kwargs:
+        batch_space_4 = batch_space(space=space, n=4)
+    else:
+        batch_space_4 = batch_space(space, n=4)
     assert batch_space_4 == expected_batch_space_4
 
 
@@ -100,6 +104,10 @@ def test_batch_space(space, expected_batch_space_4):
     list(zip(custom_spaces, expected_custom_batch_spaces_4)),
     ids=[space.__class__.__name__ for space in custom_spaces],
 )
-def test_batch_space_custom_space(space, expected_batch_space_4):
-    batch_space_4 = batch_space(space, n=4)
+@pytest.mark.parametrize("use_all_kwargs", [True, False])
+def test_batch_space_custom_space(space: Space, expected_batch_space_4: Space, use_all_kwargs: bool):
+    if use_all_kwargs:
+        batch_space_4 = batch_space(space=space, n=4)
+    else:
+        batch_space_4 = batch_space(space, n=4)
     assert batch_space_4 == expected_batch_space_4


### PR DESCRIPTION
Adds better support for "custom" Space subclasses, by making it possible to "extend" the various gym functions that take a `Space` as an argument by registering new handlers that type.

This is achieved by converting the given functions into [singledispatch functions](https://docs.python.org/3/library/functools.html#functools.singledispatch):
- gym.spaces.utils.flatten
- gym.spaces.utils.flatdim
- gym.spaces.utils.unflatten
- gym.spaces.utils.flatten_space
- gym.vector.utils.numpy_utils.concatenate
- gym.vector.utils.numpy_utils.create_empty_array
- gym.vector.utils..shared_memory.create_shared_memory
- gym.vector.utils..shared_memory.read_from_shared_memory
- gym.vector.utils..shared_memory.write_to_shared_memory

The ordering of the positional arguments for the following functions was changed, since the type of the first argument (in this case `space`) is the one used by singledispatch to choose the appropriate callable to use. There is however code in each of these to re-order the arguments in case they weren't passed in the right order, making this change fully backward-compatible. 

- gym.vector.utils.numpy_utils.concatenate
- gym.vector.utils..shared_memory.read_from_shared_memory
- gym.vector.utils..shared_memory.write_to_shared_memory

Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>