### PR TITLE
Add documentation for Vectorized environments

### DIFF
--- a/docs/vector/advanced.rst
+++ b/docs/vector/advanced.rst
@@ -1,0 +1,54 @@
+.. automodule:: gym.vector
+    :noindex:
+
+Advanced Usage
+==============
+
+Custom spaces
+-------------
+
+Vectorized environments will batch actions and observations if they are elements from standard Gym spaces, such as :class:`~gym.spaces.Box`, :class:`~gym.spaces.Discrete`, or :class:`~gym.spaces.Dict`. If you create your own environment with a custom action and/or observation space though (inheriting from :class:`gym.Space`), the vectorized environment will not attempt to automatically batch the actions/observations, and instead it will return the raw tuple of elements from all sub-environments.
+
+In the following example, we created a new environment :obj:`SMILESEnv`, whose observations are strings representing the `SMILES`_ notation of a molecular structure, with a custom observation space :obj:`SMILES`. The observations returned by the vectorized environment is a tuple of strings. 
+
+.. code-block::
+
+    >>> class SMILES(gym.Space):
+    ...     def __init__(self, symbols):
+    ...         super().__init__()
+    ...         self.symbols = symbols
+    ...
+    ...     def __eq__(self, other):
+    ...         return self.symbols == other.symbols
+
+    >>> class SMILESEnv(gym.Env):
+    ...     observation_space = SMILES("][()CO=")
+    ...     action_space = gym.spaces.Discrete(7)
+    ...
+    ...     def reset(self):
+    ...         self._state = "["
+    ...         return self._state
+    ...
+    ...     def step(self, action):
+    ...         self._state += self.observation_space.symbols[action]
+    ...         reward = done = (action == 0)
+    ...         return (self._state, float(reward), done, {})
+
+    >>> envs = gym.vector.AsyncVectorEnv(
+    ...     [lambda: SMILESEnv()] * 3,
+    ...     shared_memory=False
+    ... )
+    >>> envs.reset()
+    >>> observations, rewards, dones, infos = envs.step(np.array([2, 5, 4]))
+    >>> observations
+    ('[(', '[O', '[C')
+
+.. warning::
+    Custom observation & action spaces may inherit from the :class:`gym.Space` class. However, most use-cases should be covered by the existing space classes (e.g. :class:`~gym.spaces.Box`, :class:`~gym.spaces.Discrete`, etc...), and container classes (:class:`~gym.spaces.Tuple` & :class:`~gym.spaces.Dict`). Moreover, some implementations of Reinforcement Learning algorithms might not handle custom spaces properly. Use custom spaces with care.
+
+.. warning::
+    If you use :class:`AsyncVectorEnv` with a custom observation space, you must set ``shared_memory=False``, since shared memory and automatic batching is not compatible with custom spaces. In general if you use custom spaces with :class:`AsyncVectorEnv`, the elements of those spaces must be `pickleable`_.
+
+
+.. _SMILES: https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system
+.. _pickleable: https://docs.python.org/3/library/pickle.html

