### PR TITLE
Batch action_space in VectorEnv

### DIFF
--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -19,6 +19,7 @@ from gym.vector.utils import (
     write_to_shared_memory,
     read_from_shared_memory,
     concatenate,
+    iterate,
     CloudpickleWrapper,
     clear_mpi_env_vars,
 )
@@ -307,6 +308,7 @@ class AsyncVectorEnv(VectorEnv):
                 self._state.value,
             )
 
+        actions = iterate(actions, self.action_space)
         for pipe, action in zip(self.parent_pipes, actions):
             pipe.send(("step", action))
         self._state = AsyncState.WAITING_STEP

--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -308,7 +308,7 @@ class AsyncVectorEnv(VectorEnv):
                 self._state.value,
             )
 
-        actions = iterate(actions, self.action_space)
+        actions = iterate(self.action_space, actions)
         for pipe, action in zip(self.parent_pipes, actions):
             pipe.send(("step", action))
         self._state = AsyncState.WAITING_STEP

--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -95,7 +95,7 @@ class SyncVectorEnv(VectorEnv):
         return deepcopy(self.observations) if self.copy else self.observations
 
     def step_async(self, actions):
-        self._actions = iterate(actions, self.action_space)
+        self._actions = iterate(self.action_space, actions)
 
     def step_wait(self):
         observations, infos = [], []

--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -64,7 +64,7 @@ class SyncVectorEnv(VectorEnv):
             action_space=action_space,
         )
 
-        self._check_observation_spaces()
+        self._check_spaces()
         self.observations = create_empty_array(
             self.single_observation_space, n=self.num_envs, fn=np.zeros
         )
@@ -121,15 +121,21 @@ class SyncVectorEnv(VectorEnv):
         """Close the environments."""
         [env.close() for env in self.envs]
 
-    def _check_observation_spaces(self):
+    def _check_spaces(self):
         for env in self.envs:
             if not (env.observation_space == self.single_observation_space):
-                break
+                raise RuntimeError(
+                    "Some environments have an observation space different from "
+                    f"`{self.single_observation_space}`. In order to batch observations, "
+                    "the observation spaces from all environments must be equal."
+                )
+
+            if not (env.action_space == self.single_action_space):
+                raise RuntimeError(
+                    "Some environments have an action space different from "
+                    f"`{self.single_action_space}`. In order to batch actions, the "
+                    "action spaces from all environments must be equal."
+                )
+
         else:
             return True
-        raise RuntimeError(
-            "Some environments have an observation space "
-            "different from `{}`. In order to batch observations, the "
-            "observation spaces from all environments must be "
-            "equal.".format(self.single_observation_space)
-        )

--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 
 from gym import logger
 from gym.vector.vector_env import VectorEnv
-from gym.vector.utils import concatenate, create_empty_array
+from gym.vector.utils import concatenate, iterate, create_empty_array
 
 __all__ = ["SyncVectorEnv"]
 
@@ -95,7 +95,7 @@ class SyncVectorEnv(VectorEnv):
         return deepcopy(self.observations) if self.copy else self.observations
 
     def step_async(self, actions):
-        self._actions = actions
+        self._actions = iterate(actions, self.action_space)
 
     def step_wait(self):
         observations, infos = [], []

--- a/gym/vector/utils/__init__.py
+++ b/gym/vector/utils/__init__.py
@@ -17,5 +17,5 @@ __all__ = [
     "write_to_shared_memory",
     "_BaseGymSpaces",
     "batch_space",
-    "iterate"
+    "iterate",
 ]

--- a/gym/vector/utils/__init__.py
+++ b/gym/vector/utils/__init__.py
@@ -5,7 +5,7 @@ from gym.vector.utils.shared_memory import (
     read_from_shared_memory,
     write_to_shared_memory,
 )
-from gym.vector.utils.spaces import _BaseGymSpaces, batch_space
+from gym.vector.utils.spaces import _BaseGymSpaces, batch_space, iterate
 
 __all__ = [
     "CloudpickleWrapper",
@@ -17,4 +17,5 @@ __all__ = [
     "write_to_shared_memory",
     "_BaseGymSpaces",
     "batch_space",
+    "iterate"
 ]

--- a/gym/vector/utils/spaces.py
+++ b/gym/vector/utils/spaces.py
@@ -114,7 +114,7 @@ def iterate(space, items):
     ... 'position': Box(low=0, high=1, shape=(2, 3), dtype=np.float32),
     ... 'velocity': Box(low=0, high=1, shape=(2, 2), dtype=np.float32)})
     >>> items = space.sample()
