### PR TITLE
Fix indent level in video recorder

### DIFF
--- a/gym/wrappers/monitoring/video_recorder.py
+++ b/gym/wrappers/monitoring/video_recorder.py
@@ -300,7 +300,7 @@ class ImageEncoder(object):
         if frame.dtype != np.uint8:
             raise error.InvalidFrame("Your frame has data type {}, but we require uint8 (i.e. RGB values from 0-255).".format(frame.dtype))
 
-            self.proc.stdin.write(frame.tobytes())
+        self.proc.stdin.write(frame.tobytes())
 
     def close(self):
         self.proc.stdin.close()


### PR DESCRIPTION
Since it is declared after an exception is raised, the following statement on line 303 is never executed:

    self.proc.stdin.write(frame.tobytes())

The solution is to once unindent the statement. Refer to https://github.com/openai/gym/issues/1925#issuecomment-753465510