### PR TITLE
Fix a RecordVideo bug

### DIFF
--- a/gym/wrappers/record_video.py
+++ b/gym/wrappers/record_video.py
@@ -32,7 +32,8 @@ class RecordVideo(gym.Wrapper):
 
     def reset(self, **kwargs):
         observations = super(RecordVideo, self).reset(**kwargs)
-        self.start_video_recorder()
+        if self._video_enabled():
+            self.start_video_recorder()
         return observations
 
     def start_video_recorder(self):
@@ -63,14 +64,15 @@ class RecordVideo(gym.Wrapper):
                     self.close_video_recorder()
             else:
                 if not self.is_vector_env:
-                    dones = [dones]
-                if dones[0]:
+                    if dones:
+                        self.close_video_recorder()
+                elif dones[0]:
                     self.close_video_recorder()
 
         elif self._video_enabled():
             self.start_video_recorder()
 
-        return observations, rewards, dones if self.is_vector_env else dones[0], infos
+        return observations, rewards, dones, infos
 
     def close_video_recorder(self) -> None:
         if self.recording:

--- a/gym/wrappers/test_record_video.py
+++ b/gym/wrappers/test_record_video.py
@@ -12,13 +12,15 @@ def test_record_video():
         env, "videos", record_video_trigger=lambda x: x % 100 == 0
     )
     env.reset()
-    for _ in range(200):
+    for _ in range(199):
         action = env.action_space.sample()
         _, _, done, _ = env.step(action)
         if done:
-            env.close()
-            break
+            env.reset()
+    env.close()
     assert os.path.isdir("videos")
+    mp4_files = [file for file in os.listdir("videos") if file.endswith(".mp4")]
+    assert len(mp4_files) == 2
     shutil.rmtree("videos")
 
 
@@ -28,23 +30,26 @@ def make_env(gym_id, seed):
         env.seed(seed)
         env.action_space.seed(seed)
         env.observation_space.seed(seed)
-        env = gym.wrappers.RecordVideo(
-            env, "videos", record_video_trigger=lambda x: x % 100 == 0
-        )
+        if seed == 1:
+            env = gym.wrappers.RecordVideo(
+                env, "videos", record_video_trigger=lambda x: x % 100 == 0
+            )
         return env
 
     return thunk
 
 
-def test_record_video_vector():
+def test_record_video_within_vector():
     envs = gym.vector.SyncVectorEnv([make_env("CartPole-v1", 1 + i) for i in range(2)])
     envs = gym.wrappers.RecordEpisodeStatistics(envs)
     envs.reset()
-    for i in range(100):
+    for i in range(199):
         _, _, _, infos = envs.step(envs.action_space.sample())
         for info in infos:
             if "episode" in info.keys():
                 print(f"i, episode_reward={info['episode']['r']}")
                 break
     assert os.path.isdir("videos")
+    mp4_files = [file for file in os.listdir("videos") if file.endswith(".mp4")]
+    assert len(mp4_files) == 2
     shutil.rmtree("videos")


### PR DESCRIPTION
Currently, the `RecordVideo`'s `record_video_trigger` won't work in the episodic case. In effect, it will record videos at every episode and your video folder would look like this:
<img width="261" alt="image" src="https://user-images.githubusercontent.com/5555347/130517053-f5112fbf-86dc-405f-8d96-cf0a89a9fb32.png">



This is because `self.start_video_recorder()` is called at every reset. This PR fixes this issue. By running either of the code below, you would get

<img width="258" alt="image" src="https://user-images.githubusercontent.com/5555347/130516970-b594af3c-a935-4759-bd79-0e9f706664be.png">


```python
import gym
env = gym.make("CartPole-v1")
env = gym.wrappers.RecordVideo(env, "videos", record_video_trigger=lambda x: x % 100 == 0)
observation = env.reset()
for _ in range(1000):
  env.render()
  action = env.action_space.sample() # your agent here (this takes random actions)
  observation, reward, done, info = env.step(action)

  if done:
    observation = env.reset()
env.close()
```

```python
import gym
from gym.vector import SyncVectorEnv as SyncVectorEnvBase
class SyncVectorEnv(SyncVectorEnvBase):
    def render(self, mode='human', close=False):
        return self.envs[0].render(mode)
envs = SyncVectorEnv([lambda: gym.make("CartPole-v1")])
envs = gym.wrappers.RecordEpisodeStatistics(envs)
envs = gym.wrappers.RecordVideo(envs, "videos", record_video_trigger=lambda x: x % 100 == 0)
envs.reset()
for i in range(1000):
    _, _, _, infos = envs.step(envs.action_space.sample())
    for info in infos:
        if "episode" in info.keys():
            print(f"i, episode_reward={info['episode']['r']}")
            break
```