### PR TITLE
Add Algorithmic Environment documentation

### DIFF
--- a/docs/algorithmic.md
+++ b/docs/algorithmic.md
@@ -1,0 +1,41 @@
+# Algorithmic Environments
+
+The unique dependencies for this set of environments can be installed via:
+
+````bash
+pip install gym[algorithmic]
+````
+
+### Characteristics
+
+Algorithmic environments have the following traits in common:
+- A 1-d "input tape" or 2-d "input grid" of characters
+- A target string which is a deterministic function of the input characters
+
+Agents control a read head that moves over the input tape. Observations consist
+of the single character currently under the read head. The read head may fall
+off the end of the tape in any direction. When this happens, agents will observe
+a special blank character (with index=env.base) until they get back in bounds.
+
+### Actions
+Actions consist of 3 sub-actions:
+- Direction to move the read head (left or right, plus up and down for 2-d
+      envs)
+- Whether to write to the output tape
+- Which character to write (ignored if the above sub-action is 0)
+
+An episode ends when:
+- The agent writes the full target string to the output tape.
+- The agent writes an incorrect character.
+- The agent runs out the time limit. (Which is fairly conservative.)
+
+Reward schedule:
+- write a correct character: +1
+- write a wrong character: -.5
+- run out the clock: -1
+- otherwise: 0
+
+In the beginning, input strings will be fairly short. After an environment has
+been consistently solved over some window of episodes, the environment will
+increase the average length of generated strings. Typical env specs require
+leveling up many times to reach their reward threshold.

--- a/docs/algorithmic/copy.md
+++ b/docs/algorithmic/copy.md
@@ -1,0 +1,58 @@
+---
+action-type: "Discrete"
+title: "Copy"
+actions: Discrete
+agents: "1"
+manual-control: "Yes"
+action-shape: "(3,)"
+action-values: "[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]"
+observation-shape: "(1,)"
+observation-values: "(0,<a href="#base">base</a>)"
+average-total-reward: ""
+import: "from gym.algorithmic import Copy-v0"
+agent-labels: "none"
+---
+
+{% include info_box.md %}
+
+This task involves copying content from the input tape to the output tape. This task was originally used in the paper <a href="http://arxiv.org/abs/1511.07275">Learning Simple Algorithms from Examples</a>.
+
+The model has to learn: 
+- correspondence between input and output symbols.
+- executing the move right action on input tape.
+
+The agent take a 3-element vector for actions.
+The action space is `(x, w, v)`, where: 
+- `x` is used for left/right movement. It can take values (0,1).
+- `w` is used for writing to output tape or not. It can take values (0,1). 
+- `r` is used for selecting the value to be written on output tape.
+
+
+The observation space size is `(1,)` .
+
+**Rewards:**
+
+Rewards are issued similar to other Algorithmic Environments.Reward schedule:
+- write a correct character: +1
+- write a wrong character: -.5
+- run out the clock: -1
+- otherwise: 0
+
+### Manual Control
+
+TBD
+
+
+### Arguments
+
+```
+gym.make('Copy-v0', base=5, chars=True)
+```
+
+<a id="base">`base`</a>: Number of distinct characters to read/write.
+
+`chars`: If True, use uppercase alphabet. Otherwise, digits. Only affects rendering.
+
+### Version History
+
+* v0: Initial versions release (1.0.0)

--- a/docs/algorithmic/copy.md
+++ b/docs/algorithmic/copy.md
@@ -1,19 +1,9 @@
+Copy
 ---
-action-type: "Discrete"
-title: "Copy"
-actions: Discrete
-agents: "1"
-manual-control: "Yes"
-action-shape: "(3,)"
-action-values: "[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]"
-observation-shape: "(1,)"
-observation-values: "(0,<a href="#base">base</a>)"
-average-total-reward: ""
-import: "from gym.envs.algorithmic import copy_"
-agent-labels: "none"
+|Title|Action Type|Action Shape|Action Values|Observation Shape|Observation Values|Average Total Reward|Import|
+| ----------- | -----------| ----------- | -----------| ----------- | -----------| ----------- | -----------|
+|Copy|Discrete|(3,)|[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]|(1,)|(0,<a href="#base">base</a>)| |from gym.envs.algorithmic import copy_|
 ---
-
-{% include info_box.md %}
 
 This task involves copying content from the input tape to the output tape. This task was originally used in the paper <a href="http://arxiv.org/abs/1511.07275">Learning Simple Algorithms from Examples</a>.
 
@@ -37,11 +27,6 @@ Rewards are issued similar to other Algorithmic Environments. Reward schedule:
 - write a wrong character: -.5
 - run out the clock: -1
 - otherwise: 0
-
-### Manual Control
-
-TBD
-
 
 ### Arguments
 

--- a/docs/algorithmic/copy.md
+++ b/docs/algorithmic/copy.md
@@ -9,7 +9,7 @@ action-values: "[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]"
 observation-shape: "(1,)"
 observation-values: "(0,<a href="#base">base</a>)"
 average-total-reward: ""
-import: "from gym.algorithmic import Copy-v0"
+import: "from gym.envs.algorithmic import copy_"
 agent-labels: "none"
 ---
 
@@ -32,7 +32,7 @@ The observation space size is `(1,)` .
 
 **Rewards:**
 
-Rewards are issued similar to other Algorithmic Environments.Reward schedule:
+Rewards are issued similar to other Algorithmic Environments. Reward schedule:
 - write a correct character: +1
 - write a wrong character: -.5
 - run out the clock: -1