--- a/docs/vector/api_reference.rst
+++ b/docs/vector/api_reference.rst
@@ -1,0 +1,140 @@
+.. automodule:: gym.vector
+    :noindex:
+
+API Reference
+=============
+
+.. autofunction:: make
+
+VectorEnv
+---------
+
+.. autoclass:: VectorEnv
+    
+    .. py:property:: action_space
+
+        :type: :class:`gym.spaces.Space`
+
+        The (batched) action space. The input actions of :meth:`step` must be valid elements of :obj:`action_space`.
+
+        .. code-block::
+
+            >>> envs = gym.vector.make("CartPole-v1", num_envs=3)
+            >>> envs.action_space
+            MultiDiscrete([2 2 2])
+
+    .. py:property:: observation_space
+
+        :type: :class:`gym.spaces.Space`
+
+        The (batched) observation space. The observations returned by :meth:`reset` and :meth:`step` are valid elements of :obj:`observation_space`.
+
+        .. code-block::
+
+            >>> envs = gym.vector.make("CartPole-v1", num_envs=3)
+            >>> envs.observation_space
+            Box([[-4.8 ...]], [[4.8 ...]], (3, 4), float32)
+
+    .. py:property:: single_action_space
+
+        :type: :class:`gym.spaces.Space`
+
+        The action space of a sub-environment.
+
+        .. code-block::
+
+            >>> envs = gym.vector.make("CartPole-v1", num_envs=3)
+            >>> envs.single_action_space
+            Discrete(2)
+
+    .. py:property:: single_observation_space
+
+        :type: :class:`gym.spaces.Space`
+
+        The observation space of a sub-environment.
+
+        .. code-block::
+
+            >>> envs = gym.vector.make("CartPole-v1", num_envs=3)
+            >>> envs.single_action_space
+            Box([-4.8 ...], [4.8 ...], (4,), float32)
+
+    .. automethod:: reset
+
+        .. code-block::
+
+            >>> envs = gym.vector.make("CartPole-v1", num_envs=3)
+            >>> envs.reset()
+            array([[-0.04456399,  0.04653909,  0.01326909, -0.02099827],
+                   [ 0.03073904,  0.00145001, -0.03088818, -0.03131252],
+                   [ 0.03468829,  0.01500225,  0.01230312,  0.01825218]],
+                  dtype=float32)
+
+    .. automethod:: step
+
+        .. code-block::
+
+            >>> envs = gym.vector.make("CartPole-v1", num_envs=3)
+            >>> envs.reset()
+            >>> actions = np.array([1, 0, 1])
+            >>> observations, rewards, dones, infos = envs.step(actions)
+
+            >>> observations
+            array([[ 0.00122802,  0.16228443,  0.02521779, -0.23700266],
+                   [ 0.00788269, -0.17490888,  0.03393489,  0.31735462],
+                   [ 0.04918966,  0.19421194,  0.02938497, -0.29495203]],
+                  dtype=float32)
+            >>> rewards
+            array([1., 1., 1.])
+            >>> dones
+            array([False, False, False])
+            >>> infos
+            ({}, {}, {})
+
+    .. automethod:: seed
+
+        .. code-block::
+
+            >>> envs = gym.vector.make("CartPole-v1", num_envs=3)
+            >>> envs.seed([1, 3, 5])
+            >>> envs.reset()
+            array([[ 0.03073904,  0.00145001, -0.03088818, -0.03131252],
+                   [ 0.02281231, -0.02475473,  0.02306162,  0.02072129],
+                   [-0.03742824, -0.02316945,  0.0148571 ,  0.0296055 ]],
+                  dtype=float32)
+
+    .. automethod:: close
+
+AsyncVectorEnv
+--------------
+
+.. autoclass:: AsyncVectorEnv
+
+    .. automethod:: reset
+
+        .. note::
+            This is equivalent to a call to :meth:`reset_async`, followed by a subsequent call to :meth:`reset_wait` (with no timeout).
+
+    .. automethod:: reset_async
+    .. automethod:: reset_wait
+    .. automethod:: step
+
+        .. note::
+            This is equivalent to a call to :meth:`step_async`, followed by a subsequent call to :meth:`step_wait` (with no timeout).
+
+    .. automethod:: step_async
+    .. automethod:: step_wait
+    .. automethod:: seed
+    .. automethod:: close_extras
+
+SyncVectorEnv
+-------------
+
+.. autoclass:: SyncVectorEnv
+
+    .. automethod:: reset
+    .. automethod:: step
+    .. automethod:: seed
+    .. automethod:: close_extras
+
+.. _multiprocessing: https://docs.python.org/3/library/multiprocessing.html

