### PR TITLE
Add LongiControl to third party environment list

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -414,3 +414,10 @@ Fork of gym-retro with additional games, states, scenarios, etc. Open to PRs of 
 Reinforcement learning environments for compiler optimization tasks, such as LLVM phase ordering, GCC flag tuning, and CUDA loop nest code generation.
 
 Learn more here: https://github.com/facebookresearch/CompilerGym
+
+### LongiControl
+
+An environment for the stochastic longitudinal control of an electric vehicle.
+It is intended to be a descriptive and comprehensible example for a continuous real-world problem within the field of autonomous driving.
+
+Learn more here: https://github.com/dynamik1703/gym_longicontrol


### PR DESCRIPTION
Hello! This adds [LongiControl](https://github.com/dynamik1703/gym_longicontrol), an environment for an easy to grasp challenge within the field of autonomous driving, to the list of third party environments.