### PR TITLE
Changed .shape to be a property

### DIFF
--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -57,7 +57,7 @@ class Box(Space):
         if np.isscalar(high):
             high = np.full(shape, high, dtype=dtype)
 
-        self.shape = shape
+        self._shape = shape
         self.low = low
         self.high = high
 

--- a/gym/spaces/space.py
+++ b/gym/spaces/space.py
@@ -19,7 +19,7 @@ class Space(object):
     def __init__(self, shape=None, dtype=None):
         import numpy as np  # takes about 300-400ms to import, so we load lazily
 
-        self.shape = None if shape is None else tuple(shape)
+        self._shape = None if shape is None else tuple(shape)
         self.dtype = None if dtype is None else np.dtype(dtype)
         self._np_random = None
 
@@ -32,6 +32,11 @@ class Space(object):
             self.seed()
 
         return self._np_random
+
+    @property
+    def shape(self):
+        """Return the shape of the space as a nonchangeable property"""
+        return self._shape
 
     def sample(self):
         """Randomly sample an element of this space. Can be

--- a/gym/spaces/space.py
+++ b/gym/spaces/space.py
@@ -35,7 +35,7 @@ class Space(object):
 
     @property
     def shape(self):
-        """Return the shape of the space as a nonchangeable property"""
+        """Return the shape of the space as an immutable property"""
         return self._shape
 
     def sample(self):


### PR DESCRIPTION
In relation to issue #1880, it's similar (but not exactly the same) as what the OP there suggested. Basically the shape is now stored as `self._shape`, and has a `@property`-based getter. There is no setter, as changing the shape might also require changing `low` and `high`, and at that point it's probably better to just create a new object.

It shouldn't change the behavior at all, except that there's an exception thrown if someone tries to manually change `self.shape`. 

I opted for a `_name` naming because dunder methods (as suggested by OP) are typically reserved for other stuff.

It'd be good if there's another set of eyes to see if it for sure doesn't break anything. It's simple enough, and the tests (should) pass, but 