### PR TITLE
use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/py.Dockerfile
+++ b/py.Dockerfile
@@ -7,7 +7,7 @@ RUN \
     mkdir /root/.mujoco && \
     cd /root/.mujoco  && \
     curl -O https://www.roboti.us/download/mjpro150_linux.zip  && \
-    unzip mjpro150_linux.zip
+    unzip mjpro150_linux.zip && mjpro150_linux.zip
 
 ARG PYTHON_VER
 ARG MUJOCO_KEY
@@ -15,14 +15,14 @@ ENV MUJOCO_KEY=$MUJOCO_KEY
 
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mjpro150/bin
 RUN echo $MUJOCO_KEY | base64 --decode > /root/.mujoco/mjkey.txt
-RUN pip install pytest pytest-forked lz4
+RUN pip install --no-cache-dir pytest pytest-forked lz4
 
 COPY . /usr/local/gym/
 WORKDIR /usr/local/gym/
 # install all extras for python 3.6 and 3.7, and skip mujoco add-ons for 3.8 and 3.9
 # as mujoco 1.50 does not seem to work with 3.8 and 3.9
-# RUN bash -c "[[ $PYTHON_VER =~ 3\.[6-7]\.[0-9] ]] && pip install -e .[all] || pip install -e .[nomujoco]"
-RUN pip install -e .[nomujoco]
+# RUN bash -c "[[ $PYTHON_VER =~ 3\.[6-7]\.[0-9] ]] && pip install --no-cache-dir -e .[all] || pip install --no-cache-dir -e .[nomujoco]"
+RUN pip install --no-cache-dir -e .[nomujoco]
 
 ENTRYPOINT ["/usr/local/gym/bin/docker_entrypoint"]
 CMD ["pytest","--forked"]


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik raj <rajpratik71@gmail.com>