--- a/docs/vector/getting_started.rst
+++ b/docs/vector/getting_started.rst
@@ -1,0 +1,188 @@
+.. automodule:: gym.vector
+    :noindex:
+
+Getting Started
+===============
+
+Creating a vectorized environment
+---------------------------------
+
+To create a vectorized environment that runs multiple sub-environments, you can wrap your sub-environments inside :class:`gym.vector.SyncVectorEnv` (for sequential execution), or :class:`gym.vector.AsyncVectorEnv` (for parallel execution, with `multiprocessing`_). These vectorized environments take as input a list of callable specifying how the sub-environments are created.
+
+.. code-block::
+
+    >>> envs = gym.vector.AsyncVectorEnv([
+    ...     lambda: gym.make("CartPole-v1"),
+    ...     lambda: gym.make("CartPole-v1"),
+    ...     lambda: gym.make("CartPole-v1")
+    ... ])
+
+Alternatively, to create a vectorized environment of multiple copies of the same registered sub-environment, you can use the function :func:`gym.vector.make`.
+
+.. code-block::
+
+    >>> envs = gym.vector.make("CartPole-v1", num_envs=3)  # Equivalent
+
+.. note::
+    To enable automatic batching of actions and observations, all the sub-environments must share the same :obj:`action_space` and :obj:`observation_space`. However, all the sub-environments are not required to be exact copies of one another. For example, you can run 2 instances of ``Pendulum-v0`` with different values of the gravity in a vectorized environment with
+
+    .. code-block::
+
+        >>> env = gym.vector.AsyncVectorEnv([
+        ...     lambda: gym.make("Pendulum-v0", g=9.81),
+        ...     lambda: gym.make("Pendulum-v0", g=1.62)
+        ... ])
+
+    See also :ref:`Observation & Action spaces` for more information about automatic batching.
+
+.. warning::
+    When using :class:`AsyncVectorEnv` with either the ``spawn`` or ``forkserver`` start methods, you must wrap your code containing the vectorized environment with ``if __name__ == "__main__":``. See `this documentation <https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods>`_ for more information.
+
+    .. code-block::
+
+        if __name__ == "__main__":
+            envs = gym.vector.make("CartPole-v1", num_envs=3, context="spawn")
+
+Working with vectorized environments
+------------------------------------
+
+While standard Gym environments take a single action and return a single observation (with a reward, and boolean indicating termination), vectorized environments take a *batch of actions* as input, and return a *batch of observations*, together with an array of rewards and booleans indicating if the episode ended in each sub-environment.
+
+.. code-block::
+
+    >>> envs = gym.vector.make("CartPole-v1", num_envs=3)
+    >>> envs.reset()
+    array([[ 0.00198895, -0.00569421, -0.03170966,  0.00126465],
+           [-0.02658334,  0.00755256,  0.04376719, -0.00266695],
+           [-0.02898625,  0.04779156,  0.02686412, -0.01298284]],
+          dtype=float32)
+
+    >>> actions = np.array([1, 0, 1])
+    >>> observations, rewards, dones, infos = envs.step(actions)
+
+    >>> observations
+    array([[ 0.00187507,  0.18986781, -0.03168437, -0.301252  ],
+           [-0.02643229, -0.18816885,  0.04371385,  0.3034975 ],
+           [-0.02803041,  0.24251814,  0.02660446, -0.29707024]],
+          dtype=float32)
+    >>> rewards
+    array([1., 1., 1.])
+    >>> dones
+    array([False, False, False])
+    >>> infos
+    ({}, {}, {})
+
+Vectorized environments are compatible with any sub-environment, regardless of the action and observation spaces (e.g. container spaces like :class:`~gym.spaces.Dict`, or any arbitrarily nested spaces). In particular, vectorized environments can automatically batch the observations returned by :meth:`~VectorEnv.reset` and :meth:`~VectorEnv.step` for any standard Gym space (e.g. :class:`~gym.spaces.Box`, :class:`~gym.spaces.Discrete`, :class:`~gym.spaces.Dict`, or any nested structure thereof). Similarly, vectorized environments can take batches of actions from any standard Gym space.
+
+.. code-block::
+
+    >>> class DictEnv(gym.Env):
+    ...     observation_space = gym.spaces.Dict({
+    ...         "position": gym.spaces.Box(-1., 1., (3,), np.float32),
+    ...         "velocity": gym.spaces.Box(-1., 1., (2,), np.float32)
+    ...     })
+    ...     action_space = gym.spaces.Dict({
+    ...         "fire": gym.spaces.Discrete(2),
+    ...         "jump": gym.spaces.Discrete(2),
+    ...         "acceleration": gym.spaces.Box(-1., 1., (2,), np.float32)
+    ...     })
+    ...
+    ...     def reset(self):
+    ...         return self.observation_space.sample()
+    ...
+    ...     def step(self, action):
+    ...         observation = self.observation_space.sample()
+    ...         return (observation, 0., False, {})
+
+    >>> envs = gym.vector.AsyncVectorEnv([lambda: DictEnv()] * 3)
+    >>> envs.observation_space
+    Dict(position:Box(-1.0, 1.0, (3, 3), float32), velocity:Box(-1.0, 1.0, (3, 2), float32))
+    >>> envs.action_space
+    Dict(fire:MultiDiscrete([2 2 2]), jump:MultiDiscrete([2 2 2]), acceleration:Box(-1.0, 1.0, (3, 2), float32))
+
+    >>> envs.reset()
+    >>> actions = {
+    ...     "fire": np.array([1, 1, 0]),
+    ...     "jump": np.array([0, 1, 0]),
+    ...     "acceleration": np.random.uniform(-1., 1., size=(3, 2))
+    ... }
+    >>> observations, rewards, dones, infos = envs.step(actions)
+    >>> observations
+    {"position": array([[-0.5337036 ,  0.7439302 ,  0.41748118],
+                        [ 0.9373266 , -0.5780453 ,  0.8987405 ],
+                        [-0.917269  , -0.5888639 ,  0.812942  ]], dtype=float32),
+    "velocity": array([[ 0.23626241, -0.0616814 ],
+                       [-0.4057572 , -0.4875375 ],
+                       [ 0.26341468,  0.72282314]], dtype=float32)}
+
+.. note::
+    The sub-environments inside a vectorized environment automatically call :obj:`reset` at the end of an episode. In the following example, the episode of the 3rd sub-environment ends after 2 steps (the agent fell in a hole), and the sub-environment gets reset (observation ``0``).
+
+    .. code-block::
+
+        >>> envs = gym.vector.make("FrozenLake-v1", num_envs=3, is_slippery=False)
+        >>> envs.reset()
+        array([0, 0, 0])
+        >>> observations, rewards, dones, infos = envs.step(np.array([1, 2, 2]))
+        >>> observations, rewards, dones, infos = envs.step(np.array([1, 2, 1]))
+
+        >>> dones
+        array([False, False,  True])
+        >>> observations
+        array([8, 2, 0])
+
+Observation & Action spaces
+---------------------------
+
+Like any Gym environment, vectorized environments contain two properties :attr:`~VectorEnv.observation_space` and :attr:`~VectorEnv.action_space` to specify the observation and action spaces of the environment. Since vectorized environments operate on multiple sub-environments, where the observations and actions of sub-environments are batched together, the observation and action spaces are adequately batched as well so that the input actions are valid elements of :attr:`~VectorEnv.action_space`, and the observations are valid elements of :attr:`~VectorEnv.observation_space`.
+
+.. code-block::
+
+    >>> envs = gym.vector.make("CartPole-v1", num_envs=3)
+    >>> envs.observation_space
+    Box([[-4.8 ...]], [[4.8 ...]], (3, 4), float32)
+    >>> envs.action_space
+    MultiDiscrete([2 2 2])
+
+.. note::
+    In order to appropriately batch the observations and actions in vectorized environments, the observation and action spaces of all the sub-environments are required to be identical.
+
+    .. code-block::
+
+        >>> envs = gym.vector.AsyncVectorEnv([
+        ...     lambda: gym.make("CartPole-v1"),
+        ...     lambda: gym.make("MountainCar-v0")
+        ... ])
+        RuntimeError: Some environments have an observation space different from `Box([-4.8 ...], [4.8 ...], (4,), float32)`. In order to batch observations, the observation spaces from all environments must be equal.
+
+However, sometimes it may be handy to have access to the observation and action spaces of a sub-environment, and not the batched spaces. You can access those with the properties :attr:`~VectorEnv.single_observation_space` and :attr:`~VectorEnv.single_action_space` of the vectorized environment.
+
+.. code-block::
+
+    >>> envs = gym.vector.make("CartPole-v1", num_envs=3)
+    >>> envs.single_observation_space
+    Box([-4.8 ...], [4.8 ...], (4,), float32)
+    >>> envs.single_action_space
+    Discrete(2)
+
+This is convenient, for example, if you instantiate a policy. In the following example, we used :attr:`~VectorEnv.single_observation_space` and :attr:`~VectorEnv.single_action_space` to define the weights of a linear policy. Note that thanks to the vectorized environment, you can apply the policy directly to the whole batch of observations with a single call to :obj:`policy`.
+
+.. code-block::
+
+    >>> from gym.spaces.utils import flatdim
+    >>> from scipy.special import softmax
+
+    >>> def policy(weights, observations):
+    ...     logits = np.dot(observations, weights)
+    ...     return softmax(logits, axis=1)
+
+    >>> envs = gym.vector.make("CartPole-v1", num_envs=3)
+    >>> weights = np.random.randn(
+    ...     flatdim(envs.single_observation_space),
+    ...     envs.single_action_space.n
+    ... )
+    >>> observations = envs.reset()
+    >>> actions = policy(weights, observations).argmax(axis=1)
+    >>> observations, rewards, dones, infos = envs.step(actions)
+
+.. _multiprocessing: https://docs.python.org/3/library/multiprocessing.html

