### PR TITLE
fix fetch EzPickle

### DIFF
--- a/gym/envs/robotics/fetch/pick_and_place.py
+++ b/gym/envs/robotics/fetch/pick_and_place.py
@@ -20,4 +20,4 @@ class FetchPickAndPlaceEnv(fetch_env.FetchEnv, utils.EzPickle):
             gripper_extra_height=0.2, target_in_the_air=True, target_offset=0.0,
             obj_range=0.15, target_range=0.15, distance_threshold=0.05,
             initial_qpos=initial_qpos, reward_type=reward_type)
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, reward_type=reward_type)

--- a/gym/envs/robotics/fetch/push.py
+++ b/gym/envs/robotics/fetch/push.py
@@ -20,4 +20,4 @@ class FetchPushEnv(fetch_env.FetchEnv, utils.EzPickle):
             gripper_extra_height=0.0, target_in_the_air=False, target_offset=0.0,
             obj_range=0.15, target_range=0.15, distance_threshold=0.05,
             initial_qpos=initial_qpos, reward_type=reward_type)
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, reward_type=reward_type)

--- a/gym/envs/robotics/fetch/reach.py
+++ b/gym/envs/robotics/fetch/reach.py
@@ -19,4 +19,4 @@ class FetchReachEnv(fetch_env.FetchEnv, utils.EzPickle):
             gripper_extra_height=0.2, target_in_the_air=True, target_offset=0.0,
             obj_range=0.15, target_range=0.15, distance_threshold=0.05,
             initial_qpos=initial_qpos, reward_type=reward_type)
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, reward_type=reward_type)

--- a/gym/envs/robotics/fetch/slide.py
+++ b/gym/envs/robotics/fetch/slide.py
@@ -22,4 +22,4 @@ class FetchSlideEnv(fetch_env.FetchEnv, utils.EzPickle):
             gripper_extra_height=-0.02, target_in_the_air=False, target_offset=np.array([0.4, 0.0, 0.0]),
             obj_range=0.1, target_range=0.3, distance_threshold=0.05,
             initial_qpos=initial_qpos, reward_type=reward_type)
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, reward_type=reward_type)


### PR DESCRIPTION
Some fetch environments have unintended behavior after pickling-and-reloading. An example script to verify the issue: 
```
import gym
import pickle

if __name__ == '__main__':
    env_1 = gym.make('FetchReachDense-v1')
    env_2 = pickle.loads(pickle.dumps(env_1))
    assert env_1.reward_type == env_2.reward_type,  (env_1.reward_type, env_2.reward_type)
```

The script raises ```AssertionError: ('dense', 'sparse')```
since `env_2` uses the default argument `reward_type = "sparse"` instead of `reward_type = "dense"` as in `env_1`. 


Similar to #1496, the issue is fixed by passing `reward_type` as an argument to `EzPickle.__init__`. 