### PR TITLE
Fix dtypes to be consistent with observation_space

### DIFF
--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -487,7 +487,7 @@ class BipedalWalker(gym.Env, EzPickle):
             done = True
         if pos[0] > (TERRAIN_LENGTH - TERRAIN_GRASS) * TERRAIN_STEP:
             done = True
-        return np.array(state), reward, done, {}
+        return np.array(state, dtype=np.float32), reward, done, {}
 
     def render(self, mode="human"):
         from gym.envs.classic_control import rendering

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -392,7 +392,7 @@ class CarRacing(gym.Env, EzPickle):
                 done = True
                 step_reward = -100
 
-        return self.state.astype(np.float32), step_reward, done, {}
+        return self.state, step_reward, done, {}
 
     def render(self, mode="human"):
         assert mode in ["human", "state_pixels", "rgb_array"]

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -392,7 +392,7 @@ class CarRacing(gym.Env, EzPickle):
                 done = True
                 step_reward = -100
 
-        return self.state, step_reward, done, {}
+        return self.state.astype(np.float32), step_reward, done, {}
 
     def render(self, mode="human"):
         assert mode in ["human", "state_pixels", "rgb_array"]

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -142,7 +142,7 @@ class CarRacing(gym.Env, EzPickle):
         )  # steer, gas, brake
 
         self.observation_space = spaces.Box(
-            low=0, high=255, shape=(STATE_H, STATE_W, 3), dtype=np.uint8
+            low=0, high=255, shape=(STATE_H, STATE_W, 3), dtype=np.float32
         )
 
     def seed(self, seed=None):
@@ -392,7 +392,7 @@ class CarRacing(gym.Env, EzPickle):
                 done = True
                 step_reward = -100
 
-        return self.state, step_reward, done, {}
+        return self.state.astype(np.float32), step_reward, done, {}
 
     def render(self, mode="human"):
         assert mode in ["human", "state_pixels", "rgb_array"]

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -102,7 +102,9 @@ class AcrobotEnv(core.Env):
         return [seed]
 
     def reset(self):
-        self.state = self.np_random.uniform(low=-0.1, high=0.1, size=(4,)).astype(np.float32)
+        self.state = self.np_random.uniform(low=-0.1, high=0.1, size=(4,)).astype(
+            np.float32
+        )
         return self._get_ob()
 
     def step(self, a):
@@ -139,7 +141,9 @@ class AcrobotEnv(core.Env):
 
     def _get_ob(self):
         s = self.state
-        return np.array([cos(s[0]), sin(s[0]), cos(s[1]), sin(s[1]), s[2], s[3]], dtype=np.float32)
+        return np.array(
+            [cos(s[0]), sin(s[0]), cos(s[1]), sin(s[1]), s[2], s[3]], dtype=np.float32
+        )
 
     def _terminal(self):
         s = self.state

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -102,7 +102,7 @@ class AcrobotEnv(core.Env):
         return [seed]
 
     def reset(self):
-        self.state = self.np_random.uniform(low=-0.1, high=0.1, size=(4,))
+        self.state = self.np_random.uniform(low=-0.1, high=0.1, size=(4,)).astype(np.float32)
         return self._get_ob()
 
     def step(self, a):
@@ -139,7 +139,7 @@ class AcrobotEnv(core.Env):
 
     def _get_ob(self):
         s = self.state
-        return np.array([cos(s[0]), sin(s[0]), cos(s[1]), sin(s[1]), s[2], s[3]])
+        return np.array([cos(s[0]), sin(s[0]), cos(s[1]), sin(s[1]), s[2], s[3]], dtype=np.float32)
 
     def _terminal(self):
         s = self.state

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -156,12 +156,12 @@ class CartPoleEnv(gym.Env):
             self.steps_beyond_done += 1
             reward = 0.0
 
-        return np.array(self.state), reward, done, {}
+        return np.array(self.state, dtype=np.float32), reward, done, {}
 
     def reset(self):
         self.state = self.np_random.uniform(low=-0.05, high=0.05, size=(4,))
         self.steps_beyond_done = None
-        return np.array(self.state)
+        return np.array(self.state, dtype=np.float32)
 
     def render(self, mode="human"):
         screen_width = 600

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -118,12 +118,12 @@ class Continuous_MountainCarEnv(gym.Env):
             reward = 100.0
         reward -= math.pow(action[0], 2) * 0.1
 
-        self.state = np.array([position, velocity])
+        self.state = np.array([position, velocity], dtype=np.float32)
         return self.state, reward, done, {}
 
     def reset(self):
         self.state = np.array([self.np_random.uniform(low=-0.6, high=-0.4), 0])
-        return np.array(self.state)
+        return np.array(self.state, dtype=np.float32)
 
     def _height(self, xs):
         return np.sin(3 * xs) * 0.45 + 0.55

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -96,11 +96,11 @@ class MountainCarEnv(gym.Env):
         reward = -1.0
 
         self.state = (position, velocity)
-        return np.array(self.state), reward, done, {}
+        return np.array(self.state, dtype=np.float32), reward, done, {}
 
     def reset(self):
         self.state = np.array([self.np_random.uniform(low=-0.6, high=-0.4), 0])
