### PR TITLE
Updated registration.py

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -1,7 +1,6 @@
 import re
 import copy
 import importlib
-import warnings
 
 from gym import error, logger
 
@@ -104,16 +103,6 @@ class EnvRegistry(object):
             logger.info("Making new env: %s", path)
         spec = self.spec(path)
         env = spec.make(**kwargs)
-        # We used to have people override _reset/_step rather than
-        # reset/step. Set _gym_disable_underscore_compat = True on
-        # your environment if you use these methods and don't want
-        # compatibility code to be invoked.
-        if (
-            hasattr(env, "_reset")
-            and hasattr(env, "_step")
-            and not getattr(env, "_gym_disable_underscore_compat", False)
-        ):
-            patch_deprecated_methods(env)
         if env.spec.max_episode_steps is not None:
             from gym.wrappers.time_limit import TimeLimit
 
@@ -125,11 +114,10 @@ class EnvRegistry(object):
 
     def spec(self, path):
         if ":" in path:
-            mod_name, _sep, id = path.partition(":")
+            mod_name, _, id = path.partition(":")
             try:
                 importlib.import_module(mod_name)
-            # catch ImportError for python2.7 compatibility
-            except ImportError:
+            except ModuleNotFoundError:
                 raise error.Error(
                     "A module ({}) was specified for the environment but was not found, make sure the package is installed with `pip install` before calling `gym.make()`".format(
                         mod_name
@@ -182,7 +170,7 @@ class EnvRegistry(object):
 
     def register(self, id, **kwargs):
         if id in self.env_specs:
-            raise error.Error("Cannot re-register id: {}".format(id))
+            logger.warn("Overriding environment {}".format(id))
         self.env_specs[id] = EnvSpec(id, **kwargs)
 
 
@@ -201,31 +189,3 @@ def make(id, **kwargs):
 def spec(id):
     return registry.spec(id)
 
-
-warn_once = True
-
-
-def patch_deprecated_methods(env):
-    """
-    Methods renamed from '_method' to 'method', render() no longer has 'close' parameter, close is a separate method.
-    For backward compatibility, this makes it possible to work with unmodified environments.
-    """
-    global warn_once
-    if warn_once:
-        logger.warn(
-            "Environment '%s' has deprecated methods '_step' and '_reset' rather than 'step' and 'reset'. Compatibility code invoked. Set _gym_disable_underscore_compat = True to disable this behavior."
-            % str(type(env))
-        )
-        warn_once = False
-    env.reset = env._reset
-    env.step = env._step
-    env.seed = env._seed
-
-    def render(mode):
-        return env._render(mode, close=False)
-
-    def close():
-        env._render("human", close=True)
-
-    env.render = render
-    env.close = close

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -188,4 +188,3 @@ def make(id, **kwargs):
 
 def spec(id):
     return registry.spec(id)
-


### PR DESCRIPTION
Changes:
Re-registering the same environment ID in using gym.register() now raises a warning instead of an exception  
Deprecate Python 2.7 by changing ImportError to ModuleNotFoundError  
Remove the deprecated _step, _reset, and render(close) methods (These have been deprecated since at least 2018, but not removed)

Please let me know if you would like me to remove any of these changes.  