### PR TITLE
Fix broken link in docstring

### DIFF
--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -1,5 +1,5 @@
 """
-http://incompleteideas.net/sutton/MountainCar/MountainCar1.cp
+http://incompleteideas.net/MountainCar/MountainCar1.cp
 permalink: https://perma.cc/6Z2N-PFWC
 """
 import math


### PR DESCRIPTION
The link to the original implementation of mountain car on incompleteideas.net was broken. Replaced with the correct link.