--- a/docs/vector/index.rst
+++ b/docs/vector/index.rst
@@ -1,0 +1,54 @@
+.. automodule:: gym.vector
+
+Vectorized Environments
+=======================
+
+.. toctree::
+    :hidden:
+
+    getting_started
+    intermediate
+    advanced
+    api_reference
+
+*Vectorized environments* are environments that run multiple (independent) sub-environments, either sequentially, or in parallel using `multiprocessing`_. Vectorized environments take as input a batch of actions, and return a batch of observations. This is particularly useful, for example, when the policy is defined as a neural network that operates over a batch of observations.
+
+Gym provides two types of vectorized environments:
+
+    - :class:`gym.vector.SyncVectorEnv`, where the sub-environment are executed sequentially.
+    - :class:`gym.vector.AsyncVectorEnv`, where the sub-environments are executed in parallel using `multiprocessing`_. This creates one process per sub-environment.
+
+.. rubric:: Quickstart
+
+Similar to :func:`gym.make`, you can run a vectorized version of a registered environment using the :func:`gym.vector.make` function. This runs multiple copies of the same environment (in parallel, by default).
+
+The following example runs 3 copies of the ``CartPole-v1`` environment in parallel, taking as input a vector of 3 binary actions (one for each sub-environment), and returning an array of 3 observations stacked along the first dimension, with an array of rewards returned by each sub-environment, and an array of booleans indicating if the episode in each sub-environment has ended.
+
+.. code-block::
+
+    >>> envs = gym.vector.make("CartPole-v1", num_envs=3)
+    >>> envs.reset()
+    >>> actions = np.array([1, 0, 1])
+    >>> observations, rewards, dones, infos = envs.step(actions)
+
+    >>> observations
+    array([[ 0.00122802,  0.16228443,  0.02521779, -0.23700266],
+           [ 0.00788269, -0.17490888,  0.03393489,  0.31735462],
+           [ 0.04918966,  0.19421194,  0.02938497, -0.29495203]],
+          dtype=float32)
+    >>> rewards
+    array([1., 1., 1.])
+    >>> dones
+    array([False, False, False])
+    >>> infos
+    ({}, {}, {})
+
+.. note::
+
+    The function :func:`gym.vector.make` is meant to be used only in basic cases (e.g. running multiple copies of the same registered environment). For any other use-cases, please use either the :class:`SyncVectorEnv` for sequential execution, or :class:`AsyncVectorEnv` for parallel execution. These use-cases may include:
+
+        - Running multiple instances of the same environment with different parameters (e.g. ``"Pendulum-v0"`` with different values for the gravity).
+        - Running multiple instances of an unregistered environment (e.g. a custom environment)
+        - Using a wrapper on some (but not all) sub-environments.
+
+.. _multiprocessing: https://docs.python.org/3/library/multiprocessing.html

