### PR TITLE
Env plugins, remove gym.envs.internal and replace with __internal__ key

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -3,11 +3,11 @@ from gym.envs.registration import (
     register,
     make,
     spec,
-    load_plugins as _load_plugins,
+    load_env_plugins as _load_env_plugins,
 )
 
 # Hook to load plugins from entry points
-_load_plugins()
+_load_env_plugins()
 
 
 # Classic


### PR DESCRIPTION
In the previous PR RE: the env plugin system, I think a design choice was made which doesn't make sense.

We should specify a function to execute, NOT a module to load. Creating modules is more of a pain when we a package maintainer could specify one module with multiple functions to call.

Secondly, we should remove the `gym.envs.internal` entry point and just have a special key of `__internal__`. This is much cleaner and doesn't require the use of an arbitrary key for `gym.envs.internal` that would never be used.

We also silently fail upon executing the plugin function so we don't crash Gym upon import.