### PR TITLE
Bump pyglet version to support OpenGL in BigSur

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='gym',
                 if package.startswith('gym')],
       zip_safe=False,
       install_requires=[
-          'scipy', 'numpy>=1.10.4', 'pyglet>=1.4.0,<=1.5.0', 'Pillow<=7.2.0', 'cloudpickle>=1.2.0,<1.7.0',
+          'scipy', 'numpy>=1.10.4', 'pyglet>=1.4.0,<=1.5.11', 'Pillow<=7.2.0', 'cloudpickle>=1.2.0,<1.7.0',
       ],
       extras_require=extras,
       package_data={'gym': [


### PR DESCRIPTION
Apple went and did some stuff in BigSur to the way OpenGL is present in the filesystem which BigBroke pyglet which broke some gyms. (Specifically, `classic_control/rendering.py` was falling over when doing `from pyglet.gl import *`. See https://github.com/pyglet/pyglet/issues/274#issuecomment-691702291 and https://github.com/pyglet/pyglet/issues/274#issuecomment-691702291 for details. But the tl;dr is version bumping makes it happy.