### PR TITLE
Lint Python: Black is not mandatory but most pytests are

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -8,14 +8,20 @@ jobs:
       - uses: actions/setup-python@v2
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety
       - run: bandit --recursive --skip B101,B108,B301,B403,B404,B603 .
-      - run: black --check .
+      - run: black --check . || true
       - run: codespell --ignore-words-list=nd,reacher,thist,ths -w
       - run: flake8 --ignore=E203,E402,E712,E722,E731,E741,F401,F403,F405,F524,F841,W503
                     --max-complexity=30 --max-line-length=456 --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -e .[nomujoco]
       - run: mypy --install-types --non-interactive . || true
-      - run: pytest . || true
-      - run: pytest --doctest-modules . || true
+      # All tests except these three are mandatory
+      - run: pytest . --ignore=gym/envs/tests/test_determinism.py
+                      --ignore=gym/envs/tests/test_envs.py
+                      --ignore=gym/wrappers/monitoring/tests/test_video_recorder.py
+      # TODO: fix the following failing tests and make them mandatory
+      - run: pytest gym/envs/tests/test_determinism.py
+                    gym/envs/tests/test_envs.py
+                    gym/wrappers/monitoring/tests/test_video_recorder.py || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           run: pytest gym/envs/tests/test_determinism.py
                       gym/envs/tests/test_envs.py
-                      gym/wrappers/monitoring/tests/test_video_recorder.py || true
+                      gym/wrappers/monitoring/tests/test_video_recorder.py
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -22,6 +22,6 @@ jobs:
       # TODO: fix the following failing tests and make them mandatory
       - run: pytest gym/envs/tests/test_determinism.py
                     gym/envs/tests/test_envs.py
-                    gym/wrappers/monitoring/tests/test_video_recorder.py
+                    gym/wrappers/monitoring/tests/test_video_recorder.py || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -20,8 +20,10 @@ jobs:
                       --ignore=gym/envs/tests/test_envs.py
                       --ignore=gym/wrappers/monitoring/tests/test_video_recorder.py
       # TODO: fix the following failing tests and make them mandatory
-      - run: pytest gym/envs/tests/test_determinism.py
-                    gym/envs/tests/test_envs.py
-                    gym/wrappers/monitoring/tests/test_video_recorder.py || true
+      - uses: GabrielBB/xvfb-action@v1
+        with:
+          run: pytest gym/envs/tests/test_determinism.py
+                      gym/envs/tests/test_envs.py
+                      gym/wrappers/monitoring/tests/test_video_recorder.py || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -14,16 +14,14 @@ jobs:
                     --max-complexity=30 --max-line-length=456 --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -e .[nomujoco]
-      - run: mypy --install-types --non-interactive . || true
+      - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
       # All tests except these three are mandatory
       - run: pytest . --ignore=gym/envs/tests/test_determinism.py
                       --ignore=gym/envs/tests/test_envs.py
                       --ignore=gym/wrappers/monitoring/tests/test_video_recorder.py
       # TODO: fix the following failing tests and make them mandatory
-      - uses: GabrielBB/xvfb-action@v1
-        with:
-          run: pytest gym/envs/tests/test_determinism.py
-                      gym/envs/tests/test_envs.py
-                      gym/wrappers/monitoring/tests/test_video_recorder.py
+      - run: pytest gym/envs/tests/test_determinism.py
+                    gym/envs/tests/test_envs.py
+                    gym/wrappers/monitoring/tests/test_video_recorder.py
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
       - run: safety check


### PR DESCRIPTION
It is a chore for all contributors to blacken all their changes so let’s make it optional on each PR and then run black occasionally.  Like #2265

We currently have three failing pytest files.  Let’s make all other pytests mandatory.  Let’s continue to run the failing tests in _allow failures_ (`|| true`) mode so we can monitor attempts to fix them.

```
$ pytest gym/envs/tests/test_determinism.py gym/envs/tests/test_envs.py \
         gym/wrappers/monitoring/tests/test_video_recorder.py || true

============================= test session starts ==============================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /home/runner/work/gym/gym
collected 119 items

gym/envs/tests/test_determinism.py ....F................................ [ 31%]
...................                                                      [ 47%]
gym/envs/tests/test_envs.py FFF.FFF..FFF.......FFFFF.FFFFFFFFFFFFF.....F [ 84%]
FFFFFFFFFFF...                                                           [ 95%]
gym/wrappers/monitoring/tests/test_video_recorder.py F....               [100%]
```
@mzjp2 Do you have any insight into why these tests are failing for me?