### PR TITLE
Make RecordEpisodeStatistics work with VectorEnv

### DIFF
--- a/gym/wrappers/record_episode_statistics.py
+++ b/gym/wrappers/record_episode_statistics.py
@@ -11,7 +11,9 @@ class RecordEpisodeStatistics(gym.Wrapper):
         if not isinstance(env, gym.vector.VectorEnv):
             self.num_envs = 1
             self.env_is_vec = False
-        self.t0 = time.time()  # TODO: use perf_counter when gym removes Python 2 support
+        self.t0 = (
+            time.time()
+        )  # TODO: use perf_counter when gym removes Python 2 support
         self.episode_count = 0
         self.episode_returns = None
         self.episode_lengths = None
@@ -25,7 +27,9 @@ class RecordEpisodeStatistics(gym.Wrapper):
         return observations
 
     def step(self, action):
-        observations, rewards, dones, infos = super(RecordEpisodeStatistics, self).step(action)
+        observations, rewards, dones, infos = super(RecordEpisodeStatistics, self).step(
+            action
+        )
         self.episode_returns += rewards
         self.episode_lengths += 1
         if not self.env_is_vec:
@@ -36,11 +40,20 @@ class RecordEpisodeStatistics(gym.Wrapper):
                 infos[i] = infos[i].copy()
                 episode_return = self.episode_returns[i]
                 episode_length = self.episode_lengths[i]
-                episode_info = {"r": episode_return, "l": episode_length, "t": round(time.time() - self.t0, 6)}
+                episode_info = {
+                    "r": episode_return,
+                    "l": episode_length,
+                    "t": round(time.time() - self.t0, 6),
+                }
                 infos[i]["episode"] = episode_info
                 self.return_queue.append(episode_return)
                 self.length_queue.append(episode_length)
                 self.episode_count += 1
                 self.episode_returns[i] = 0
                 self.episode_lengths[i] = 0
-        return observations, rewards, dones if self.env_is_vec else dones[0], infos if self.env_is_vec else infos[0]
+        return (
+            observations,
+            rewards,
+            dones if self.env_is_vec else dones[0],
+            infos if self.env_is_vec else infos[0],
+        )

--- a/gym/wrappers/record_episode_statistics.py
+++ b/gym/wrappers/record_episode_statistics.py
@@ -1,39 +1,46 @@
 import time
 from collections import deque
+import numpy as np
 import gym
 
 
 class RecordEpisodeStatistics(gym.Wrapper):
     def __init__(self, env, deque_size=100):
         super(RecordEpisodeStatistics, self).__init__(env)
-        self.t0 = (
-            time.time()
-        )  # TODO: use perf_counter when gym removes Python 2 support
-        self.episode_return = 0.0
-        self.episode_length = 0
+        self.env_is_vec = True
+        if not isinstance(env, gym.vector.VectorEnv):
+            self.num_envs = 1
+            self.env_is_vec = False
+        self.t0 = time.time()  # TODO: use perf_counter when gym removes Python 2 support
+        self.episode_count = 0
+        self.episode_returns = None
+        self.episode_lengths = None
         self.return_queue = deque(maxlen=deque_size)
         self.length_queue = deque(maxlen=deque_size)
 
     def reset(self, **kwargs):
-        observation = super(RecordEpisodeStatistics, self).reset(**kwargs)
-        self.episode_return = 0.0
-        self.episode_length = 0
-        return observation
+        observations = super(RecordEpisodeStatistics, self).reset(**kwargs)
+        self.episode_returns = np.zeros(self.num_envs, dtype=np.float32)
+        self.episode_lengths = np.zeros(self.num_envs, dtype=np.int32)
+        return observations
 
     def step(self, action):
