### PR TITLE
Remove warning of float32 in CarRacing-v0 action space

### DIFF
--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -137,7 +137,7 @@ class CarRacing(gym.Env, EzPickle):
         )
 
         self.action_space = spaces.Box(
-            np.array([-1, 0, 0]), np.array([+1, +1, +1]), dtype=np.float32
+            np.array([-1, 0, 0]), np.array([+1, +1, +1]), dtype=np.uint32
         )  # steer, gas, brake
 
         self.observation_space = spaces.Box(

--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -46,8 +46,8 @@ class Box(Space):
             high = np.full(shape, high, dtype=dtype)
 
         self.shape = shape
-        self.low = low
-        self.high = high
+        self.low = np.float32(low)
+        self.high = np.float32(high)
 
         def _get_precision(dtype):
             if np.issubdtype(dtype, np.floating):


### PR DESCRIPTION
Removes warning of float32 of CarRacing-v0 action space. 
Issue:https://github.com/openai/gym/issues/2216
#2216 