### PR TITLE
Add plugin system for third-party environments

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -1,4 +1,14 @@
-from gym.envs.registration import registry, register, make, spec
+from gym.envs.registration import (
+    registry,
+    register,
+    make,
+    spec,
+    load_plugins as _load_plugins,
+)
+
+# Hook to load plugins from entry points
+_load_plugins()
+
 
 # Classic
 # ----------------------------------------

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -1,6 +1,14 @@
 import re
+import sys
 import copy
 import importlib
+
+from contextlib import contextmanager
+
+if sys.version_info < (3, 8):
+    import importlib_metadata as metadata
+else:
+    import importlib.metadata as metadata
 
 from gym import error, logger
 
@@ -10,6 +18,9 @@ from gym import error, logger
 # 2016-10-31: We're experimentally expanding the environment ID format
 # to include an optional username.
 env_id_re = re.compile(r"^(?:[\w:-]+\/)?([\w:.-]+)-v(\d+)$")
+
+# Whitelist of plugins which can hook into the `gym.envs.internal` entry point.
+plugin_internal_whitelist = {"ale_py.gym"}
 
 
 def load(name):
@@ -95,6 +106,7 @@ class EnvRegistry(object):
 
     def __init__(self):
         self.env_specs = {}
+        self._ns = None
 
     def make(self, path, **kwargs):
         if len(kwargs) > 0:
@@ -169,9 +181,24 @@ class EnvRegistry(object):
                 raise error.UnregisteredEnv("No registered env with id: {}".format(id))
 
     def register(self, id, **kwargs):
+        if self._ns is not None:
+            if "/" in id:
+                namespace, id = id.split("/")
+                logger.warn(
+                    f"Custom namespace '{namespace}' is being overrode by namespace '{self._ns}'. "
+                    "If you are developing a plugin you shouldn't specify a namespace in `register` calls. "
+                    "The namespace is specified through the entry point key."
+                )
+            id = f"{self._ns}/{id}"
         if id in self.env_specs:
             logger.warn("Overriding environment {}".format(id))
         self.env_specs[id] = EnvSpec(id, **kwargs)
+
+    @contextmanager
+    def namespace(self, ns):
+        self._ns = ns
+        yield
+        self._ns = None
 
 
 # Have a global registry
@@ -188,3 +215,35 @@ def make(id, **kwargs):
 
 def spec(id):
     return registry.spec(id)
+
+
+@contextmanager
+def namespace(ns):
+    with registry.namespace(ns):
+        yield
+
+
+def load_plugins(
+    third_party_entry_point="gym.envs", internal_entry_point="gym.envs.internal"
+):
+    # Load third-party environments
+    for external in metadata.entry_points().get(third_party_entry_point, []):
+        if external.attr is not None:
+            raise error.Error(
+                "Gym environment plugins must specify a root module to load, not a function"
+            )
+        # Force namespace on all `register` calls for third-party envs
+        with namespace(external.name):
+            external.load()
+
+    # Load plugins which hook into `gym.envs.internal`
+    # These plugins must be in the whitelist defined at the top of this file
+    # We don't force a namespace on register calls in this module
+    for internal in metadata.entry_points().get(internal_entry_point, []):
+        if internal.module not in plugin_internal_whitelist:
+            continue
+        if external.attr is not None:
+            raise error.Error(
+                "Gym environment plugins must specify a root module to load, not a function"
+            )
+        internal.load()

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     install_requires=[
         "numpy>=1.18.0",
         "cloudpickle>=1.2.0",
+        "importlib_metadata>=4.8.1; python_version < '3.8'",
     ],
     extras_require=extras,
     package_data={


### PR DESCRIPTION
Most of the discussion is at https://github.com/openai/gym/issues/2345.

This is a reference implementation of this system. One major thing has changed from #2345. Instead of having a blank key for internal environments (which actually isn't possible), I have two entry points.

1) `gym.envs` for all third-party environments with strict namespacing imposed on registration.
2) `gym.envs.internal` for packages that are part of a whitelist (e.g., `ale-py`) which can register into the root namespace, i.e., there are no namespace restrictions imposed.

Thoughts?