--- a/docs/algorithmic/duplicated_input.md
+++ b/docs/algorithmic/duplicated_input.md
@@ -1,0 +1,58 @@
+---
+action-type: "Discrete"
+title: "Duplicated Input"
+actions: Discrete
+agents: "1"
+manual-control: "Yes"
+action-shape: "(3,)"
+action-values: "[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]"
+observation-shape: "(1,)"
+observation-values: "(0,<a href="#base">base</a>)"
+average-total-reward: ""
+import: "from gym.algorithmic import DuplicatedInput-v0"
+agent-labels: "none"
+---
+
+{% include info_box.md %}
+
+Task is to return every nth (<a href="#dup">duplication</a>) character from the input tape. This task was originally used in the paper <a href="http://arxiv.org/abs/1511.07275">Learning Simple Algorithms from Examples</a>.
+
+The model has to learn: 
+- correspondence between input and output symbols.
+- executing the move right action on input tape.
+
+The agent take a 3-element vector for actions.
+The action space is `(x, w, v)`, where: 
+- `x` is used for left/right movement. It can take values (0,1).
+- `w` is used for writing to output tape or not. It can take values (0,1). 
+- `r` is used for selecting the value to be written on output tape.
+
+
+The observation space size is `(1,)` .
+
+**Rewards:**
+
+Rewards are issued similar to other Algorithmic Environments.Reward schedule:
+- write a correct character: +1
+- write a wrong character: -.5
+- run out the clock: -1
+- otherwise: 0
+
+### Manual Control
+
+TBD
+
+
+### Arguments
+
+```
+gym.make('DuplicatedInput-v0', base=5, duplication=2)
+```
+
+<a id="base">`base`</a>: Number of distinct characters to read/write.
+
+<a id="dup">`duplication`</a>: Number of similar characters that should be converted to a single character.
+
+### Version History
+
+* v0: Initial versions release (1.0.0)

--- a/docs/algorithmic/duplicated_input.md
+++ b/docs/algorithmic/duplicated_input.md
@@ -1,19 +1,9 @@
+Duplicated Input
 ---
-action-type: "Discrete"
-title: "Duplicated Input"
-actions: Discrete
-agents: "1"
-manual-control: "Yes"
-action-shape: "(3,)"
-action-values: "[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]"
-observation-shape: "(1,)"
-observation-values: "(0,<a href="#base">base</a>)"
-average-total-reward: ""
-import: "from gym.envs.algorithmic import duplicated_input"
-agent-labels: "none"
+|Title|Action Type|Action Shape|Action Values|Observation Shape|Observation Values|Average Total Reward|Import|
+| ----------- | -----------| ----------- | -----------| ----------- | -----------| ----------- | -----------|
+|Duplicated Input|Discrete|(3,)|[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]|(1,)|(0,<a href="#base">base</a>)| |from gym.envs.algorithmic import duplicated_input|
 ---
-
-{% include info_box.md %}
 
 Task is to return every nth (<a href="#dup">duplication</a>) character from the input tape. This task was originally used in the paper <a href="http://arxiv.org/abs/1511.07275">Learning Simple Algorithms from Examples</a>.
 
@@ -37,11 +27,6 @@ Rewards are issued similar to other Algorithmic Environments. Reward schedule:
 - write a wrong character: -.5
 - run out the clock: -1
 - otherwise: 0
-
-### Manual Control
-
-TBD
-
 
 ### Arguments
 

--- a/docs/algorithmic/duplicated_input.md
+++ b/docs/algorithmic/duplicated_input.md
@@ -9,7 +9,7 @@ action-values: "[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]"
 observation-shape: "(1,)"
 observation-values: "(0,<a href="#base">base</a>)"
 average-total-reward: ""
-import: "from gym.algorithmic import DuplicatedInput-v0"
+import: "from gym.envs.algorithmic import duplicated_input"
 agent-labels: "none"
 ---
 
@@ -32,7 +32,7 @@ The observation space size is `(1,)` .
 
 **Rewards:**
 
-Rewards are issued similar to other Algorithmic Environments.Reward schedule:
+Rewards are issued similar to other Algorithmic Environments. Reward schedule:
 - write a correct character: +1
 - write a wrong character: -.5
 - run out the clock: -1

--- a/docs/algorithmic/repeat_copy.md
+++ b/docs/algorithmic/repeat_copy.md
@@ -1,0 +1,58 @@
+---
+action-type: "Discrete"
+title: "Repeat Copy"
+actions: Discrete
+agents: "1"
+manual-control: "Yes"
+action-shape: "(3,)"
+action-values: "[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]"
+observation-shape: "(1,)"
+observation-values: "(0,<a href="#base">base</a>)"
+average-total-reward: ""
+import: "from gym.algorithmic import RepeatCopy-v0"
+agent-labels: "none"
+---
+
+{% include info_box.md %}
+
+This task involves copying content from the input tape to the output tape in normal order, reverse order and normal order, for example for input [x​1 x2​​ …xk] the required output is [x​1 x2​​ …xk xk …x2 x1 x​1 x2​​ …xk] . This task was originally used in the paper <a href="http://arxiv.org/abs/1511.07275">Learning Simple Algorithms from Examples</a>.
+
+The model has to learn: 
+- correspondence between input and output symbols.
+- executing the move left and right action on input tape.
+
+The agent take a 3-element vector for actions.
+The action space is `(x, w, v)`, where: 
+- `x` is used for left/right movement. It can take values (0,1).
+- `w` is used for writing to output tape or not. It can take values (0,1). 
+- `r` is used for selecting the value to be written on output tape.
+
+
+The observation space size is `(1,)` .
+
+**Rewards:**
+
+Rewards are issued similar to other Algorithmic Environments.Reward schedule:
+- write a correct character: +1
+- write a wrong character: -.5
+- run out the clock: -1
+- otherwise: 0
+
+### Manual Control
+
+TBA
+
+
+### Arguments
+
+```
+gym.make('RepeatCopy-v0', base=5)
+```
+
+<a id="base">`base`</a>: Number of distinct characters to read/write.
+
+
+
+### Version History
+
+* v0: Initial versions release (1.0.0)

