### PR TITLE
Remove safety from CI

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -18,4 +18,3 @@ jobs:
       - run: pytest . || true
       - run: pytest --doctest-modules . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
-      - run: safety check


### PR DESCRIPTION
Right now safety is randomly failing due to a CVE in Pillow 8.2, which is causing tests to be flakey. For supporting people on even slightly old systems, we can't set pillow >8.2, and the likelihood of issues of this nature impacting Gym the way it could other libraries is fantastically low. 