--- a/docs/vector/intermediate.rst
+++ b/docs/vector/intermediate.rst
@@ -1,0 +1,54 @@
+.. automodule:: gym.vector
+    :noindex:
+
+Intermediate Usage
+==================
+
+Shared memory
+-------------
+
+:class:`AsyncVectorEnv` runs each sub-environment inside an individual process. At each call to :meth:`~AsyncVectorEnv.reset` or :meth:`~AsyncVectorEnv.step`, the observations of all the sub-environments are sent back to the main process. To avoid expensive transfers of data between processes, especially with large observations (e.g. images), :class:`AsyncVectorEnv` uses a shared memory by default (``shared_memory=True``) that processes can write to and read from at minimal cost. This can increase the throughout of the vectorized environment.
+
+.. code-block::
+
+    >>> env_fns = [lambda: gym.make("BreakoutNoFrameskip-v4")] * 5
+
+    >>> envs = gym.vector.AsyncVectorEnv(env_fns, shared_memory=False)
+    >>> envs.reset()
+    >>> %timeit envs.step(envs.action_space.sample())
+    2.23 ms ± 136 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
+
+    >>> envs = gym.vector.AsyncVectorEnv(env_fns, shared_memory=True)
+    >>> envs.reset()
+    >>> %timeit envs.step(envs.action_space.sample())
+    1.36 ms ± 15.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
+
+Exception handling
+------------------
+
+Because sometimes things may not go as planned, the exceptions raised in sub-environments are re-raised in the vectorized environment, even when the sub-environments run in parallel with :class:`AsyncVectorEnv`. This way, you can choose how to handle these exceptions yourself (with ``try ... except``).
+
+.. code-block::
+
+    >>> class ErrorEnv(gym.Env):
+    ...     observation_space = gym.spaces.Box(-1., 1., (2,), np.float32)
+    ...     action_space = gym.spaces.Discrete(2)
+    ...
+    ...     def reset(self):
+    ...         return np.zeros((2,), dtype=np.float32)
+    ...
+    ...     def step(self, action):
+    ...         if action == 1:
+    ...             raise ValueError("An error occurred.")
+    ...         observation = self.observation_space.sample()
+    ...         return (observation, 0., False, {})
+
+    >>> envs = gym.vector.AsyncVectorEnv([lambda: ErrorEnv()] * 3)
+    >>> observations = envs.reset()
+    >>> observations, rewards, dones, infos = envs.step(np.array([0, 0, 1]))
+    ERROR: Received the following error from Worker-2: ValueError: An error occurred.
+    ERROR: Shutting down Worker-2.
+    ERROR: Raising the last exception back to the main process.
+    ValueError: An error occurred.
+
+.. _multiprocessing: https://docs.python.org/3/library/multiprocessing.html

