### PR TITLE
Pass **kwargs in step() of env wrappers

### DIFF
--- a/gym/wrappers/atari_preprocessing.py
+++ b/gym/wrappers/atari_preprocessing.py
@@ -100,11 +100,11 @@ class AtariPreprocessing(gym.Wrapper):
             low=_low, high=_high, shape=_shape, dtype=_obs_dtype
         )
 
-    def step(self, action):
+    def step(self, action, **kwargs):
         R = 0.0
 
         for t in range(self.frame_skip):
-            _, reward, done, info = self.env.step(action)
+            _, reward, done, info = self.env.step(action, **kwargs)
             R += reward
             self.game_over = done
 

--- a/gym/wrappers/frame_stack.py
+++ b/gym/wrappers/frame_stack.py
@@ -111,8 +111,8 @@ class FrameStack(ObservationWrapper):
         assert len(self.frames) == self.num_stack, (len(self.frames), self.num_stack)
         return LazyFrames(list(self.frames), self.lz4_compress)
 
-    def step(self, action):
-        observation, reward, done, info = self.env.step(action)
+    def step(self, action, **kwargs):
+        observation, reward, done, info = self.env.step(action, **kwargs)
         self.frames.append(observation)
         return self.observation(), reward, done, info
 

--- a/gym/wrappers/monitor.py
+++ b/gym/wrappers/monitor.py
@@ -45,9 +45,9 @@ class Monitor(Wrapper):
             directory, video_callable, force, resume, write_upon_reset, uid, mode
         )
 
-    def step(self, action):
+    def step(self, action, **kwargs):
         self._before_step(action)
-        observation, reward, done, info = self.env.step(action)
+        observation, reward, done, info = self.env.step(action, **kwargs)
         done = self._after_step(observation, reward, done, info)
 
         return observation, reward, done, info

--- a/gym/wrappers/record_episode_statistics.py
+++ b/gym/wrappers/record_episode_statistics.py
@@ -24,9 +24,9 @@ class RecordEpisodeStatistics(gym.Wrapper):
         self.episode_lengths = np.zeros(self.num_envs, dtype=np.int32)
         return observations
 
-    def step(self, action):
+    def step(self, action, **kwargs):
         observations, rewards, dones, infos = super(RecordEpisodeStatistics, self).step(
-            action
+            action, **kwargs
         )
         self.episode_returns += rewards
         self.episode_lengths += 1

--- a/gym/wrappers/record_video.py
+++ b/gym/wrappers/record_video.py
@@ -82,8 +82,10 @@ class RecordVideo(gym.Wrapper):
         else:
             return self.episode_trigger(self.episode_id)
 
-    def step(self, action):
-        observations, rewards, dones, infos = super(RecordVideo, self).step(action)
+    def step(self, action, **kwargs):
+        observations, rewards, dones, infos = super(RecordVideo, self).step(
+            action, **kwargs
+        )
 
         # increment steps and episodes
         self.step_id += 1

--- a/gym/wrappers/time_aware_observation.py
+++ b/gym/wrappers/time_aware_observation.py
@@ -23,9 +23,9 @@ class TimeAwareObservation(ObservationWrapper):
     def observation(self, observation):
         return np.append(observation, self.t)
 
-    def step(self, action):
+    def step(self, action, **kwargs):
         self.t += 1
-        return super(TimeAwareObservation, self).step(action)
+        return super(TimeAwareObservation, self).step(action, **kwargs)
 
     def reset(self, **kwargs):
         self.t = 0

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -11,11 +11,11 @@ class TimeLimit(gym.Wrapper):
         self._max_episode_steps = max_episode_steps
         self._elapsed_steps = None
 
-    def step(self, action):
+    def step(self, action, **kwargs):
         assert (
             self._elapsed_steps is not None
         ), "Cannot call env.step() before calling reset()"
-        observation, reward, done, info = self.env.step(action)
+        observation, reward, done, info = self.env.step(action, **kwargs)
         self._elapsed_steps += 1
         if self._elapsed_steps >= self._max_episode_steps:
             info["TimeLimit.truncated"] = not done


### PR DESCRIPTION
I find myself inserting this key-word passing all the time into the step function of different gym.Wrapper's.
One particular use case: When using the FrameStack Wrapper for observation stacking on a custom PyBullet or MuJoCo env, it is often useful to pass arguments in the step function that enable specific logging code that should otherwise not be executed because it is very expensive (i.e. logging each simulation step, logging contact information...).