### PR TITLE
Change action rescale argument names

### DIFF
--- a/gym/wrappers/rescale_action.py
+++ b/gym/wrappers/rescale_action.py
@@ -4,11 +4,11 @@ from gym import spaces
 
 
 class RescaleAction(gym.ActionWrapper):
-    r"""Rescales the continuous action space of the environment to a range [a,b].
+    r"""Rescales the continuous action space of the environment to a range [min_action, max_action].
 
     Example::
 
-        >>> RescaleAction(env, a, b).action_space == Box(a,b)
+        >>> RescaleAction(env, min_action, max_action).action_space == Box(min_action, max_action)
         True
 
     """

--- a/gym/wrappers/rescale_action.py
+++ b/gym/wrappers/rescale_action.py
@@ -21,7 +21,7 @@ class RescaleAction(gym.ActionWrapper):
 
         super(RescaleAction, self).__init__(env)
         self.min_action = np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + min_action
-        self.b = np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + max_action
+        self.max_action = np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + max_action
         self.action_space = spaces.Box(
             low=min_action, high=max_action, shape=env.action_space.shape, dtype=env.action_space.dtype
         )

--- a/gym/wrappers/rescale_action.py
+++ b/gym/wrappers/rescale_action.py
@@ -13,17 +13,17 @@ class RescaleAction(gym.ActionWrapper):
 
     """
 
-    def __init__(self, env, a, b):
+    def __init__(self, env, min_action, max_action):
         assert isinstance(
             env.action_space, spaces.Box
         ), "expected Box action space, got {}".format(type(env.action_space))
-        assert np.less_equal(a, b).all(), (a, b)
+        assert np.less_equal(min, min_action).all(), (min_action, max_action)
 
         super(RescaleAction, self).__init__(env)
-        self.a = np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + a
-        self.b = np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + b
+        self.a = np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + min_action
+        self.b = np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + max_action
         self.action_space = spaces.Box(
-            low=a, high=b, shape=env.action_space.shape, dtype=env.action_space.dtype
+            low=min_action, high=max_action, shape=env.action_space.shape, dtype=env.action_space.dtype
         )
 
     def action(self, action):

--- a/gym/wrappers/rescale_action.py
+++ b/gym/wrappers/rescale_action.py
@@ -20,17 +20,29 @@ class RescaleAction(gym.ActionWrapper):
         assert np.less_equal(min_action, max_action).all(), (min_action, max_action)
 
         super(RescaleAction, self).__init__(env)
-        self.min_action = np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + min_action
-        self.max_action = np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + max_action
+        self.min_action = (
+            np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + min_action
+        )
+        self.max_action = (
+            np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + max_action
+        )
         self.action_space = spaces.Box(
-            low=min_action, high=max_action, shape=env.action_space.shape, dtype=env.action_space.dtype
+            low=min_action,
+            high=max_action,
+            shape=env.action_space.shape,
+            dtype=env.action_space.dtype,
         )
 
     def action(self, action):
-        assert np.all(np.greater_equal(action, self.min_action)), (action, self.min_action)
+        assert np.all(np.greater_equal(action, self.min_action)), (
+            action,
+            self.min_action,
+        )
         assert np.all(np.less_equal(action, self.max_action)), (action, self.max_action)
         low = self.env.action_space.low
         high = self.env.action_space.high
-        action = low + (high - low) * ((action - self.min_action) / (self.max_action - self.min_action))
+        action = low + (high - low) * (
+            (action - self.min_action) / (self.max_action - self.min_action)
+        )
         action = np.clip(action, low, high)
         return action

--- a/gym/wrappers/rescale_action.py
+++ b/gym/wrappers/rescale_action.py
@@ -17,20 +17,20 @@ class RescaleAction(gym.ActionWrapper):
         assert isinstance(
             env.action_space, spaces.Box
         ), "expected Box action space, got {}".format(type(env.action_space))
-        assert np.less_equal(min, min_action).all(), (min_action, max_action)
+        assert np.less_equal(min_action, max_action).all(), (min_action, max_action)
 
         super(RescaleAction, self).__init__(env)
-        self.a = np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + min_action
+        self.min_action = np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + min_action
         self.b = np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + max_action
         self.action_space = spaces.Box(
             low=min_action, high=max_action, shape=env.action_space.shape, dtype=env.action_space.dtype
         )
 
     def action(self, action):
-        assert np.all(np.greater_equal(action, self.a)), (action, self.a)
-        assert np.all(np.less_equal(action, self.b)), (action, self.b)
+        assert np.all(np.greater_equal(action, self.min_action)), (action, self.min_action)
+        assert np.all(np.less_equal(action, self.max_action)), (action, self.max_action)
         low = self.env.action_space.low
         high = self.env.action_space.high
-        action = low + (high - low) * ((action - self.a) / (self.b - self.a))
+        action = low + (high - low) * ((action - self.min_action) / (self.max_action - self.min_action))
         action = np.clip(action, low, high)
         return action


### PR DESCRIPTION
`a` and `b` are not suitable names here. This should only be a breaking change in very rare circumstances and the fix where it is breaking is trivial.