### PR TITLE
Autoclose manually maintained video recorders

### DIFF
--- a/gym/wrappers/monitoring/video_recorder.py
+++ b/gym/wrappers/monitoring/video_recorder.py
@@ -10,10 +10,14 @@ import distutils.version
 import numpy as np
 
 from gym import error, logger
+from gym.utils import closer
 
 
 def touch(path):
     open(path, "a").close()
+
+
+video_recorder_closer = closer.Closer()
 
 
 class VideoRecorder(object):
@@ -37,6 +41,7 @@ class VideoRecorder(object):
         modes = env.metadata.get("render.modes", [])
         self._async = env.metadata.get("semantics.async")
         self.enabled = enabled
+        self._recorder_id = video_recorder_closer.register(self)
 
         # Don't bother setting anything else if not enabled
         if not self.enabled:
@@ -144,7 +149,7 @@ class VideoRecorder(object):
                 self._encode_image_frame(frame)
 
     def close(self):
-        """Make sure to manually close, or else you'll leak the encoder process"""
+        """Flush all data to disk and close any open frame encoders."""
         if not self.enabled:
             return
 
@@ -178,9 +183,17 @@ class VideoRecorder(object):
 
         self.write_metadata()
 
+        # Stop tracking this for autoclose
+        video_recorder_closer.unregister(self._recorder_id)
+        self.enabled = False
+
     def write_metadata(self):
         with open(self.metadata_path, "w") as f:
             json.dump(self.metadata, f)
+
+    def __del__(self):
+        # Make sure we've closed up shop when garbage collecting
+        self.close()
 
     def _encode_ansi_frame(self, frame):
         if not self.encoder:


### PR DESCRIPTION
When I am using [`gym.wrappers.monitoring.video_recorder.VideoRecorder`](https://github.com/openai/gym/blob/master/gym/wrappers/monitoring/video_recorder.py) to recorder my rollout videos, I will get a error if the program is exited unexpectedly (e.g. a keyboard interrupt).

```
[rawvideo @ 0x5646579bf4c0] Invalid buffer size, packet size 327680 < expected frame_size 1920000
Error while decoding stream #0:0: Invalid argument
```

`gym.wrappers.Monitor` has been registered with a closer and can be autoclosed at program exit. However, for low level API users, `VideoRecorder` itself may should have autoclose feature as well.

I know I can use the higher API `gym.wrappers.Monitor` to handle this. But I just want to record only one episode, so I prefer to use `VideoRecorder` rather than `gym.wrappers.Monitor`. In addition, `gym.wrappers.Monitor` does not allow users to customize the file name.

This PR is reopened for #2316 #2317.