--- a/docs/algorithmic/repeat_copy.md
+++ b/docs/algorithmic/repeat_copy.md
@@ -1,19 +1,11 @@
+Repeat Copy
 ---
-action-type: "Discrete"
-title: "Repeat Copy"
-actions: Discrete
-agents: "1"
-manual-control: "Yes"
-action-shape: "(3,)"
-action-values: "[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]"
-observation-shape: "(1,)"
-observation-values: "(0,<a href="#base">base</a>)"
-average-total-reward: ""
-import: "from gym.envs.algorithmic import repeat_copy"
-agent-labels: "none"
+|Title|Action Type|Action Shape|Action Values|Observation Shape|Observation Values|Average Total Reward|Import|
+| ----------- | -----------| ----------- | -----------| ----------- | -----------| ----------- | -----------|
+|Repeat Copy|Discrete|(3,)|[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]|(1,)|(0,<a href="#base">base</a>)| |from gym.envs.algorithmic import repeat_copy|
 ---
 
-{% include info_box.md %}
+
 
 This task involves copying content from the input tape to the output tape in normal order, reverse order and normal order, for example for input [x​1 x2​​ …xk] the required output is [x​1 x2​​ …xk xk …x2 x1 x​1 x2​​ …xk] . This task was originally used in the paper <a href="http://arxiv.org/abs/1511.07275">Learning Simple Algorithms from Examples</a>.
 
@@ -38,9 +30,6 @@ Rewards are issued similar to other Algorithmic Environments. Reward schedule:
 - run out the clock: -1
 - otherwise: 0
 
-### Manual Control
-
-TBA
 
 
 ### Arguments

--- a/docs/algorithmic/repeat_copy.md
+++ b/docs/algorithmic/repeat_copy.md
@@ -9,7 +9,7 @@ action-values: "[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]"
 observation-shape: "(1,)"
 observation-values: "(0,<a href="#base">base</a>)"
 average-total-reward: ""
-import: "from gym.algorithmic import RepeatCopy-v0"
+import: "from gym.envs.algorithmic import repeat_copy"
 agent-labels: "none"
 ---
 
@@ -32,7 +32,7 @@ The observation space size is `(1,)` .
 
 **Rewards:**
 
-Rewards are issued similar to other Algorithmic Environments.Reward schedule:
+Rewards are issued similar to other Algorithmic Environments. Reward schedule:
 - write a correct character: +1
 - write a wrong character: -.5
 - run out the clock: -1

--- a/docs/algorithmic/reverse.md
+++ b/docs/algorithmic/reverse.md
@@ -1,19 +1,9 @@
+Reverse
 ---
-action-type: "Discrete"
-title: "Reverse"
-actions: Discrete
-agents: "1"
-manual-control: "Yes"
-action-shape: "(3,)"
-action-values: "[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]"
-observation-shape: "(1,)"
-observation-values: "(0,<a href="#base">base</a>)"
-average-total-reward: ""
-import: "from gym.envs.algorithmic import reverse"
-agent-labels: "none"
+|Title|Action Type|Action Shape|Action Values|Observation Shape|Observation Values|Average Total Reward|Import|
+| ----------- | -----------| ----------- | -----------| ----------- | -----------| ----------- | -----------|
+|Reverse|Discrete|(3,)|[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]|(1,)|(0,<a href="#base">base</a>)| |from gym.envs.algorithmic import reverse|
 ---
-
-{% include info_box.md %}
 
 The goal is to reverse a sequence of symbols on the input tape. We provide a special character `r` to indicate the end of the sequence. The model must learn to move right multiple times until it hits the `r` symbol, then move to the left, copying the symbols to the output tape. This task was originally used in the paper <a href="http://arxiv.org/abs/1511.07275">Learning Simple Algorithms from Examples</a>.
 
@@ -37,11 +27,6 @@ Rewards are issued similar to other Algorithmic Environments. Reward schedule:
 - write a wrong character: -.5
 - run out the clock: -1
 - otherwise: 0
-
-### Manual Control
-
-TBA
-
 
 ### Arguments
 

--- a/docs/algorithmic/reverse.md
+++ b/docs/algorithmic/reverse.md
@@ -1,0 +1,56 @@
+---
+action-type: "Discrete"
+title: "Reverse"
+actions: Discrete
+agents: "1"
+manual-control: "Yes"
+action-shape: "(3,)"
+action-values: "[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]"
+observation-shape: "(1,)"
+observation-values: "(0,<a href="#base">base</a>)"
+average-total-reward: ""
+import: "from gym.algorithmic import Reverse-v0"
+agent-labels: "none"
+---
+
+{% include info_box.md %}
+
+The goal is to reverse a sequence of symbols on the input tape. We provide a special character `r` to indicate the end of the sequence. The model must learn to move right multiple times until it hits the `r` symbol, then move to the left, copying the symbols to the output tape. This task was originally used in the paper <a href="http://arxiv.org/abs/1511.07275">Learning Simple Algorithms from Examples</a>.
+
+The model has to learn: 
+- correspondence between input and output symbols.
+- executing the move left and right action on input tape.
+
+The agent take a 3-element vector for actions.
+The action space is `(x, w, v)`, where: 
+- `x` is used for left/right movement. It can take values (0,1).
+- `w` is used for writing to output tape or not. It can take values (0,1). 
+- `r` is used for selecting the value to be written on output tape.
+
+
+The observation space size is `(1,)` .
+
+**Rewards:**
+
+Rewards are issued similar to other Algorithmic Environments.Reward schedule:
+- write a correct character: +1
+- write a wrong character: -.5
+- run out the clock: -1
+- otherwise: 0
+
+### Manual Control
+
+TBA
+
+
+### Arguments
+
+```
+gym.make('Reverse-v0', base=2)
+```
+
+<a id="base">`base`</a>: Number of distinct characters to read/write.
+
+### Version History
+
+* v0: Initial versions release (1.0.0)