--- a/gym/vector/__init__.py
+++ b/gym/vector/__init__.py
@@ -12,7 +12,7 @@ __all__ = ["AsyncVectorEnv", "SyncVectorEnv", "VectorEnv", "VectorEnvWrapper", "
 
 def make(id, num_envs=1, asynchronous=True, wrappers=None, **kwargs):
     """Create a vectorized environment from multiple copies of an environment,
-    from its id
+    from its id.
 
     Parameters
     ----------
@@ -22,24 +22,23 @@ def make(id, num_envs=1, asynchronous=True, wrappers=None, **kwargs):
     num_envs : int
         Number of copies of the environment.
 
-    asynchronous : bool (default: `True`)
-        If `True`, wraps the environments in an `AsyncVectorEnv` (which uses
-        `multiprocessing` to run the environments in parallel). If `False`,
-        wraps the environments in a `SyncVectorEnv`.
+    asynchronous : bool
+        If `True`, wraps the environments in an :class:`AsyncVectorEnv` (which uses
+        `multiprocessing`_ to run the environments in parallel). If ``False``,
+        wraps the environments in a :class:`SyncVectorEnv`.
 
-    wrappers : Callable or Iterable of Callables (default: `None`)
-        If not `None`, then apply the wrappers to each internal
+    wrappers : callable, or iterable of callables, optional
+        If not ``None``, then apply the wrappers to each internal
         environment during creation.
 
     Returns
     -------
-    env : `gym.vector.VectorEnv` instance
+    :class:`gym.vector.VectorEnv`
         The vectorized environment.
 
     Example
     -------
-    >>> import gym
-    >>> env = gym.vector.make('CartPole-v1', 3)
+    >>> env = gym.vector.make('CartPole-v1', num_envs=3)
     >>> env.reset()
     array([[-0.04456399,  0.04653909,  0.01326909, -0.02099827],
            [ 0.03073904,  0.00145001, -0.03088818, -0.03131252],

--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -34,47 +34,75 @@ class AsyncState(Enum):
 
 class AsyncVectorEnv(VectorEnv):
     """Vectorized environment that runs multiple environments in parallel. It
-    uses `multiprocessing` processes, and pipes for communication.
+    uses `multiprocessing`_ processes, and pipes for communication.
 
     Parameters
     ----------
     env_fns : iterable of callable
         Functions that create the environments.
 
-    observation_space : `gym.spaces.Space` instance, optional
-        Observation space of a single environment. If `None`, then the
+    observation_space : :class:`gym.spaces.Space`, optional
+        Observation space of a single environment. If ``None``, then the
         observation space of the first environment is taken.
 
-    action_space : `gym.spaces.Space` instance, optional
-        Action space of a single environment. If `None`, then the action space
+    action_space : :class:`gym.spaces.Space`, optional
+        Action space of a single environment. If ``None``, then the action space
         of the first environment is taken.
 
-    shared_memory : bool (default: `True`)
-        If `True`, then the observations from the worker processes are
+    shared_memory : bool
+        If ``True``, then the observations from the worker processes are
         communicated back through shared variables. This can improve the
         efficiency if the observations are large (e.g. images).
 
-    copy : bool (default: `True`)
-        If `True`, then the `reset` and `step` methods return a copy of the
-        observations.
+    copy : bool
+        If ``True``, then the :meth:`~AsyncVectorEnv.reset` and
+        :meth:`~AsyncVectorEnv.step` methods return a copy of the observations.
 
     context : str, optional
-        Context for multiprocessing. If `None`, then the default context is used.
-        Only available in Python 3.
+        Context for `multiprocessing`_. If ``None``, then the default context is used.
 
-    daemon : bool (default: `True`)
-        If `True`, then subprocesses have `daemon` flag turned on; that is, they
-        will quit if the head process quits. However, `daemon=True` prevents
+    daemon : bool
+        If ``True``, then subprocesses have ``daemon`` flag turned on; that is, they
+        will quit if the head process quits. However, ``daemon=True`` prevents
         subprocesses to spawn children, so for some environments you may want
-        to have it set to `False`
+        to have it set to ``False``.
 
-    worker : function, optional
-        WARNING - advanced mode option! If set, then use that worker in a subprocess
-        instead of a default one. Can be useful to override some inner vector env
-        logic, for instance, how resets on done are handled. Provides high
-        degree of flexibility and a high chance to shoot yourself in the foot; thus,
-        if you are writing your own worker, it is recommended to start from the code
-        for `_worker` (or `_worker_shared_memory`) method below, and add changes
+    worker : callable, optional
+        If set, then use that worker in a subprocess instead of a default one.
+        Can be useful to override some inner vector env logic, for instance,
+        how resets on done are handled.
+
+    Warning
+    -------
+    :attr:`worker` is an advanced mode option. It provides a high degree of
+    flexibility and a high chance to shoot yourself in the foot; thus,
+    if you are writing your own worker, it is recommended to start from the code
+    for ``_worker`` (or ``_worker_shared_memory``) method, and add changes.
+
+    Raises
+    ------
+    RuntimeError
+        If the observation space of some sub-environment does not match
+        :obj:`observation_space` (or, by default, the observation space of
+        the first sub-environment).
+
+    ValueError
+        If :obj:`observation_space` is a custom space (i.e. not a default
+        space in Gym, such as :class:`~gym.spaces.Box`, :class:`~gym.spaces.Discrete`,
+        or :class:`~gym.spaces.Dict`) and :obj:`shared_memory` is ``True``.
+
+    Example
+    -------
+
+    .. code-block::
+
+        >>> env = gym.vector.AsyncVectorEnv([
+        ...     lambda: gym.make("Pendulum-v0", g=9.81),
+        ...     lambda: gym.make("Pendulum-v0", g=1.62)
+        ... ])
+        >>> env.reset()
+        array([[-0.8286432 ,  0.5597771 ,  0.90249056],
+               [-0.85009176,  0.5266346 ,  0.60007906]], dtype=float32)
     """
 
     def __init__(
@@ -179,6 +207,19 @@ class AsyncVectorEnv(VectorEnv):
         self._raise_if_errors(successes)
 
     def reset_async(self):
+        """Send the calls to :obj:`reset` to each sub-environment.
+
+        Raises
+        ------
+        ClosedEnvironmentError
+            If the environment was closed (if :meth:`close` was previously called).
+
+        AlreadyPendingCallError
+            If the environment is already waiting for a pending call to another
+            method (e.g. :meth:`step_async`). This can be caused by two consecutive
+            calls to :meth:`reset_async`, with no call to :meth:`reset_wait` in
+            between.
+        """
         self._assert_is_running()
         if self._state != AsyncState.DEFAULT:
             raise AlreadyPendingCallError(
@@ -192,17 +233,30 @@ class AsyncVectorEnv(VectorEnv):
         self._state = AsyncState.WAITING_RESET
 
     def reset_wait(self, timeout=None):
-        """
+        """Wait for the calls to :obj:`reset` in each sub-environment to finish.
+
         Parameters
         ----------
         timeout : int or float, optional
-            Number of seconds before the call to `reset_wait` times out. If
-            `None`, the call to `reset_wait` never times out.
+            Number of seconds before the call to :meth:`reset_wait` times out.
+            If ``None``, the call to :meth:`reset_wait` never times out.
 
         Returns
         -------
-        observations : sample from `observation_space`
+        element of :attr:`~VectorEnv.observation_space`
             A batch of observations from the vectorized environment.
+
+        Raises
+        ------
+        ClosedEnvironmentError
+            If the environment was closed (if :meth:`close` was previously called).
+
+        NoAsyncCallError
+            If :meth:`reset_wait` was called without any prior call to
+            :meth:`reset_async`.
+
+        TimeoutError
+            If :meth:`reset_wait` timed out.
         """
         self._assert_is_running()
         if self._state != AsyncState.WAITING_RESET:
@@ -230,11 +284,23 @@ class AsyncVectorEnv(VectorEnv):
         return deepcopy(self.observations) if self.copy else self.observations
 
     def step_async(self, actions):
-        """
+        """Send the calls to :obj:`step` to each sub-environment.
+
         Parameters
         ----------
-        actions : iterable of samples from `action_space`
-            List of actions.
+        actions : element of :attr:`~VectorEnv.action_space`
+            Batch of actions.
+
+        Raises
+        ------
+        ClosedEnvironmentError
+            If the environment was closed (if :meth:`close` was previously called).
+
+        AlreadyPendingCallError
+            If the environment is already waiting for a pending call to another
+            method (e.g. :meth:`reset_async`). This can be caused by two consecutive
+            calls to :meth:`step_async`, with no call to :meth:`step_wait` in
+            between.
         """
         self._assert_is_running()
         if self._state != AsyncState.DEFAULT:
@@ -249,26 +315,39 @@ class AsyncVectorEnv(VectorEnv):
         self._state = AsyncState.WAITING_STEP
 
     def step_wait(self, timeout=None):
-        """
+        """Wait for the calls to :obj:`step` in each sub-environment to finish.
+
         Parameters
         ----------
         timeout : int or float, optional
-            Number of seconds before the call to `step_wait` times out. If
-            `None`, the call to `step_wait` never times out.
+            Number of seconds before the call to :meth:`step_wait` times out. If
+            ``None``, the call to :meth:`step_wait` never times out.
 
         Returns
         -------
-        observations : sample from `observation_space`
+        observations : element of :attr:`~VectorEnv.observation_space`
             A batch of observations from the vectorized environment.
 
-        rewards : `np.ndarray` instance (dtype `np.float_`)
+        rewards : :obj:`np.ndarray`, dtype :obj:`np.float_`
             A vector of rewards from the vectorized environment.
 
-        dones : `np.ndarray` instance (dtype `np.bool_`)
+        dones : :obj:`np.ndarray`, dtype :obj:`np.bool_`
             A vector whose entries indicate whether the episode has ended.
 
         infos : list of dict
-            A list of auxiliary diagnostic information.
+            A list of auxiliary diagnostic information dicts from sub-environments.
+
+        Raises
+        ------
+        ClosedEnvironmentError
+            If the environment was closed (if :meth:`close` was previously called).
+
+        NoAsyncCallError
+            If :meth:`step_wait` was called without any prior call to
+            :meth:`step_async`.
+
+        TimeoutError
+            If :meth:`step_wait` timed out.
         """
         self._assert_is_running()
         if self._state != AsyncState.WAITING_STEP:
@@ -302,17 +381,24 @@ class AsyncVectorEnv(VectorEnv):
         )
 
     def close_extras(self, timeout=None, terminate=False):
