### PR TITLE
change FrameStack wrapper to inherit from ObservationWrapper

### DIFF
--- a/gym/wrappers/frame_stack.py
+++ b/gym/wrappers/frame_stack.py
@@ -1,7 +1,7 @@
 from collections import deque
 import numpy as np
 from gym.spaces import Box
-from gym import Wrapper
+from gym import ObservationWrapper
 
 
 class LazyFrames(object):
@@ -60,7 +60,7 @@ class LazyFrames(object):
         return frame
 
 
-class FrameStack(Wrapper):
+class FrameStack(ObservationWrapper):
     r"""Observation wrapper that stacks the observations in a rolling manner.
 
     For example, if the number of stacks is 4, then the returned observation contains
@@ -107,16 +107,16 @@ class FrameStack(Wrapper):
             low=low, high=high, dtype=self.observation_space.dtype
         )
 
-    def _get_observation(self):
+    def observation(self):
         assert len(self.frames) == self.num_stack, (len(self.frames), self.num_stack)
         return LazyFrames(list(self.frames), self.lz4_compress)
 
     def step(self, action):
         observation, reward, done, info = self.env.step(action)
         self.frames.append(observation)
-        return self._get_observation(), reward, done, info
+        return self.observation(), reward, done, info
 
     def reset(self, **kwargs):
         observation = self.env.reset(**kwargs)
         [self.frames.append(observation) for _ in range(self.num_stack)]
-        return self._get_observation()
+        return self.observation()


### PR DESCRIPTION
This PR addresses #2102 by changing the base class of [`FrameStack`](https://github.com/openai/gym/blob/c4d0af393ef9fba641bd3ebbbf1f60d291c8475d/gym/wrappers/frame_stack.py#L58) to inherit from [`ObservationWrapper`](https://github.com/openai/gym/blob/c4d0af393ef9fba641bd3ebbbf1f60d291c8475d/gym/core.py#L262) instead of from [`Wrapper`](https://github.com/openai/gym/blob/c4d0af393ef9fba641bd3ebbbf1f60d291c8475d/gym/core.py#L201).

It is a small change, the `ObservationWrapper` requires that a `observation` method is defined which returns the observations from the environment, so renaming the existing `_get_observation` method and changing all references to it satisfied this requirement.