### PR TITLE
pull request about issue #2062 (car_racing.py memory leaking issue )

### DIFF
--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -590,6 +590,7 @@ class CarRacing(gym.Env, EzPickle):
             len(polygons) // 3, ("v3f", polygons), ("c4f", colors)  # gl.GL_QUADS,
         )
         vl.draw(gl.GL_QUADS)
+        vl.delete()
         self.score_label.text = "%04i" % self.reward
         self.score_label.draw()
 

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -528,6 +528,7 @@ class CarRacing(gym.Env, EzPickle):
             len(polygons_) // 3, ("v3f", polygons_), ("c4f", colors)  # gl.GL_QUADS,
         )
         vl.draw(gl.GL_QUADS)
+        vl.delete()
 
     def render_indicators(self, W, H):
         s = W / 40.0


### PR DESCRIPTION
Pull request about issue #2062 

There is memory leaking issue caused by pyglet module and solved with simply delete after drawing vertexs 

I confirmed with e-mail from @praveenVnktsh