### PR TITLE
Minor fix to ImageEncoder capture_frame

### DIFF
--- a/gym/wrappers/monitoring/video_recorder.py
+++ b/gym/wrappers/monitoring/video_recorder.py
@@ -300,7 +300,7 @@ class ImageEncoder(object):
         if frame.dtype != np.uint8:
             raise error.InvalidFrame("Your frame has data type {}, but we require uint8 (i.e. RGB values from 0-255).".format(frame.dtype))
 
-            self.proc.stdin.write(frame.tobytes())
+        self.proc.stdin.write(frame.tobytes())
 
     def close(self):
         self.proc.stdin.close()


### PR DESCRIPTION
ImageEncoder was not writing frames in the capture_frame function.
Unindented the call to write a frame in line 303 of video_recorder.py so that it is reachable.