### PR TITLE
Fix pendulum rendering when sending zero control

### DIFF
--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -82,7 +82,7 @@ class PendulumEnv(gym.Env):
 
         self.viewer.add_onetime(self.img)
         self.pole_transform.set_rotation(self.state[0] + np.pi / 2)
-        if self.last_u:
+        if self.last_u is not None:
             self.imgtrans.scale = (-self.last_u / 2, np.abs(self.last_u) / 2)
 
         return self.viewer.render(return_rgb_array=mode == "rgb_array")


### PR DESCRIPTION
When sending a control input of zero the rendering was wrong because `if self.last_u:` would evaluate to False.