--- a/docs/algorithmic/reverse.md
+++ b/docs/algorithmic/reverse.md
@@ -9,7 +9,7 @@ action-values: "[(0, 1),(0,1),(0,<a href="#base">base</a>-1)]"
 observation-shape: "(1,)"
 observation-values: "(0,<a href="#base">base</a>)"
 average-total-reward: ""
-import: "from gym.algorithmic import Reverse-v0"
+import: "from gym.envs.algorithmic import reverse"
 agent-labels: "none"
 ---
 
@@ -32,7 +32,7 @@ The observation space size is `(1,)` .
 
 **Rewards:**
 
-Rewards are issued similar to other Algorithmic Environments.Reward schedule:
+Rewards are issued similar to other Algorithmic Environments. Reward schedule:
 - write a correct character: +1
 - write a wrong character: -.5
 - run out the clock: -1

--- a/docs/algorithmic/reversed_addition.md
+++ b/docs/algorithmic/reversed_addition.md
@@ -1,19 +1,9 @@
+Reversed Addition
 ---
-action-type: "Discrete"
-title: "Reversed Addition"
-actions: Discrete
-agents: "1"
-manual-control: "Yes"
-action-shape: "(3,)"
-action-values: "[(0,1,2,3),(0,1),(0,<a href="#base">base</a>-1)]"
-observation-shape: "(1,)"
-observation-values: "(0,<a href="#base">base</a>)"
-average-total-reward: ""
-import: "from gym.envs.algorithmic import reversed_addition" 
-agent-labels: "none"
+|Title|Action Type|Action Shape|Action Values|Observation Shape|Observation Values|Average Total Reward|Import|
+| ----------- | -----------| ----------- | -----------| ----------- | -----------| ----------- | -----------|
+|Reversed Addition|Discrete|(3,)|[(0,1,2,3),(0,1),(0,<a href="#base">base</a>-1)]|(1,)|(0,<a href="#base">base</a>)| |from gym.envs.algorithmic import reversed_addition|
 ---
-
-{% include info_box.md %}
 
 The goal is to add <a href="#rows">"rows"</a> number of multi-digit sequences, provided on an input grid. The sequences are provided in <a href="#rows">"rows"</a> number adjacent rows, with the right edges aligned. The initial position of the read head is the last digit of the top number (i.e. upper-right corner). This task was originally used in the paper <a href="http://arxiv.org/abs/1511.07275">Learning Simple Algorithms from Examples</a>.
 
@@ -38,11 +28,6 @@ Rewards are issued similar to other Algorithmic Environments. Reward schedule:
 - write a wrong character: -.5
 - run out the clock: -1
 - otherwise: 0
-
-### Manual Control
-
-TBA
-
 
 ### Arguments
 

--- a/docs/algorithmic/reversed_addition.md
+++ b/docs/algorithmic/reversed_addition.md
@@ -1,0 +1,61 @@
+---
+action-type: "Discrete"
+title: "Reversed Addition"
+actions: Discrete
+agents: "1"
+manual-control: "Yes"
+action-shape: "(3,)"
+action-values: "[(0,1,2,3),(0,1),(0,<a href="#base">base</a>-1)]"
+observation-shape: "(1,)"
+observation-values: "(0,<a href="#base">base</a>)"
+average-total-reward: ""
+import: "from gym.algorithmic import ReversedAddition-v0" or "from gym.algorithmic import ReversedAddition3-v0"
+agent-labels: "none"
+---
+
+{% include info_box.md %}
+
+The goal is to add <a href="#rows">"rows"</a> number of multi-digit sequences, provided on an input grid. The sequences are provided in <a href="#rows">"rows"</a> number adjacent rows, with the right edges aligned. The initial position of the read head is the last digit of the top number (i.e. upper-right corner). This task was originally used in the paper <a href="http://arxiv.org/abs/1511.07275">Learning Simple Algorithms from Examples</a>.
+
+The model has to: 
+- memorize an addition table for pairs of digits. 
+- learn how to move over the input grid.
+- discover the concept of a carry. 
+
+The agent take a 3-element vector for actions.
+The action space is `(x, w, v)`, where: 
+- `x` is used for direction of movement. It can take values (0,1,2,3).
+- `w` is used for writing to output tape or not. It can take values (0,1). 
+- `r` is used for selecting the value to be written on output tape.
+
+
+The observation space size is `(1,)` .
+
+**Rewards:**
+
+Rewards are issued similar to other Algorithmic Environments.Reward schedule:
+- write a correct character: +1
+- write a wrong character: -.5
+- run out the clock: -1
+- otherwise: 0
+
+### Manual Control
+
+TBA
+
+
+### Arguments
+
+```
+gym.make('ReversedAddition-v0', rows=2, base=3) #for ReversedAddition
+gym.make('ReversedAddition3-v0', rows=3, base=3) #for ReversedAddition3
+gym.make('ReversedAddition-v0', rows=n, base=3) #for ReversedAddition with n numbers
+```
+
+<a id="rows">`rows`</a>: Number of multi-digit sequences to add at a time.
+
+<a id="base">`base`</a>: Number of distinct characters to read/write.
+
+### Version History
+
+* v0: Initial versions release (1.0.0)

