### PR TITLE
bugfix Box.contains

### DIFF
--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -146,8 +146,8 @@ class Box(Space):
         return (
             np.can_cast(x.dtype, self.dtype)
             and x.shape == self.shape
-            and np.any(x >= self.low)
-            and np.any(x <= self.high)
+            and np.all(x >= self.low)
+            and np.all(x <= self.high)
         )
 
     def to_jsonable(self, sample_n):


### PR DESCRIPTION
As per @rohanb2018 's comment https://github.com/openai/gym/pull/2374#issuecomment-912101385; the `np.all` was (accidentally) changed to `np.any`; this PR reverts the change as it isn't what we want here.