### PR TITLE
Tests: don't use editable mode, use import-mode=append

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,4 @@ jobs:
              --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
              --tag gym-docker .
       - name: Run tests
-        run: docker run gym-docker pytest --forked
+        run: docker run gym-docker pytest --forked --import-mode=append

--- a/py.Dockerfile
+++ b/py.Dockerfile
@@ -15,6 +15,6 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mjpro150/bin
 COPY . /usr/local/gym/
 WORKDIR /usr/local/gym/
 
-RUN pip install -e .[nomujoco,accept-rom-license] && pip install -r test_requirements.txt
+RUN pip install .[nomujoco,accept-rom-license] && pip install -r test_requirements.txt
 
 ENTRYPOINT ["/usr/local/gym/bin/docker_entrypoint"]


### PR DESCRIPTION
Long story short, `ale-py` uses a namespace package of `gym.envs.atari` and namespace packages aren't supported by `setuptools` editable mode. This is being worked on with native editable support in `pip`. I don't know the reason for having our test Dockerfile install as editable, but this shouldn't matter.

We also have to use `--import-mode=append` so it'll pick up the installed package instead of the local `gym/` directory. We could also just change directories but this will work for now.