-    >>> it = iterate(items, space)
+    >>> it = iterate(space, items)
     >>> next(it)
     {'position': array([-0.99644893, -0.08304597, -0.7238421 ], dtype=float32),
     'velocity': array([0.35848552, 0.1533453 ], dtype=float32)}

--- a/gym/vector/utils/spaces.py
+++ b/gym/vector/utils/spaces.py
@@ -96,11 +96,11 @@ def iterate(space, items):
 
     Parameters
     ----------
-    items : samples of `space`
-        Items to be iterated over.
-
     space : `gym.spaces.Space` instance
         Space to which `items` belong to.
+
+    items : samples of `space`
+        Items to be iterated over.
 
     Returns
     -------

--- a/gym/vector/utils/spaces.py
+++ b/gym/vector/utils/spaces.py
@@ -130,13 +130,15 @@ def iterate(space, items):
     )
 
 
-@iterate.register(Box)
 @iterate.register(Discrete)
+def iterate_discrete(space, items):
+    raise TypeError("Unable to iterate over a space of type `Discrete`.")
+
+
+@iterate.register(Box)
 @iterate.register(MultiDiscrete)
 @iterate.register(MultiBinary)
 def iterate_base(space, items):
-    if isinstance(space, Discrete):
-        raise TypeError("Unable to iterate over a space of type `Discrete`.")
     try:
         return iter(items)
     except TypeError:

--- a/gym/vector/utils/spaces.py
+++ b/gym/vector/utils/spaces.py
@@ -147,18 +147,25 @@ def iterate_base(items, space):
 
 
 def iterate_tuple(items, space):
-    # If this is a tuple of custome subspaces only, then simply iterate over items
-    if all(not isinstance(subspace, (_BaseGymSpaces, Tuple, Dict))
-            for subspace in space.spaces):
+    # If this is a tuple of custom subspaces only, then simply iterate over items
+    if all(
+        not isinstance(subspace, (_BaseGymSpaces, Tuple, Dict))
+        for subspace in space.spaces
+    ):
         return iter(items)
 
-    return zip(*[iterate(items[i], subspace)
-        for i, subspace in enumerate(space.spaces)])
+    return zip(
+        *[iterate(items[i], subspace) for i, subspace in enumerate(space.spaces)]
+    )
 
 
 def iterate_dict(items, space):
-    keys, values = zip(*[(key, iterate(items[key], subspace))
-        for key, subspace in space.spaces.items()])
+    keys, values = zip(
+        *[
+            (key, iterate(items[key], subspace))
+            for key, subspace in space.spaces.items()
+        ]
+    )
     for item in zip(*values):
         yield OrderedDict([(key, value) for (key, value) in zip(keys, item)])
 
@@ -166,6 +173,6 @@ def iterate_dict(items, space):
 def iterate_custom(items, space):
     raise CustomSpaceError(
         f"Unable to iterate over {items}, since {space} "
-        "is a custome `gym.Space` instance (i.e. not one of "
+        "is a custom `gym.Space` instance (i.e. not one of "
         "`Box`, `Dict`, etc...)."
     )

--- a/gym/vector/vector_env.py
+++ b/gym/vector/vector_env.py
@@ -33,7 +33,7 @@ class VectorEnv(gym.Env):
         self.num_envs = num_envs
         self.is_vector_env = True
         self.observation_space = batch_space(observation_space, n=num_envs)
-        self.action_space = Tuple((action_space,) * num_envs)
+        self.action_space = batch_space(action_space, n=num_envs)
 
         self.closed = False
         self.viewer = None

--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -193,10 +193,10 @@ def test_already_closed_async_vector_env(shared_memory):
 
 
 @pytest.mark.parametrize("shared_memory", [True, False])
-def test_check_observations_async_vector_env(shared_memory):
-    # CubeCrash-v0 - observation_space: Box(40, 32, 3)
+def test_check_spaces_async_vector_env(shared_memory):
+    # CubeCrash-v0 - observation_space: Box(40, 32, 3), action_space: Discrete(3)
     env_fns = [make_env("CubeCrash-v0", i) for i in range(8)]
-    # MemorizeDigits-v0 - observation_space: Box(24, 32, 3)
+    # MemorizeDigits-v0 - observation_space: Box(24, 32, 3), action_space: Discrete(10)
     env_fns[1] = make_env("MemorizeDigits-v0", 1)
     with pytest.raises(RuntimeError):
         env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)

