### PR TITLE
Remove constraints on package versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='gym',
                 if package.startswith('gym')],
       zip_safe=False,
       install_requires=[
-          'scipy', 'numpy>=1.10.4', 'pyglet>=1.4.0,<=1.5.0', 'Pillow<=7.2.0', 'cloudpickle>=1.2.0,<1.7.0',
+          'scipy', 'numpy>=1.10.4', 'pyglet>=1.4.0', 'Pillow', 'cloudpickle>=1.2.0,<1.7.0',
       ],
       extras_require=extras,
       package_data={'gym': [


### PR DESCRIPTION
**Issue:**
Current constraints on versions of pillow preventing Gym 0.18 from being installed in Windows Python 3.9.
Reason: In `setup.py`, Pillow's version <=7.2.0, but Pillow did not release Python 3.9 Windows binary for that version. Pillow released Python 3.9 Windows binary for the latest few versions.

**Why it happens:**
PR #2084 limited the version of Pillow to be <=7.2.0 in order to be compatible with the old version of pyglet. If it did not do so, codes would not be compiled. 

For example, a method in Pillow called `tostring()` has been deprecated in favor of the method `tobytes()`, but old pyglet did not change to adjust it. Now pyglet has updated it. (Cf. https://github.com/pyglet/pyglet/blob/master/pyglet/image/codecs/pil.py#L77)

**Solution:**
Remove the constraints on package versions.