### PR TITLE
Do not depend on a specific Pillow version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='gym',
                 if package.startswith('gym')],
       zip_safe=False,
       install_requires=[
-          'scipy', 'numpy>=1.10.4', 'pyglet>=1.4.0,<=1.5.0', 'Pillow<=7.2.0', 'cloudpickle>=1.2.0,<1.7.0',
+          'scipy', 'numpy>=1.10.4', 'pyglet>=1.4.0,<=1.5.0', 'Pillow', 'cloudpickle>=1.2.0,<1.7.0',
       ],
       extras_require=extras,
       package_data={'gym': [


### PR DESCRIPTION
Several people have been unable to install Gym because it depends on Pillow 7.2 which does not support Python 3.9.

Python 3.9 is the standard on Ubuntu and Mac now.

The rationale behind removing the version number is that according to `setup.py` versions before 7.2 worked fine and according to Travis CI, current versions also work fine.