-        observation, reward, done, info = super(RecordEpisodeStatistics, self).step(
-            action
-        )
-        self.episode_return += reward
-        self.episode_length += 1
-        if done:
-            info["episode"] = {
-                "r": self.episode_return,
-                "l": self.episode_length,
-                "t": round(time.time() - self.t0, 6),
-            }
-            self.return_queue.append(self.episode_return)
-            self.length_queue.append(self.episode_length)
-            self.episode_return = 0.0
-            self.episode_length = 0
-        return observation, reward, done, info
+        observations, rewards, dones, infos = super(RecordEpisodeStatistics, self).step(action)
+        self.episode_returns += rewards
+        self.episode_lengths += 1
+        if not self.env_is_vec:
+            infos = [infos]
+            dones = [dones]
+        for i in range(len(dones)):
+            if dones[i]:
+                infos[i] = infos[i].copy()
+                episode_return = self.episode_returns[i]
+                episode_length = self.episode_lengths[i]
+                episode_info = {"r": episode_return, "l": episode_length, "t": round(time.time() - self.t0, 6)}
+                infos[i]["episode"] = episode_info
+                self.return_queue.append(episode_return)
+                self.length_queue.append(episode_length)
+                self.episode_count += 1
+                self.episode_returns[i] = 0
+                self.episode_lengths[i] = 0
+        return observations, rewards, dones if self.env_is_vec else dones[0], infos if self.env_is_vec else infos[0]

--- a/gym/wrappers/test_record_episode_statistics.py
+++ b/gym/wrappers/test_record_episode_statistics.py
@@ -26,7 +26,7 @@ def test_record_episode_statistics(env_id, deque_size):
 
 @pytest.mark.parametrize("env_id", ["CartPole-v0"])
 def test_record_episode_statistics_with_vectorenv(env_id):
-    envs = gym.vector.make(env_id)
+    envs = gym.vector.make(env_id, asynchronous=False)
     envs = RecordEpisodeStatistics(envs)
     envs.reset()
     for _ in range(envs.env.envs[0].spec.max_episode_steps + 1):

--- a/gym/wrappers/test_record_episode_statistics.py
+++ b/gym/wrappers/test_record_episode_statistics.py
@@ -29,9 +29,10 @@ def test_record_episode_statistics_with_vectorenv(env_id):
     envs = gym.vector.make(env_id)
     envs = RecordEpisodeStatistics(envs)
     envs.reset()
-    for _ in range(envs.spec.max_episode_steps + 1):
-        _, _, _, infos = envs.step(envs.action_space.sample())
-        for info in infos:
-            assert "episode" in info
-            assert all([item in info["episode"] for item in ["r", "l", "t"]])
-            break
+    for _ in range(envs.env.envs[0].spec.max_episode_steps + 1):
+        _, _, dones, infos = envs.step(envs.action_space.sample())
+        for idx, info in enumerate(infos):
+            if dones[idx]:
+                assert "episode" in info
+                assert all([item in info["episode"] for item in ["r", "l", "t"]])
+                break

--- a/gym/wrappers/test_record_episode_statistics.py
+++ b/gym/wrappers/test_record_episode_statistics.py
@@ -25,7 +25,7 @@ def test_record_episode_statistics(env_id, deque_size):
 
 
 @pytest.mark.parametrize("num_envs", [1, 4])
-def test_record_episode_statistics_with_vectorenv(env_id, num_envs):
+def test_record_episode_statistics_with_vectorenv(num_envs):
     envs = gym.vector.make("CartPole-v0", num_envs=num_envs, asynchronous=False)
     envs = RecordEpisodeStatistics(envs)
     envs.reset()

--- a/gym/wrappers/test_record_episode_statistics.py
+++ b/gym/wrappers/test_record_episode_statistics.py
@@ -22,3 +22,15 @@ def test_record_episode_statistics(env_id, deque_size):
                 break
     assert len(env.return_queue) == deque_size
     assert len(env.length_queue) == deque_size
+
+@pytest.mark.parametrize("env_id", ["CartPole-v0"])
+def test_record_episode_statistics_with_vectorenv(env_id):
+    envs = gym.vector.make(env_id)
+    envs = RecordEpisodeStatistics(envs)
+    envs.reset()
+    for _ in range(envs.spec.max_episode_steps+1):
+        _, _, _, infos = envs.step(envs.action_space.sample())
+        for info in infos:
+            assert "episode" in info
+            assert all([item in info["episode"] for item in ["r", "l", "t"]])
+            break

--- a/gym/wrappers/test_record_episode_statistics.py
+++ b/gym/wrappers/test_record_episode_statistics.py
@@ -12,8 +12,8 @@ def test_record_episode_statistics(env_id, deque_size):
 
     for n in range(5):
         env.reset()