--- a/docs/algorithmic/reversed_addition.md
+++ b/docs/algorithmic/reversed_addition.md
@@ -9,7 +9,7 @@ action-values: "[(0,1,2,3),(0,1),(0,<a href="#base">base</a>-1)]"
 observation-shape: "(1,)"
 observation-values: "(0,<a href="#base">base</a>)"
 average-total-reward: ""
-import: "from gym.algorithmic import ReversedAddition-v0" or "from gym.algorithmic import ReversedAddition3-v0"
+import: "from gym.envs.algorithmic import reversed_addition" 
 agent-labels: "none"
 ---
 
@@ -33,7 +33,7 @@ The observation space size is `(1,)` .
 
 **Rewards:**
 
-Rewards are issued similar to other Algorithmic Environments.Reward schedule:
+Rewards are issued similar to other Algorithmic Environments. Reward schedule:
 - write a correct character: +1
 - write a wrong character: -.5
 - run out the clock: -1

--- a/docs/toy_text/blackjack.md
+++ b/docs/toy_text/blackjack.md
@@ -1,18 +1,9 @@
+Blackjack
 ---
-action-type: "Discrete"
-title: "Blackjack"
-actions: Discrete
-agents: "1"
-manual-control: "No -Env doesnt render"
-action-shape: "(1,)"
-action-values: "(0, 1)"
-observation-shape: "(3,)"
-observation-values: "[(0,31),(0,10),(0,1)]"
-average-total-reward: ""
-import: "from gym.toy_text import blackjack"
-agent-labels: "none"
+|Title|Action Type|Action Shape|Action Values|Observation Shape|Observation Values|Average Total Reward|Import|
+| ----------- | -----------| ----------- | -----------| ----------- | -----------| ----------- | -----------|
+|Blackjack|Discrete|(1,)|(0,1)|(3,)|[(0,31),(0,10),(0,1)]| |from gym.envs.toy_text import blackjack|
 ---
-
 
 Blackjack is a card game where the goal is to obtain cards that sum to as near as possible to 21 without going over.  They're playing against a fixed dealer.
 
@@ -55,11 +46,6 @@ Reward schedule:
     +1.5 (if <a href="#nat">natural</a> is True.) 
     
     +1 (if <a href="#nat">natural</a> is False.)
-
-### Manual Control
-
-TBD
-
 
 ### Arguments
 

--- a/docs/toy_text/blackjack.md
+++ b/docs/toy_text/blackjack.md
@@ -1,0 +1,74 @@
+---
+action-type: "Discrete"
+title: "Blackjack"
+actions: Discrete
+agents: "1"
+manual-control: "No -Env doesnt render"
+action-shape: "(1,)"
+action-values: "(0, 1)"
+observation-shape: "(3,)"
+observation-values: "[(0,31),(0,10),(0,1)]"
+average-total-reward: ""
+import: "from gym.toy_text import blackjack"
+agent-labels: "none"
+---
+
+
+Blackjack is a card game where the goal is to obtain cards that sum to as near as possible to 21 without going over.  They're playing against a fixed dealer.
+
+Card Values:
+
+- Face cards (Jack, Queen, King) have point value 10.
+- Aces can either count as 11 or 1, and it's called 'usable ace' at 11.
+- Numerical cards (2-9) have value of their number.
+
+This game is placed with an infinite deck (or with replacement).
+The game starts with dealer having one face up and one face down card, while player having two face up cards. 
+
+The player can request additional cards (hit, action=1) until they decide to stop
+(stick, action=0) or exceed 21 (bust).
+After the player sticks, the dealer reveals their facedown card, and draws
+until their sum is 17 or greater.  If the dealer goes bust the player wins.
+If neither player nor dealer busts, the outcome (win, lose, draw) is
+decided by whose sum is closer to 21.
+
+The agent take a 1-element vector for actions.
+The action space is `(action)`, where: 
+- `action` is used to decide stick/hit for values (0,1).
+
+The observation of a 3-tuple of: the players current sum,
+the dealer's one showing card (1-10 where 1 is ace), and whether or not the player holds a usable ace (0 or 1).
+
+This environment corresponds to the version of the blackjack problem
+described in Example 5.1 in Reinforcement Learning: An Introduction
+by Sutton and Barto.
+http://incompleteideas.net/book/the-book-2nd.html
+
+**Rewards:**
+
+Reward schedule:
+- win game: +1
+- lose game: -1
+- draw game: 0
+- win game with natural blackjack: 
+
+    +1.5 (if <a href="#nat">natural</a> is True.) 
+    
+    +1 (if <a href="#nat">natural</a> is False.)
+
+### Manual Control
+
+TBD
+
+
+### Arguments
+
+```
+gym.make('Blackjack-v0', natural=False)
+```
+
+<a id="nat">`natural`</a>: Whether to give an additional reward for starting with a natural blackjack, i.e. starting with an ace and ten (sum is 21).
+
+### Version History
+
+* v0: Initial versions release (1.0.0)

