### PR TITLE
Made Box __repr__ output clearer (#2182)

### DIFF
--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -151,9 +151,7 @@ class Box(Space):
         return [np.asarray(sample) for sample in sample_n]
 
     def __repr__(self):
-        return "Box({}, {}, {}, {})".format(
-            self.low.min(), self.high.max(), self.shape, self.dtype
-        )
+        return f"Box({self.low}, {self.high}, {self.shape}, {self.dtype})"
 
     def __eq__(self, other):
         return (


### PR DESCRIPTION
Fix for #2182. This should avoid confusion about what limits are actually defined for continuous spaces.