### PR TITLE
BUG FIX: Bipedal Walker; Car Racing; Guessing Game; Hotter Colder - Showing Warning

### DIFF
--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -138,9 +138,9 @@ class BipedalWalker(gym.Env, EzPickle):
 
         self.reset()
 
-        high = np.array([np.inf] * 24)
-        self.action_space = spaces.Box(np.array([-1, -1, -1, -1]), np.array([1, 1, 1, 1]), dtype=np.float32)
-        self.observation_space = spaces.Box(-high, high, dtype=np.float32)
+        high = np.array([np.inf] * 24).astype(np.float32)
+        self.action_space = spaces.Box(np.array([-1, -1, -1, -1]).astype(np.float32), np.array([1, 1, 1, 1]).astype(np.float32))
+        self.observation_space = spaces.Box(-high, high)
 
     def seed(self, seed=None):
         self.np_random, seed = seeding.np_random(seed)

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -137,7 +137,7 @@ class CarRacing(gym.Env, EzPickle):
         )
 
         self.action_space = spaces.Box(
-            np.array([-1, 0, 0]), np.array([+1, +1, +1]), dtype=np.float32
+            np.array([-1, 0, 0]).astype(np.float32), np.array([+1, +1, +1]).astype(np.float32)
         )  # steer, gas, brake
 
         self.observation_space = spaces.Box(

--- a/gym/envs/toy_text/guessing_game.py
+++ b/gym/envs/toy_text/guessing_game.py
@@ -42,7 +42,7 @@ class GuessingGame(gym.Env):
         self.bounds = 10000
 
         self.action_space = spaces.Box(low=np.array([-self.bounds]).astype(np.float32)  ,
-                                       high=np.array([self.bounds])).astype(np.float32) )
+                                       high=np.array([self.bounds]).astype(np.float32)  )
         self.observation_space = spaces.Discrete(4)
 
         self.number = 0

--- a/gym/envs/toy_text/guessing_game.py
+++ b/gym/envs/toy_text/guessing_game.py
@@ -41,8 +41,7 @@ class GuessingGame(gym.Env):
         self.range = 1000  # Randomly selected number is within +/- this value
         self.bounds = 10000
 
-        self.action_space = spaces.Box(low=np.array([-self.bounds]), high=np.array([self.bounds]),
-                                       dtype=np.float32)
+        self.action_space = spaces.Box(low=np.array([-self.bounds]).astype(np.float32), high=np.array([self.bounds])).astype(np.float32)
         self.observation_space = spaces.Discrete(4)
 
         self.number = 0

--- a/gym/envs/toy_text/guessing_game.py
+++ b/gym/envs/toy_text/guessing_game.py
@@ -41,7 +41,8 @@ class GuessingGame(gym.Env):
         self.range = 1000  # Randomly selected number is within +/- this value
         self.bounds = 10000
 
-        self.action_space = spaces.Box(low=np.array([-self.bounds]).astype(np.float32), high=np.array([self.bounds])).astype(np.float32)
+        self.action_space = spaces.Box(low=np.array([-self.bounds]).astype(np.float32)  ,
+                                       high=np.array([self.bounds])).astype(np.float32) )
         self.observation_space = spaces.Discrete(4)
 
         self.number = 0

--- a/gym/envs/toy_text/hotter_colder.py
+++ b/gym/envs/toy_text/hotter_colder.py
@@ -26,8 +26,7 @@ class HotterColder(gym.Env):
         self.range = 1000  # +/- the value number can be between
         self.bounds = 2000  # Action space bounds
 
-        self.action_space = spaces.Box(low=np.array([-self.bounds]), high=np.array([self.bounds]),
-                                       dtype=np.float32)
+        self.action_space = spaces.Box(low=np.array([-self.bounds]).astype(np.float32), high=np.array([self.bounds]).astype(np.float32))
         self.observation_space = spaces.Discrete(4)
 
         self.number = 0


### PR DESCRIPTION
Fixing an issue at some gym environments causing a Warning message to pop because of conversion from python standard `float64` to `np.float32`.

The environments fixed were: Bipedal Walker, Car Racing, Guessing Game and Hotter Colder.

Error message bellow shows up when running `gym.make()` with the environments mentioned  (ex: `gym.make("BipedalWalker-v3")`).

The implemented solution was suggested [here (StackOverflow)](https://stackoverflow.com/a/60832860/11048201).    
     
```
Warning (from warnings module):
  File "C:\Python38\lib\site-packages\gym\logger.py", line 30
    warnings.warn(colorize('%s: %s'%('WARN', msg % args), 'yellow'))
UserWarning: �[33mWARN: Box bound precision lowered by casting to float32�[0m
```