-        assert env.episode_return == 0.0
-        assert env.episode_length == 0
+        assert env.episode_returns[0] == 0.0
+        assert env.episode_lengths[0] == 0
         for t in range(env.spec.max_episode_steps):
             _, _, done, info = env.step(env.action_space.sample())
             if done:

--- a/gym/wrappers/test_record_episode_statistics.py
+++ b/gym/wrappers/test_record_episode_statistics.py
@@ -23,12 +23,13 @@ def test_record_episode_statistics(env_id, deque_size):
     assert len(env.return_queue) == deque_size
     assert len(env.length_queue) == deque_size
 
+
 @pytest.mark.parametrize("env_id", ["CartPole-v0"])
 def test_record_episode_statistics_with_vectorenv(env_id):
     envs = gym.vector.make(env_id)
     envs = RecordEpisodeStatistics(envs)
     envs.reset()
-    for _ in range(envs.spec.max_episode_steps+1):
+    for _ in range(envs.spec.max_episode_steps + 1):
         _, _, _, infos = envs.step(envs.action_space.sample())
         for info in infos:
             assert "episode" in info

--- a/gym/wrappers/test_record_episode_statistics.py
+++ b/gym/wrappers/test_record_episode_statistics.py
@@ -24,9 +24,9 @@ def test_record_episode_statistics(env_id, deque_size):
     assert len(env.length_queue) == deque_size
 
 
-@pytest.mark.parametrize("env_id", ["CartPole-v0"])
-def test_record_episode_statistics_with_vectorenv(env_id):
-    envs = gym.vector.make(env_id, asynchronous=False)
+@pytest.mark.parametrize("num_envs", [1, 4])
+def test_record_episode_statistics_with_vectorenv(env_id, num_envs):
+    envs = gym.vector.make("CartPole-v0", num_envs=num_envs, asynchronous=False)
     envs = RecordEpisodeStatistics(envs)
     envs.reset()
     for _ in range(envs.env.envs[0].spec.max_episode_steps + 1):


### PR DESCRIPTION
Following up with #2279, this PR makes `RecordEpisodeStatistics` work with `VectorEnv` as well. That is

```python
import gym
from gym.vector import SyncVectorEnv

def make_env(gym_id, seed):
    def thunk():
        env = gym.make(gym_id)
        env = gym.wrappers.RecordEpisodeStatistics(env)
        env.seed(seed)
        env.action_space.seed(seed)
        env.observation_space.seed(seed)
        return env
    return thunk

envs = SyncVectorEnv([make_env("CartPole-v1", 1 + i) for i in range(2)])
envs.reset()
for i in range(100):
    _, _, _, infos = envs.step(envs.action_space.sample())
    for info in infos:
        if "episode" in info.keys():
            print(f"i, episode_reward={info['episode']['r']}")
            break
```

will produce the same results as

```python
import gym
from gym.vector import SyncVectorEnv

def make_env(gym_id, seed):
    def thunk():
        env = gym.make(gym_id)
        env.seed(seed)
        env.action_space.seed(seed)
        env.observation_space.seed(seed)
        return env
    return thunk

envs = SyncVectorEnv([make_env("CartPole-v1", 1 + i) for i in range(2)])
envs = gym.wrappers.RecordEpisodeStatistics(envs)
envs.reset()
for i in range(100):
    _, _, _, infos = envs.step(envs.action_space.sample())
    for info in infos:
        if "episode" in info.keys():
            print(f"i, episode_reward={info['episode']['r']}")
            break
```

The reason why this PR is important is that some envs don't allow you to insert a `RecordEpisodeStatistics` in the `make_env` function. The [procgen environment](https://github.com/openai/procgen) is one such example. So this PR will allow you to do something like this:


```python
import gym
from procgen import ProcgenEnv

envs = ProcgenEnv(num_envs=2, env_name="coinrun", num_levels=0, start_level=0, distribution_mode='hard')
envs = gym.wrappers.RecordEpisodeStatistics(envs)
envs.reset()
for i in range(100):
    _, _, _, infos = envs.step(envs.action_space.sample())
    for info in infos:
        if "episode" in info.keys():
            print(f"i, episode_reward={info['episode']['r']}")
            break
```