-        """
+        """Close the environments & clean up the extra resources
+        (processes and pipes).
+
         Parameters
         ----------
         timeout : int or float, optional
-            Number of seconds before the call to `close` times out. If `None`,
-            the call to `close` never times out. If the call to `close` times
-            out, then all processes are terminated.
+            Number of seconds before the call to :meth:`close` times out. If ``None``,
+            the call to :meth:`close` never times out. If the call to :meth:`close`
+            times out, then all processes are terminated.
 
-        terminate : bool (default: `False`)
-            If `True`, then the `close` operation is forced and all processes
+        terminate : bool
+            If ``True``, then the :meth:`close` operation is forced and all processes
             are terminated.
+
+        Raises
+        ------
+        TimeoutError
+            If :meth:`close` timed out.
         """
         timeout = 0 if terminate else timeout
         try:

--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -16,17 +16,37 @@ class SyncVectorEnv(VectorEnv):
     env_fns : iterable of callable
         Functions that create the environments.
 
-    observation_space : `gym.spaces.Space` instance, optional
-        Observation space of a single environment. If `None`, then the
+    observation_space : :class:`gym.spaces.Space`, optional
+        Observation space of a single environment. If ``None``, then the
         observation space of the first environment is taken.
 
-    action_space : `gym.spaces.Space` instance, optional
-        Action space of a single environment. If `None`, then the action space
+    action_space : :class:`gym.spaces.Space`, optional
+        Action space of a single environment. If ``None``, then the action space
         of the first environment is taken.
 
-    copy : bool (default: `True`)
-        If `True`, then the `reset` and `step` methods return a copy of the
-        observations.
+    copy : bool
+        If ``True``, then the :meth:`reset` and :meth:`step` methods return a
+        copy of the observations.
+
+    Raises
+    ------
+    RuntimeError
+        If the observation space of some sub-environment does not match
+        :obj:`observation_space` (or, by default, the observation space of
+        the first sub-environment).
+
+    Example
+    -------
+
+    .. code-block::
+
+        >>> env = gym.vector.SyncVectorEnv([
+        ...     lambda: gym.make("Pendulum-v0", g=9.81),
+        ...     lambda: gym.make("Pendulum-v0", g=1.62)
+        ... ])
+        >>> env.reset()
+        array([[-0.8286432 ,  0.5597771 ,  0.90249056],
+               [-0.85009176,  0.5266346 ,  0.60007906]], dtype=float32)
     """
 
     def __init__(self, env_fns, observation_space=None, action_space=None, copy=True):