--- a/docs/toy_text/frozen_lake.md
+++ b/docs/toy_text/frozen_lake.md
@@ -1,0 +1,83 @@
+---
+action-type: "Discrete"
+title: "Frozen Lake"
+actions: Discrete
+agents: "1"
+manual-control: "Yes"
+action-shape: "(1,)"
+action-values: "(0,3)"
+observation-shape: "(1,)"
+observation-values: "(0,nrows*ncolumns),"
+average-total-reward: ""
+import: "from gym.toy_text import frozen_lake"
+agent-labels: "none"
+---
+
+
+Frozen lake involves crossing a frozen lake from Start(S) to goal(G) without falling into any holes(H). The agent may not always move in the intended direction due to the slippery nature of the frozen lake.
+
+The agent take a 1-element vector for actions.
+The action space is `(dir)`, where `dir` decides direction to move in which can be:
+
+- 0: LEFT
+- 1: DOWN
+- 2: RIGHT
+- 3: UP 
+
+The observation is a value representing the agents current position as
+
+    current_row * nrows + current_col
+
+**Rewards:**
+
+Reward schedule:
+- Reach goal(G): +1
+- Reach hole(H): 0
+
+### Manual Control
+
+TBD
+
+
+### Arguments
+
+```
+gym.make('FrozenLake-v0', desc=None,map_name="4x4", is_slippery=True)
+```
+
+`desc`: Used to specify custom map for frozen lake. For example,
+
+    desc=["SFFF", "FHFH", "FFFH", "HFFG"].
+
+`map_name`: ID to use any of the preloaded maps.
+
+    "4x4":[
+        "SFFF", 
+        "FHFH", 
+        "FFFH", 
+        "HFFG"
+        ]
+
+    "8x8": [
+        "SFFFFFFF",
+        "FFFFFFFF",
+        "FFFHFFFF",
+        "FFFFFHFF",
+        "FFFHFFFF",
+        "FHHFFFHF",
+        "FHFFHFHF",
+        "FFFHFFFG",
+    ]
+
+
+    
+
+`is_slippery`: True/False. If True will move in intended direction with probability of 1/3 else will move in either perpendicular direction with equal probability of 1/3 in both directions.
+
+    For example, if action is left and is_slippery is True, then:
+    - P(move left)=1/3
+    - P(move up)=1/3
+    - P(move down)=1/3 
+### Version History
+
+* v0: Initial versions release (1.0.0)

--- a/docs/toy_text/frozen_lake.md
+++ b/docs/toy_text/frozen_lake.md
@@ -1,16 +1,8 @@
+Frozen Lake
 ---
-action-type: "Discrete"
-title: "Frozen Lake"
-actions: Discrete
-agents: "1"
-manual-control: "Yes"
-action-shape: "(1,)"
-action-values: "(0,3)"
-observation-shape: "(1,)"
-observation-values: "(0,nrows*ncolumns),"
-average-total-reward: ""
-import: "from gym.toy_text import frozen_lake"
-agent-labels: "none"
+|Title|Action Type|Action Shape|Action Values|Observation Shape|Observation Values|Average Total Reward|Import|
+| ----------- | -----------| ----------- | -----------| ----------- | -----------| ----------- | -----------|
+|Frozen Lake|Discrete|(1,)|(0,3)|(1,)|(0,nrows*ncolumns)| |from gym.envs.toy_text import frozen_lake|
 ---
 
 
@@ -33,11 +25,6 @@ The observation is a value representing the agents current position as
 Reward schedule:
 - Reach goal(G): +1
 - Reach hole(H): 0
-
-### Manual Control
-
-TBD
-
 
 ### Arguments
 

--- a/docs/toy_text/guessing_game.md
+++ b/docs/toy_text/guessing_game.md
@@ -1,0 +1,59 @@
+---
+action-type: "Continuous"
+title: "Guessing Game"
+actions: Continuous
+agents: "1"
+manual-control: "No -Env doesnt render"
+action-shape: "(1,)"
+action-values: "(-10000, 10000)"
+observation-shape: "(1,)"
+observation-values: "(0,3)"
+average-total-reward: ""
+import: "from gym.toy_text import guessing_game"
+agent-labels: "none"
+---
+
+The object of the game is to guess within 1% of the randomly chosen number
+within 200 time steps.
+
+The agent take a 1-element vector for actions.
+The action space is `(action)`, where: 
+- `action` is the prediction of the agent.
+
+After each step the agent is provided with one of four possible observations
+which indicate where the guess is in relation to the randomly chosen number:
+
+- 0 - No guess yet submitted (only after reset)
+- 1 - Guess is lower than the target
+- 2 - Guess is equal to the target
+- 3 - Guess is higher than the target
+
+The episode terminates after the agent guesses within 1% of the target or
+200 steps have been taken.
+
+The agent will need to use a memory of previously submitted actions and observations in order to efficiently explore the available actions.
+The purpose is to have agents optimize their exploration parameters (e.g. how far to explore from previous actions) based on previous experience. Because the goal changes each episode a state-value or action-value function isn't able to provide any additional benefit apart from being able to tell whether to increase or decrease the next guess.
+
+The perfect agent would likely learn the bounds of the action space (without referring
+to them explicitly) and then follow binary tree style exploration towards to goal number
+
+**Rewards:**
+
+Reward schedule:
+- 0 if the agent's guess is outside of 1% of the target
+- 1 if the agent's guess is inside 1% of the target
+
+### Manual Control
+
+TBD
+
+
+### Arguments
+
+```
+gym.make('GuessingGame-v0' )
+```
+
+### Version History
+
+* v0: Initial versions release (1.0.0)