--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 from multiprocessing import TimeoutError
-from gym.spaces import Box, Tuple
+from gym.spaces import Box, Tuple, Discrete, MultiDiscrete
 from gym.error import AlreadyPendingCallError, NoAsyncCallError, ClosedEnvironmentError
 from tests.vector.utils import (
     CustomSpace,
@@ -48,6 +48,10 @@ def test_step_async_vector_env(shared_memory, use_single_action_space):
     try:
         env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)
         observations = env.reset()
+
+        assert isinstance(env.single_action_space, Discrete)
+        assert isinstance(env.action_space, MultiDiscrete)
+
         if use_single_action_space:
             actions = [env.single_action_space.sample() for _ in range(8)]
         else:
@@ -204,6 +208,10 @@ def test_custom_space_async_vector_env():
     try:
         env = AsyncVectorEnv(env_fns, shared_memory=False)
         reset_observations = env.reset()
+
+        assert isinstance(env.single_action_space, CustomSpace)
+        assert isinstance(env.action_space, Tuple)
+
         actions = ("action-2", "action-3", "action-5", "action-7")
         step_observations, rewards, dones, _ = env.step(actions)
     finally:

--- a/tests/vector/test_spaces.py
+++ b/tests/vector/test_spaces.py
@@ -106,7 +106,7 @@ def test_batch_space_custom_space(space, expected_batch_space_4):
 
 
 @pytest.mark.parametrize(
-    "space,batch_space", 
+    "space,batch_space",
     list(zip(spaces, expected_batch_spaces_4)),
     ids=[space.__class__.__name__ for space in spaces],
 )

--- a/tests/vector/test_spaces.py
+++ b/tests/vector/test_spaces.py
@@ -4,7 +4,7 @@ import numpy as np
 from gym.spaces import Box, MultiDiscrete, Tuple, Dict
 from tests.vector.utils import spaces, custom_spaces, CustomSpace
 
-from gym.vector.utils.spaces import batch_space
+from gym.vector.utils.spaces import batch_space, iterate
 
 expected_batch_spaces_4 = [
     Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float64),
@@ -103,3 +103,29 @@ def test_batch_space(space, expected_batch_space_4):
 def test_batch_space_custom_space(space, expected_batch_space_4):
     batch_space_4 = batch_space(space, n=4)
     assert batch_space_4 == expected_batch_space_4
+
+
+@pytest.mark.parametrize(
+    "space,batch_space", 
+    list(zip(spaces, expected_batch_spaces_4)),
+    ids=[space.__class__.__name__ for space in spaces],
+)
+def test_iterate(space, batch_space):
+    items = batch_space.sample()
+    iterator = iterate(items, batch_space)
+    for i, item in enumerate(iterator):
+        assert item in space
+    assert i == 3
+
+
+@pytest.mark.parametrize(
+    "space,batch_space",
+    list(zip(custom_spaces, expected_custom_batch_spaces_4)),
+    ids=[space.__class__.__name__ for space in custom_spaces],
+)
+def test_iterate_custom_space(space, batch_space):
+    items = batch_space.sample()
+    iterator = iterate(items, batch_space)
+    for i, item in enumerate(iterator):
+        assert item in space
+    assert i == 3

--- a/tests/vector/test_spaces.py
+++ b/tests/vector/test_spaces.py
@@ -112,7 +112,7 @@ def test_batch_space_custom_space(space, expected_batch_space_4):
 )
 def test_iterate(space, batch_space):
     items = batch_space.sample()
-    iterator = iterate(items, batch_space)
+    iterator = iterate(batch_space, items)
     for i, item in enumerate(iterator):
         assert item in space
     assert i == 3
@@ -125,7 +125,7 @@ def test_iterate(space, batch_space):
 )
 def test_iterate_custom_space(space, batch_space):
     items = batch_space.sample()
-    iterator = iterate(items, batch_space)
+    iterator = iterate(batch_space, items)
     for i, item in enumerate(iterator):
         assert item in space
     assert i == 3

--- a/tests/vector/test_sync_vector_env.py
+++ b/tests/vector/test_sync_vector_env.py
@@ -67,10 +67,10 @@ def test_step_sync_vector_env(use_single_action_space):
     assert dones.size == 8
 
 
