### PR TITLE
Add CompilerGym to third party environment list

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -407,3 +407,10 @@ Learn more here: https://github.com/modanesh/anomalous_rl_envs
 ### stable-retro
 
 Fork of gym-retro with additional games, states, scenarios, etc. Open to PRs of additional games, features and plateforms since gym-retro is in maintenance mode.
+
+
+### CompilerGym
+
+Reinforcement learning environments for compiler optimization tasks, such as LLVM phase ordering, GCC flag tuning, and CUDA loop nest code generation.
+
+Learn more here: https://github.com/facebookresearch/CompilerGym


### PR DESCRIPTION
[CompilerGym](https://github.com/facebookresearch/CompilerGym) is a third party library of environments for Gym that adds compiler optimization tasks. Install it using `pip install compiler_gym` and then use it by importing the `compiler_gym` module:

```py
import gym
import compiler_gym

env = gym.make("llvm-v0")
env.reset()
env.render()
```