### PR TITLE
Pendulum updates

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -42,7 +42,7 @@ register(
 )
 
 register(
-    id="Pendulum-v0",
+    id="Pendulum-v1",
     entry_point="gym.envs.classic_control:PendulumEnv",
     max_episode_steps=200,
 )

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -41,10 +41,7 @@ class PendulumEnv(gym.Env):
         self.last_u = u  # for rendering
         costs = angle_normalize(th) ** 2 + 0.1 * thdot ** 2 + 0.001 * (u ** 2)
 
-        newthdot = (
-            thdot
-            + (3 * g / (2 * l) * np.sin(th) + 3.0 / (m * l ** 2) * u) * dt
-        )
+        newthdot = thdot + (3 * g / (2 * l) * np.sin(th) + 3.0 / (m * l ** 2) * u) * dt
         newthdot = np.clip(newthdot, -self.max_speed, self.max_speed)
         newth = th + newthdot * dt
 

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -43,7 +43,7 @@ class PendulumEnv(gym.Env):
 
         newthdot = (
             thdot
-            + (-3 * g / (2 * l) * np.sin(th + np.pi) + 3.0 / (m * l ** 2) * u) * dt
+            + (3 * g / (2 * l) * np.sin(th) + 3.0 / (m * l ** 2) * u) * dt
         )
         newth = th + newthdot * dt
         newthdot = np.clip(newthdot, -self.max_speed, self.max_speed)

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -45,8 +45,8 @@ class PendulumEnv(gym.Env):
             thdot
             + (3 * g / (2 * l) * np.sin(th) + 3.0 / (m * l ** 2) * u) * dt
         )
-        newth = th + newthdot * dt
         newthdot = np.clip(newthdot, -self.max_speed, self.max_speed)
+        newth = th + newthdot * dt
 
         self.state = np.array([newth, newthdot])
         return self._get_obs(), -costs, False, {}

--- a/gym/wrappers/frame_stack.py
+++ b/gym/wrappers/frame_stack.py
@@ -64,7 +64,7 @@ class FrameStack(ObservationWrapper):
     r"""Observation wrapper that stacks the observations in a rolling manner.
 
     For example, if the number of stacks is 4, then the returned observation contains
-    the most recent 4 observations. For environment 'Pendulum-v0', the original observation
+    the most recent 4 observations. For environment 'Pendulum-v1', the original observation
     is an array with shape [3], so if we stack 4 observations, the processed observation
     has shape [4, 3].
 

--- a/gym/wrappers/test_frame_stack.py
+++ b/gym/wrappers/test_frame_stack.py
@@ -12,7 +12,7 @@ except ImportError:
     lz4 = None
 
 
-@pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v0", "Pong-v0"])
+@pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v1", "Pong-v0"])
 @pytest.mark.parametrize("num_stack", [2, 3, 4])
 @pytest.mark.parametrize(
     "lz4_compress",

--- a/gym/wrappers/test_record_episode_statistics.py
+++ b/gym/wrappers/test_record_episode_statistics.py
@@ -4,7 +4,7 @@ import gym
 from gym.wrappers import RecordEpisodeStatistics
 
 
-@pytest.mark.parametrize("env_id", ["CartPole-v0", "Pendulum-v0"])
+@pytest.mark.parametrize("env_id", ["CartPole-v0", "Pendulum-v1"])
 @pytest.mark.parametrize("deque_size", [2, 5])
 def test_record_episode_statistics(env_id, deque_size):
     env = gym.make(env_id)

--- a/gym/wrappers/test_rescale_action.py
+++ b/gym/wrappers/test_rescale_action.py
@@ -12,8 +12,8 @@ def test_rescale_action():
         env = RescaleAction(env, -1, 1)
     del env
 
-    env = gym.make("Pendulum-v0")
-    wrapped_env = RescaleAction(gym.make("Pendulum-v0"), -1, 1)
+    env = gym.make("Pendulum-v1")
+    wrapped_env = RescaleAction(gym.make("Pendulum-v1"), -1, 1)
 
     seed = 0
     env.seed(seed)

--- a/gym/wrappers/test_time_aware_observation.py
+++ b/gym/wrappers/test_time_aware_observation.py
@@ -4,7 +4,7 @@ import gym
 from gym.wrappers import TimeAwareObservation
 
 
-@pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v0"])
+@pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v1"])
 def test_time_aware_observation(env_id):
     env = gym.make(env_id)
     wrapped_env = TimeAwareObservation(env)

--- a/gym/wrappers/test_transform_observation.py
+++ b/gym/wrappers/test_transform_observation.py
@@ -6,7 +6,7 @@ import gym
 from gym.wrappers import TransformObservation
 
 
-@pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v0"])
+@pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v1"])
 def test_transform_observation(env_id):
     affine_transform = lambda x: 3 * x + 2
     env = gym.make(env_id)

--- a/gym/wrappers/test_transform_reward.py
+++ b/gym/wrappers/test_transform_reward.py
@@ -6,7 +6,7 @@ import gym
 from gym.wrappers import TransformReward
 
 
-@pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v0"])
+@pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v1"])
 def test_transform_reward(env_id):
     # use case #1: scale
     scales = [0.1, 200]


### PR DESCRIPTION
See Issue #2156

First change is using the identity that -sin(x + pi) = sin(x)

Second change is the fact that the angular velocity is clipped to the predefined range *before* being applied to the state of the environment. This way, we are guaranteed that the actual change of the angle between two consecutive timesteps will be constrained in the (-max_speed, max_speed) range. The change in the actual dynamics of the environment is minimal, but technically can be non-zero, so I bumped the version to Pendulum-v1.