-def test_check_observations_sync_vector_env():
-    # CubeCrash-v0 - observation_space: Box(40, 32, 3)
+def test_check_spaces_sync_vector_env():
+    # CubeCrash-v0 - observation_space: Box(40, 32, 3), action_space: Discrete(3)
     env_fns = [make_env("CubeCrash-v0", i) for i in range(8)]
-    # MemorizeDigits-v0 - observation_space: Box(24, 32, 3)
+    # MemorizeDigits-v0 - observation_space: Box(24, 32, 3), action_space: Discrete(10)
     env_fns[1] = make_env("MemorizeDigits-v0", 1)
     with pytest.raises(RuntimeError):
         env = SyncVectorEnv(env_fns)

--- a/tests/vector/test_sync_vector_env.py
+++ b/tests/vector/test_sync_vector_env.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from gym.spaces import Box, Tuple
+from gym.spaces import Box, Tuple, Discrete, MultiDiscrete
 from tests.vector.utils import CustomSpace, make_env, make_custom_space_env
 
 from gym.vector.sync_vector_env import SyncVectorEnv
@@ -38,6 +38,10 @@ def test_step_sync_vector_env(use_single_action_space):
     try:
         env = SyncVectorEnv(env_fns)
         observations = env.reset()
+
+        assert isinstance(env.single_action_space, Discrete)
+        assert isinstance(env.action_space, MultiDiscrete)
+
         if use_single_action_space:
             actions = [env.single_action_space.sample() for _ in range(8)]
         else:
@@ -78,6 +82,10 @@ def test_custom_space_sync_vector_env():
     try:
         env = SyncVectorEnv(env_fns)
         reset_observations = env.reset()
+
+        assert isinstance(env.single_action_space, CustomSpace)
+        assert isinstance(env.action_space, Tuple)
+
         actions = ("action-2", "action-3", "action-5", "action-7")
         step_observations, rewards, dones, _ = env.step(actions)
     finally:

--- a/tests/vector/utils.py
+++ b/tests/vector/utils.py
@@ -70,6 +70,12 @@ class UnittestSlowEnv(gym.Env):
 class CustomSpace(gym.Space):
     """Minimal custom observation space."""
 
+    def sample(self):
+        return "sample"
+
+    def contains(self, x):
+        return isinstance(x, str)
+
     def __eq__(self, other):
         return isinstance(other, CustomSpace)
 


### PR DESCRIPTION
Given the discussion in #2279, here is a proposal to have a batch `action_space` instead of a `Tuple` instance.
```python
import gym
env = gym.vector.make('CartPole-v1', num_envs=5)
observations = env.reset()

print(env.action_space)
# Before: Tuple(Discrete(2), Discrete(2), Discrete(2), Discrete(2), Discrete(2))
# After: MultiDiscrete([2 2 2 2 2])

actions = np.array([1, 0, 0, 1, 1])
observations, rewards, dones, infos = env.step(actions)
print(f'Observations shape: {observations.shape}')
# Observations shape: (5, 4)
```

This handles any nested action space as well:
```python
import gym
import numpy as np

from gym.spaces import Dict, Box, Discrete
from gym.vector import AsyncVectorEnv

class CustomEnv(gym.Env):
    observation_space = Box(low=0, high=255, shape=(84, 84), dtype=np.uint8)
    action_space = Dict({
        'fire': Discrete(2),
        'jump': Discrete(2),
        'move': Box(low=-1., high=1., shape=(2,), dtype=np.float32)
    })

    def reset(self):
        return self.observation_space.sample()

    def step(self, action):
        # Do something with action['fire'], action['jump'], action['move']
        observation = self.observation_space.sample()
        return observation, 0., False, {}

def make_env():
    return CustomEnv()

env = AsyncVectorEnv([make_env for _ in range(5)])
print(f'Action space: {env.action_space}')
env.reset()

actions = {
    'fire': np.array([1, 0, 0, 1, 1]),
    'jump': np.array([0, 0, 1, 1, 0]),
    'move': np.random.rand(5, 2)
}
observations, rewards, dones, infos = env.step(actions)
print(f'Observations shape: {observations.shape}')

# Action space: Dict(fire:MultiDiscrete([2 2 2 2 2]), jump:MultiDiscrete([2 2 2 2 2]), move:Box(-1.0, 1.0, (5, 2), float32))
# Observations shape: (5, 84, 84)
```

 - Use `batch_space` instead of `Tuple` in `VectorEnv`
 - Add the `iterate` utility function to iterate over items from a (batch) space
 - Add tests
 - Check if the `action_space` are all the same in all sub-environments