### PR TITLE
Provide old default kwargs to Atari environments

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -691,12 +691,19 @@ for game in [
             # mark it as nondeterministic.
             nondeterministic = True
 
+        default_kwargs = {
+            "game": game,
+            "obs_type": obs_type,
+            "repeat_action_probability": 0.0,
+            "full_action_space": False,
+            "frameskip": (2, 5),
+        }
+
         register(
             id="{}-v0".format(name),
             entry_point="ale_py.gym:ALGymEnv",
             kwargs={
-                "game": game,
-                "obs_type": obs_type,
+                **default_kwargs,
                 "repeat_action_probability": 0.25,
             },
             max_episode_steps=10000,
@@ -706,7 +713,7 @@ for game in [
         register(
             id="{}-v4".format(name),
             entry_point="ale_py.gym:ALGymEnv",
-            kwargs={"game": game, "obs_type": obs_type},
+            kwargs={**default_kwargs},
             max_episode_steps=100000,
             nondeterministic=nondeterministic,
         )
@@ -722,8 +729,7 @@ for game in [
             id="{}Deterministic-v0".format(name),
             entry_point="ale_py.gym:ALGymEnv",
             kwargs={
-                "game": game,
-                "obs_type": obs_type,
+                **default_kwargs,
                 "frameskip": frameskip,
                 "repeat_action_probability": 0.25,
             },
@@ -734,7 +740,7 @@ for game in [
         register(
             id="{}Deterministic-v4".format(name),
             entry_point="ale_py.gym:ALGymEnv",
-            kwargs={"game": game, "obs_type": obs_type, "frameskip": frameskip},
+            kwargs={**default_kwargs, "frameskip": frameskip},
             max_episode_steps=100000,
             nondeterministic=nondeterministic,
         )
@@ -743,8 +749,7 @@ for game in [
             id="{}NoFrameskip-v0".format(name),
             entry_point="ale_py.gym:ALGymEnv",
             kwargs={
-                "game": game,
-                "obs_type": obs_type,
+                **default_kwargs,
                 "frameskip": 1,
                 "repeat_action_probability": 0.25,
             },  # A frameskip of 1 means we get every frame
@@ -758,8 +763,7 @@ for game in [
             id="{}NoFrameskip-v4".format(name),
             entry_point="ale_py.gym:ALGymEnv",
             kwargs={
-                "game": game,
-                "obs_type": obs_type,
+                **default_kwargs,
                 "frameskip": 1,
             },  # A frameskip of 1 means we get every frame
             max_episode_steps=frameskip * 100000,

--- a/gym/envs/tests/test_atari_env_specs.py
+++ b/gym/envs/tests/test_atari_env_specs.py
@@ -1,0 +1,132 @@
+from gym.envs.registration import registry
+
+from itertools import product
+
+
+def test_ale_legacy_env_specs():
+    versions = ["-v0", "-v4"]
+    suffixes = ["", "NoFrameskip", "Deterministic"]
+    obs_types = ["", "-ram"]
+    games = [
+        "adventure",
+        "air_raid",
+        "alien",
+        "amidar",
+        "assault",
+        "asterix",
+        "asteroids",
+        "atlantis",
+        "bank_heist",
+        "battle_zone",
+        "beam_rider",
+        "berzerk",
+        "bowling",
+        "boxing",
+        "breakout",
+        "carnival",
+        "centipede",
+        "chopper_command",
+        "crazy_climber",
+        "defender",
+        "demon_attack",
+        "double_dunk",
+        "elevator_action",
+        "enduro",
+        "fishing_derby",
+        "freeway",
+        "frostbite",
+        "gopher",
+        "gravitar",
+        "hero",
+        "ice_hockey",
+        "jamesbond",
+        "journey_escape",
+        "kangaroo",
+        "krull",
+        "kung_fu_master",
+        "montezuma_revenge",
+        "ms_pacman",
+        "name_this_game",
+        "phoenix",
+        "pitfall",
+        "pong",
+        "pooyan",
+        "private_eye",
+        "qbert",
+        "riverraid",
+        "road_runner",
+        "robotank",
+        "seaquest",
+        "skiing",
+        "solaris",
+        "space_invaders",
+        "star_gunner",
+        "tennis",
+        "time_pilot",
+        "tutankham",
+        "up_n_down",
+        "venture",
+        "video_pinball",
+        "wizard_of_wor",
+        "yars_revenge",
+        "zaxxon",
+    ]
+
+    # Convert snake case to camel case
+    games = list(map(lambda x: x.title().replace("_", ""), games))
+    specs = list(map("".join, product(games, obs_types, suffixes, versions)))
+
+    """
+    defaults:
+        repeat_action_probability = 0.0
+        full_action_space = False
+        frameskip = (2, 5)
+        game = "Pong"
+        obs_type = "ram"
+        mode = None
+        difficulty = None
+
+    v0: repeat_action_probability = 0.25
+    v4: inherits defaults
+
+    -NoFrameskip: frameskip = 1
+    -Deterministic: frameskip = 4 or 3 for space_invaders
+    """
+    for spec in specs:
+        assert spec in registry.env_specs
+        kwargs = registry.env_specs[spec]._kwargs
+
+        # Assert necessary parameters are set
+        assert "frameskip" in kwargs
+        assert "game" in kwargs
+        assert "obs_type" in kwargs
+        assert "repeat_action_probability" in kwargs
+        assert "full_action_space" in kwargs
+
+        # Common defaults
+        assert kwargs["full_action_space"] is False
+        assert "mode" not in kwargs
+        assert "difficulty" not in kwargs
+
+        if "-ram" in spec:
+            assert kwargs["obs_type"] == "ram"
+        else:
+            assert kwargs["obs_type"] == "rgb"
+
+        if "NoFrameskip" in spec:
+            assert kwargs["frameskip"] == 1
+        elif "Deterministic" in spec:
+            assert isinstance(kwargs["frameskip"], int)
+            frameskip = 3 if "SpaceInvaders" in spec else 4
+            assert kwargs["frameskip"] == frameskip
+        else:
+            assert isinstance(kwargs["frameskip"], tuple) and kwargs["frameskip"] == (
+                2,
+                5,
+            )
+
+        assert spec.endswith("v0") or spec.endswith("v4")
+        if spec.endswith("v0"):
+            assert kwargs["repeat_action_probability"] == 0.25
+        elif spec.endswith("v4"):
+            assert kwargs["repeat_action_probability"] == 0.0


### PR DESCRIPTION
The default kwargs have changed in `ale-py` and I was under the impression that the old defaults were being registered properly. They weren't and this fixes the issue so that the old versions are equivalent to those used in `atari-py`. Thanks to @vwxyzjn for bringing this to my attention.