--- a/docs/toy_text/guessing_game.md
+++ b/docs/toy_text/guessing_game.md
@@ -1,16 +1,7 @@
----
-action-type: "Continuous"
-title: "Guessing Game"
-actions: Continuous
-agents: "1"
-manual-control: "No -Env doesnt render"
-action-shape: "(1,)"
-action-values: "(-10000, 10000)"
-observation-shape: "(1,)"
-observation-values: "(0,3)"
-average-total-reward: ""
-import: "from gym.toy_text import guessing_game"
-agent-labels: "none"
+Frozen Lake---
+|Title|Action Type|Action Shape|Action Values|Observation Shape|Observation Values|Average Total Reward|Import|
+| ----------- | -----------| ----------- | -----------| ----------- | -----------| ----------- | -----------|
+|Frozen Lake|Continuous|(1,)|(-10000, 10000)|(1,)|(0,3)| |from gym.envs.toy_text import guessing_game|
 ---
 
 The object of the game is to guess within 1% of the randomly chosen number
@@ -42,11 +33,6 @@ to them explicitly) and then follow binary tree style exploration towards to goa
 Reward schedule:
 - 0 if the agent's guess is outside of 1% of the target
 - 1 if the agent's guess is inside 1% of the target
-
-### Manual Control
-
-TBD
-
 
 ### Arguments
 

--- a/docs/toy_text/nchain.md
+++ b/docs/toy_text/nchain.md
@@ -1,0 +1,61 @@
+---
+action-type: "Discrete"
+title: "N Chain"
+actions: Discrete
+agents: "1"
+manual-control: "Yes"
+action-shape: "(1,)"
+action-values: "(0,1)"
+observation-shape: "(1,)"
+observation-values: "(0,4)"
+average-total-reward: ""
+import: "from gym.toy_text import nchain"
+agent-labels: "none"
+---
+
+
+This game presents moves along a linear chain of states, with two actions:
+
+- 0- forward, which moves along the chain but returns no reward
+- 1- backward, which returns to the beginning and has a small reward
+
+The end of the chain, however, presents a large reward, and by moving 'forward' at the end of the chain this large reward can be repeated.
+
+At each action, there is a small probability that the agent 'slips' and the opposite transition is instead taken.
+
+The observed state is the current state in the chain (0 to <a href="#n">n</a>-1).
+
+This environment is described in section 6.1 of:
+A Bayesian Framework for Reinforcement Learning by Malcolm Strens (2000)
+http://ceit.aut.ac.ir/~shiry/lecture/machine-learning/papers/BRL-2000.pdf
+
+**Rewards:**
+
+Reward schedule:
+- <a href="#small">small</a> - reward for performing backward action.
+- <a href="#large">large</a> - reward for reaching end of chain.
+
+### Manual Control
+
+TBD
+
+
+### Arguments
+
+```
+gym.make('NChain-v0', n=5, slip=0.2, small=2, large=10)
+```
+
+<a id="n">`n`</a>: Length of chain.
+
+`slip`: Probability of performing reverse action.
+
+<a id="small">`small`</a>: Reward for moving backwards.
+
+<a id="large">`large`</a>: Reward on reaching end of chain.
+
+
+
+### Version History
+
+* v0: Initial versions release (1.0.0)

--- a/docs/toy_text/nchain.md
+++ b/docs/toy_text/nchain.md
@@ -1,18 +1,9 @@
+NChain
 ---
-action-type: "Discrete"
-title: "N Chain"
-actions: Discrete
-agents: "1"
-manual-control: "Yes"
-action-shape: "(1,)"
-action-values: "(0,1)"
-observation-shape: "(1,)"
-observation-values: "(0,4)"
-average-total-reward: ""
-import: "from gym.toy_text import nchain"
-agent-labels: "none"
+|Title|Action Type|Action Shape|Action Values|Observation Shape|Observation Values|Average Total Reward|Import|
+| ----------- | -----------| ----------- | -----------| ----------- | -----------| ----------- | -----------|
+|NChain|Discrete|(1,)|(0,1)|(1,)|(0,4)| |from gym.envs.toy_text import nchain|
 ---
-
 
 This game presents moves along a linear chain of states, with two actions:
 
@@ -34,11 +25,6 @@ http://ceit.aut.ac.ir/~shiry/lecture/machine-learning/papers/BRL-2000.pdf
 Reward schedule:
 - <a href="#small">small</a> - reward for performing backward action.
 - <a href="#large">large</a> - reward for reaching end of chain.
-
-### Manual Control
-
-TBD
-
 
 ### Arguments
 

--- a/docs/toy_text/roulette.md
+++ b/docs/toy_text/roulette.md
@@ -1,0 +1,48 @@
+---
+action-type: "Discrete"
+title: "Roulette"
+actions: Discrete
+agents: "1"
+manual-control: "Yes"
+action-shape: "(1,)"
+action-values: "(0,1)"
+observation-shape: "(1,)"
+observation-values: "(0,4)"
+average-total-reward: ""
+import: "from gym.toy_text import roulette"
+agent-labels: "none"
+---
+
+
+The roulette wheel has <a href="#spots">spots</a> spots. If the bet is 0 and a 0 comes up,
+you win a reward of <a href="#spots">spots</a>-2. If the parity of your bet matches the parity
+of the spin, you win 1. Otherwise you receive a reward of -1.
+The long run reward for playing 0 should be -1/<a href="#spots">spots</a> for any state
+The last action (<a href="#spots">spots</a>+1) stops the rollout for a return of 0 (walking away)
+
+**Rewards:**
+
+Reward schedule:
+- <a href="#spots">spots</a>-2: reward for betting and landing a 0.
+- 1: reward for having same parity as landed number.
+- -1/<a href="#spots">spots</a>: long run reward for playing 0.
+
+
+### Manual Control
+
+TBD
+
+
+### Arguments
+
+```
+gym.make('Roulette-v0', spots=37)
+```
+
+<a id="spots">`spots`</a>: Number of spots on Roulette.
+
+
+
+### Version History
+
+* v0: Initial versions release (1.0.0)

