### PR TITLE
Better warning control

### DIFF
--- a/gym/__init__.py
+++ b/gym/__init__.py
@@ -1,8 +1,3 @@
-import distutils.version
-import os
-import sys
-import warnings
-
 from gym import error
 from gym.version import VERSION as __version__
 

--- a/gym/logger.py
+++ b/gym/logger.py
@@ -29,9 +29,17 @@ def info(msg, *args):
         print("%s: %s" % ("INFO", msg % args))
 
 
-def warn(msg, *args):
+def warn(msg, *args, category=None, stacklevel=1):
     if MIN_LEVEL <= WARN:
-        warnings.warn(colorize("%s: %s" % ("WARN", msg % args), "yellow"))
+        warnings.warn(
+            colorize("%s: %s" % ("WARN", msg % args), "yellow"),
+            category=category,
+            stacklevel=stacklevel + 1,
+        )
+
+
+def deprecation(msg, *args):
+    warn(msg, *args, category=DeprecationWarning, stacklevel=2)
 
 
 def error(msg, *args):

--- a/gym/logger.py
+++ b/gym/logger.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 
 from gym.utils import colorize
@@ -21,12 +22,12 @@ def set_level(level):
 
 def debug(msg, *args):
     if MIN_LEVEL <= DEBUG:
-        print("%s: %s" % ("DEBUG", msg % args))
+        print("%s: %s" % ("DEBUG", msg % args), file=sys.stderr)
 
 
 def info(msg, *args):
     if MIN_LEVEL <= INFO:
-        print("%s: %s" % ("INFO", msg % args))
+        print("%s: %s" % ("INFO", msg % args), file=sys.stderr)
 
 
 def warn(msg, *args, category=None, stacklevel=1):
@@ -44,7 +45,7 @@ def deprecation(msg, *args):
 
 def error(msg, *args):
     if MIN_LEVEL <= ERROR:
-        print(colorize("%s: %s" % ("ERROR", msg % args), "red"))
+        print(colorize("%s: %s" % ("ERROR", msg % args), "red"), file=sys.stderr)
 
 
 # DEPRECATED:

--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -1,5 +1,4 @@
 import numpy as np
-import warnings
 
 from .space import Space
 from gym import logger
@@ -140,7 +139,7 @@ class Box(Space):
 
     def contains(self, x):
         if not isinstance(x, np.ndarray):
