### PR TITLE
Fix video recording.

### DIFF
--- a/gym/wrappers/monitoring/video_recorder.py
+++ b/gym/wrappers/monitoring/video_recorder.py
@@ -300,7 +300,7 @@ class ImageEncoder(object):
         if frame.dtype != np.uint8:
             raise error.InvalidFrame("Your frame has data type {}, but we require uint8 (i.e. RGB values from 0-255).".format(frame.dtype))
 
-            self.proc.stdin.write(frame.tobytes())
+        self.proc.stdin.write(frame.tobytes())
 
     def close(self):
         self.proc.stdin.close()


### PR DESCRIPTION
Tested with `python examples/agents/random_agent.py`. The code before the change would create empty video files.