### PR TITLE
Fix reward calculation for MountainCar-v0

### DIFF
--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -101,7 +101,7 @@ class MountainCarEnv(gym.Env):
         done = bool(
             position >= self.goal_position and velocity >= self.goal_velocity
         )
-        reward = -1.0
+        reward = 0 if position >= self.goal_position else -1.0
 
         self.state = (position, velocity)
         return np.array(self.state), reward, done, {}


### PR DESCRIPTION
Previously, the reward was fixed at -1, although described as being 0 if the position was >= 0.5.