-            warnings.warn("Casting input x to numpy array.")
+            logger.warn("Casting input x to numpy array.")
             x = np.asarray(x, dtype=self.dtype)
 
         return (

--- a/gym/spaces/multi_discrete.py
+++ b/gym/spaces/multi_discrete.py
@@ -1,5 +1,5 @@
 import numpy as np
-from gym.logger import warn
+from gym import logger
 from .space import Space
 from .discrete import Discrete
 
@@ -66,7 +66,7 @@ class MultiDiscrete(Space):
 
     def __len__(self):
         if self.nvec.ndim >= 2:
-            warn("Get length of a multi-dimensional MultiDiscrete space.")
+            logger.warn("Get length of a multi-dimensional MultiDiscrete space.")
         return len(self.nvec)
 
     def __eq__(self, other):

--- a/gym/utils/env_checker.py
+++ b/gym/utils/env_checker.py
@@ -10,11 +10,11 @@ Original Author: Justin Terry
 These projects are covered by the MIT License.
 """
 
-import warnings
 from typing import Union
 
 import gym
 import numpy as np
+from gym import logger
 from gym import spaces
 
 
@@ -32,7 +32,7 @@ def _check_image_input(observation_space: spaces.Box, key: str = "") -> None:
     when the observation is apparently an image.
     """
     if observation_space.dtype != np.uint8:
-        warnings.warn(
+        logger.warn(
             f"It seems that your observation {key} is an image but the `dtype` "
             "of your observation_space is not `np.uint8`. "
             "If your observation is not an image, we recommend you to flatten the observation "
@@ -40,7 +40,7 @@ def _check_image_input(observation_space: spaces.Box, key: str = "") -> None:
         )
 
     if np.any(observation_space.low != 0) or np.any(observation_space.high != 255):
-        warnings.warn(
+        logger.warn(
             f"It seems that your observation space {key} is an image but the "
             "upper and lower bounds are not in [0, 255]. "
             "Generally, CNN policies assume observations are within that range, "
@@ -55,13 +55,13 @@ def _check_nan(env: gym.Env, check_inf: bool = True) -> None:
         observation, reward, _, _ = env.step(action)
 
         if np.any(np.isnan(observation)):
-            warnings.warn("Encountered NaN value in observations.")
+            logger.warn("Encountered NaN value in observations.")
         if np.any(np.isnan(reward)):
-            warnings.warn("Encountered NaN value in rewards.")
+            logger.warn("Encountered NaN value in rewards.")
         if check_inf and np.any(np.isinf(observation)):
-            warnings.warn("Encountered inf value in observations.")
+            logger.warn("Encountered inf value in observations.")
         if check_inf and np.any(np.isinf(reward)):
-            warnings.warn("Encountered inf value in rewards.")
+            logger.warn("Encountered inf value in rewards.")
 
 
 def _check_obs(
@@ -106,22 +106,22 @@ def _check_box_obs(observation_space: spaces.Box, key: str = "") -> None:
         _check_image_input(observation_space)
 
     if len(observation_space.shape) not in [1, 3]:
-        warnings.warn(
+        logger.warn(
             f"Your observation {key} has an unconventional shape (neither an image, nor a 1D vector). "
             "We recommend you to flatten the observation "
             "to have only a 1D vector or use a custom policy to properly process the data."
         )
 
     if np.any(np.equal(observation_space.low, -np.inf)):
-        warnings.warn(
+        logger.warn(
             "Agent's minimum observation space value is -infinity. This is probably too low."
         )
     if np.any(np.equal(observation_space.high, np.inf)):
-        warnings.warn(
+        logger.warn(
             "Agent's maxmimum observation space value is infinity. This is probably too high"
         )
     if np.any(np.equal(observation_space.low, observation_space.high)):
-        warnings.warn("Agent's maximum and minimum observation space values are equal")
+        logger.warn("Agent's maximum and minimum observation space values are equal")
     if np.any(np.greater(observation_space.low, observation_space.high)):
         assert False, "Agent's minimum observation value is greater than it's maximum"
     if observation_space.low.shape != observation_space.shape:
@@ -136,15 +136,15 @@ def _check_box_obs(observation_space: spaces.Box, key: str = "") -> None:
 
 def _check_box_action(action_space: spaces.Box):
     if np.any(np.equal(action_space.low, -np.inf)):
-        warnings.warn(
+        logger.warn(
             "Agent's minimum action space value is -infinity. This is probably too low."
         )
     if np.any(np.equal(action_space.high, np.inf)):
-        warnings.warn(
+        logger.warn(
             "Agent's maxmimum action space value is infinity. This is probably too high"
         )
     if np.any(np.equal(action_space.low, action_space.high)):
-        warnings.warn("Agent's maximum and minimum action space values are equal")
+        logger.warn("Agent's maximum and minimum action space values are equal")
     if np.any(np.greater(action_space.low, action_space.high)):
         assert False, "Agent's minimum action value is greater than it's maximum"
     if action_space.low.shape != action_space.shape:
@@ -159,7 +159,7 @@ def _check_normalized_action(action_space: spaces.Box):
         or np.any(np.abs(action_space.low) > 1)
         or np.any(np.abs(action_space.high) > 1)
     ):
-        warnings.warn(
+        logger.warn(
             "We recommend you to use a symmetric and normalized Box action space (range=[-1, 1]) "
             "cf https://stable-baselines3.readthedocs.io/en/master/guide/rl_tips.html"
         )
@@ -264,7 +264,7 @@ def _check_render(
     render_modes = env.metadata.get("render.modes")
     if render_modes is None:
         if warn:
-            warnings.warn(
+            logger.warn(
                 "No render modes was declared in the environment "
                 " (env.metadata['render.modes'] is None or not defined), "
                 "you may have trouble when calling `.render()`"

--- a/gym/wrappers/monitor.py
+++ b/gym/wrappers/monitor.py
@@ -3,8 +3,6 @@ import os
 
 import numpy as np
 
-import gym
-import warnings
 from gym import Wrapper
 from gym import error, version, logger
 from gym.wrappers.monitoring import stats_recorder, video_recorder
@@ -28,7 +26,7 @@ class Monitor(Wrapper):
         mode=None,
     ):
         super(Monitor, self).__init__(env)
-        warnings.warn(
+        logger.deprecation(
             "The Monitor wrapper is being deprecated in favor of gym.wrappers.RecordVideo and gym.wrappers.RecordEpisodeStatistics (see https://github.com/openai/gym/issues/2297)"
         )
 

--- a/gym/wrappers/record_video.py
+++ b/gym/wrappers/record_video.py
@@ -1,8 +1,8 @@
 import os
 import gym
 from typing import Callable
-import warnings
 
+from gym import logger
 from gym.wrappers.monitoring import video_recorder
 
 
@@ -38,7 +38,7 @@ class RecordVideo(gym.Wrapper):
         self.video_folder = os.path.abspath(video_folder)
         # Create output folder if needed
         if os.path.isdir(self.video_folder):
-            warnings.warn(
+            logger.warn(
                 f"Overwriting existing videos at {self.video_folder} folder (try specifying a different `video_folder` for the `RecordVideo` wrapper if this is not desired)"
             )
         os.makedirs(self.video_folder, exist_ok=True)


### PR DESCRIPTION
Add `stacklevel` to `gym.logger.warn` to show the exact file name and line number.

Run the following example code:

```python
import numpy as np
from gym import spaces

space = spaces.Box(low=np.zeros(5, dtype=np.float128),
                   high=np.ones(5, dtype=np.float128),
                   dtype=np.float64)
```

The current warning (always `gym/gym/logger.py:34`):

```
/home/PanXuehai/Projects/gym/gym/logger.py:34: UserWarning: WARN: Box bound precision lowered by casting to float64
  warnings.warn(colorize("%s: %s" % ("WARN", msg % args), "yellow"))
```

In this PR, show the exact file name and line number (in this case `gym/spaces/box.py:74`)

```
/home/PanXuehai/Projects/gym/gym/spaces/box.py:74: UserWarning: WARN: Box bound precision lowered by casting to float64
  logger.warn(
```

The function `deprecation` is added for convenience. Such as could be used in PR #2422.