### PR TITLE
fix reward in mountain_car

### DIFF
--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -101,7 +101,10 @@ class MountainCarEnv(gym.Env):
         done = bool(
             position >= self.goal_position and velocity >= self.goal_velocity
         )
+
         reward = -1.0
+        if done:
+            reward = 0
 
         self.state = (position, velocity)
         return np.array(self.state), reward, done, {}


### PR DESCRIPTION
I change reward in mountain car.
I think if code comments is correct, when the car reached top position, the agent should be got reward 0.

The code comments is as below
>         Reward of 0 is awarded if the agent reached the flag (position = 0.5)
>         on top of the mountain.
>         Reward of -1 is awarded if the position of the agent is less than 0.5.

I'm sorry if I'm wrong.

Thank you