@@ -96,6 +116,7 @@ class SyncVectorEnv(VectorEnv):
         )
 
     def close_extras(self, **kwargs):
+        """Close the environments."""
         [env.close() for env in self.envs]
 
     def _check_observation_spaces(self):

--- a/gym/vector/vector_env.py
+++ b/gym/vector/vector_env.py
@@ -22,10 +22,10 @@ class VectorEnv(gym.Env):
     num_envs : int
         Number of environments in the vectorized environment.
 
-    observation_space : `gym.spaces.Space` instance
+    observation_space : :class:`gym.spaces.Space`
         Observation space of a single environment.
 
-    action_space : `gym.spaces.Space` instance
+    action_space : :class:`gym.spaces.Space`
         Action space of a single environment.
     """
 
@@ -54,7 +54,7 @@ class VectorEnv(gym.Env):
 
         Returns
         -------
-        observations : sample from `observation_space`
+        element of :attr:`observation_space`
             A batch of observations from the vectorized environment.
         """
         self.reset_async()
@@ -71,18 +71,18 @@ class VectorEnv(gym.Env):
 
         Parameters
         ----------
-        actions : iterable of samples from `action_space`
-            List of actions.
+        actions : element of :attr:`action_space`
+            Batch of actions.
 
         Returns
         -------
-        observations : sample from `observation_space`
+        observations : element of :attr:`observation_space`
             A batch of observations from the vectorized environment.
 
-        rewards : `np.ndarray` instance (dtype `np.float_`)
+        rewards : :obj:`np.ndarray`, dtype :obj:`np.float_`
             A vector of rewards from the vectorized environment.
 
-        dones : `np.ndarray` instance (dtype `np.bool_`)
+        dones : :obj:`np.ndarray`, dtype :obj:`np.bool_`
             A vector whose entries indicate whether the episode has ended.
 
         infos : list of dict
@@ -121,15 +121,16 @@ class VectorEnv(gym.Env):
         self.closed = True
 
     def seed(self, seeds=None):
-        """
+        """Set the random seed in all sub-environments.
+
         Parameters
         ----------
         seeds : list of int, or int, optional
-            Random seed for each individual environment. If `seeds` is a list of
-            length `num_envs`, then the items of the list are chosen as random
-            seeds. If `seeds` is an int, then each environment uses the random
-            seed `seeds + n`, where `n` is the index of the environment (between
-            `0` and `num_envs - 1`).
+            Random seed for each sub-environment. If ``seeds`` is a list of
+            length ``num_envs``, then the items of the list are chosen as random
+            seeds. If ``seeds`` is an int, then each sub-environment uses the random
+            seed ``seeds + n``, where ``n`` is the index of the sub-environment
+            (between ``0`` and ``num_envs - 1``).
         """
         pass
 


### PR DESCRIPTION
- Add documentation for vectorized environments (in Sphinx style).
  - Includes documentation to get started with `gym.vector.make`, `AsyncVectorEnv`, and `SyncVectorEnv`
  - Includes documentation about intermediate (shared memory in `AsyncVectorEnv` and exception handling) and advanced (custom spaces) usages of vectorized environments.
  - Includes multiple example snippets.
- Minor fixes in the docstrings of `gym.vector.make`, `VectorEnv`, `AsyncVectorEnv`, and `SyncVectorEnv` for automatic generation of the API reference.