--- a/docs/toy_text/roulette.md
+++ b/docs/toy_text/roulette.md
@@ -1,16 +1,8 @@
+Roulette
 ---
-action-type: "Discrete"
-title: "Roulette"
-actions: Discrete
-agents: "1"
-manual-control: "Yes"
-action-shape: "(1,)"
-action-values: "(0,1)"
-observation-shape: "(1,)"
-observation-values: "(0,4)"
-average-total-reward: ""
-import: "from gym.toy_text import roulette"
-agent-labels: "none"
+|Title|Action Type|Action Shape|Action Values|Observation Shape|Observation Values|Average Total Reward|Import|
+| ----------- | -----------| ----------- | -----------| ----------- | -----------| ----------- | -----------|
+|Roulette|Discrete|(1,)|(0,1)|(1,)|(0,4)| |from gym.envs.toy_text import roulette|
 ---
 
 
@@ -26,12 +18,6 @@ Reward schedule:
 - <a href="#spots">spots</a>-2: reward for betting and landing a 0.
 - 1: reward for having same parity as landed number.
 - -1/<a href="#spots">spots</a>: long run reward for playing 0.
-
-
-### Manual Control
-
-TBD
-
 
 ### Arguments
 

--- a/docs/toy_text/taxi.md
+++ b/docs/toy_text/taxi.md
@@ -1,0 +1,99 @@
+---
+action-type: "Discrete"
+title: "Taxi"
+actions: Discrete
+agents: "1"
+manual-control: "Yes"
+action-shape: "(1,)"
+action-values: "(0,5)"
+observation-shape: "(1,)"
+observation-values: "(0,499)"
+average-total-reward: ""
+import: "from gym.toy_text import taxi"
+agent-labels: "none"
+---
+
+The Taxi Problem
+from "Hierarchical Reinforcement Learning with the MAXQ Value Function Decomposition"
+
+by Tom Dietterich
+
+
+
+Description:
+
+There are four designated locations in the grid world indicated by R(ed), G(reen), Y(ellow), and B(lue). When the episode starts, the taxi starts off at a random square and the passenger is at a random location. The taxi drives to the passenger's location, picks up the passenger, drives to the passenger's destination (another one of the four specified locations), and then drops off the passenger. Once the passenger is dropped off, the episode ends.
+
+MAP:
+
+    +---------+
+    |R: | : :G|
+    | : | : : |
+    | : : : : |
+    | | : | : |
+    |Y| : |B: |
+    +---------+
+
+Actions:
+
+There are 6 discrete deterministic actions:
+- 0: move south
+- 1: move north
+- 2: move east
+- 3: move west
+- 4: pickup passenger
+- 5: drop off passenger
+
+Observations:
+
+There are 500 discrete states since there are 25 taxi positions, 5 possible locations of the passenger (including the case when the passenger is in the taxi), and 4 destination locations.
+
+Passenger locations:
+- 0: R(ed)
+- 1: G(reen)
+- 2: Y(ellow)
+- 3: B(lue)
+- 4: in taxi
+
+Destinations:
+- 0: R(ed)
+- 1: G(reen)
+- 2: Y(ellow)
+- 3: B(lue)
+
+
+
+**Rewards:**
+
+- -1 per step reward unless other reward is triggered.
+- +20 delivering passenger.
+- -10  executing "pickup" and "drop-off" actions illegally.
+
+
+Rendering:
+- blue: passenger
+- magenta: destination
+- yellow: empty taxi
+- green: full taxi
+- other letters (R, G, Y and B): locations for passengers and destinations
+state space is represented by:
+(taxi_row, taxi_col, passenger_location, destination)
+
+
+
+### Manual Control
+
+TBD
+
+
+### Arguments
+
+```
+gym.make('Taxi-v3')
+```
+
+
+
+### Version History
+
+* v0: Initial versions release (1.0.0)

--- a/docs/toy_text/taxi.md
+++ b/docs/toy_text/taxi.md
@@ -1,17 +1,10 @@
+Taxi
 ---
-action-type: "Discrete"
-title: "Taxi"
-actions: Discrete
-agents: "1"
-manual-control: "Yes"
-action-shape: "(1,)"
-action-values: "(0,5)"
-observation-shape: "(1,)"
-observation-values: "(0,499)"
-average-total-reward: ""
-import: "from gym.toy_text import taxi"
-agent-labels: "none"
+|Title|Action Type|Action Shape|Action Values|Observation Shape|Observation Values|Average Total Reward|Import|
+| ----------- | -----------| ----------- | -----------| ----------- | -----------| ----------- | -----------|
+|Taxi|Discrete|(1,)|(0,5)|(1,)|(0,499)| |from gym.envs.toy_text import taxi|
 ---
+
 
 The Taxi Problem
 from "Hierarchical Reinforcement Learning with the MAXQ Value Function Decomposition"
@@ -78,13 +71,6 @@ Rendering:
 - other letters (R, G, Y and B): locations for passengers and destinations
 state space is represented by:
 (taxi_row, taxi_col, passenger_location, destination)
-
-
-
-### Manual Control
-
-TBD
-
 
 ### Arguments
 


### PR DESCRIPTION
I have added the documentation for algorithmic environments present on OpenAI gym.

Please note Reversed_Addition and Reversed_Addition3 have a single file and can be varied by giving rows parameter values 2,3 respectively.

The following work is still pending:

*Create a new table format to accommodate hyperlinks for value ranges that use parameters defined in the class
*Add documentation for Manual Control section
*Compute Average Reward