-        return np.array(self.state)
+        return np.array(self.state, dtype=np.float32)
 
     def _height(self, xs):
         return np.sin(3 * xs) * 0.45 + 0.55

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -59,7 +59,7 @@ class PendulumEnv(gym.Env):
 
     def _get_obs(self):
         theta, thetadot = self.state
-        return np.array([np.cos(theta), np.sin(theta), thetadot])
+        return np.array([np.cos(theta), np.sin(theta), thetadot], dtype=np.float32)
 
     def render(self, mode="human"):
         if self.viewer is None:

--- a/gym/envs/tests/test_envs.py
+++ b/gym/envs/tests/test_envs.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from gym import envs
 from gym.envs.tests.spec_list import spec_list
+from gym.spaces import Box
 from gym.utils.env_checker import check_env
 
 
@@ -26,9 +27,12 @@ def test_env(spec):
     act_space = env.action_space
     ob = env.reset()
     assert ob_space.contains(ob), "Reset observation: {!r} not in space".format(ob)
-    assert (
-        ob.dtype == ob_space.dtype
-    ), "Reset observation dtype: {}, expected: {}".format(ob.dtype, ob_space.dtype)
+    if isinstance(ob_space, Box):
+        # Only checking dtypes for Box spaces to avoid iterating through tuple entries
+        assert (
+            ob.dtype == ob_space.dtype
+        ), "Reset observation dtype: {}, expected: {}".format(ob.dtype, ob_space.dtype)
+
     a = act_space.sample()
     observation, reward, done, _info = env.step(a)
     assert ob_space.contains(observation), "Step observation: {!r} not in space".format(
@@ -36,9 +40,10 @@ def test_env(spec):
     )
     assert np.isscalar(reward), "{} is not a scalar for {}".format(reward, env)
     assert isinstance(done, bool), "Expected {} to be a boolean".format(done)
-    assert (
-        observation.dtype == ob_space.dtype
-    ), "Step observation dtype: {}, expected: {}".format(ob.dtype, ob_space.dtype)
+    if isinstance(ob_space, Box):
+        assert (
+            observation.dtype == ob_space.dtype
+        ), "Step observation dtype: {}, expected: {}".format(ob.dtype, ob_space.dtype)
 
     for mode in env.metadata.get("render.modes", []):
         env.render(mode=mode)

--- a/gym/envs/tests/test_envs.py
+++ b/gym/envs/tests/test_envs.py
@@ -26,7 +26,9 @@ def test_env(spec):
     act_space = env.action_space
     ob = env.reset()
     assert ob_space.contains(ob), "Reset observation: {!r} not in space".format(ob)
-    assert ob.dtype == ob_space.dtype
+    assert (
+        ob.dtype == ob_space.dtype
+    ), "Reset observation dtype: {}, expected: {}".format(ob.dtype, ob_space.dtype)
     a = act_space.sample()
     observation, reward, done, _info = env.step(a)
     assert ob_space.contains(observation), "Step observation: {!r} not in space".format(
@@ -34,8 +36,9 @@ def test_env(spec):
     )
     assert np.isscalar(reward), "{} is not a scalar for {}".format(reward, env)
     assert isinstance(done, bool), "Expected {} to be a boolean".format(done)
-    assert observation.dtype == ob_space.dtype
-
+    assert (
+        observation.dtype == ob_space.dtype
+    ), "Step observation dtype: {}, expected: {}".format(ob.dtype, ob_space.dtype)
 
     for mode in env.metadata.get("render.modes", []):
         env.render(mode=mode)

--- a/gym/envs/tests/test_envs.py
+++ b/gym/envs/tests/test_envs.py
@@ -26,6 +26,7 @@ def test_env(spec):
     act_space = env.action_space
     ob = env.reset()
     assert ob_space.contains(ob), "Reset observation: {!r} not in space".format(ob)
+    assert ob.dtype == ob_space.dtype
     a = act_space.sample()
     observation, reward, done, _info = env.step(a)
     assert ob_space.contains(observation), "Step observation: {!r} not in space".format(
@@ -33,6 +34,8 @@ def test_env(spec):
     )
     assert np.isscalar(reward), "{} is not a scalar for {}".format(reward, env)
     assert isinstance(done, bool), "Expected {} to be a boolean".format(done)
+    assert observation.dtype == ob_space.dtype
+
 
     for mode in env.metadata.get("render.modes", []):
         env.render(mode=mode)


### PR DESCRIPTION
As per Issue #2336, these environments now return float32 observations.

Environments affected: all Classic Control envs, and BipedalWalker (it got caught by tests)

I added tests to check for agreement between the `observation_space.dtype` and `obs.dtype` after a reset and a step, but only for Box spaces. My reasoning is that it covers probably 90% of observation spaces, and checking for (possibly nested?) Tuple/Dict spaces would be a whole bunch of extra logic within tests. This, however, would be automatically checked by `contains` if #2298 is resolved, but that'd be another PR.

Initially I also changed the dtype for Car Racing, but there `observation_space` indicates `uint8`, so while I'm willing to bet that everyone just casts it to a float anyways, it's consistent