### PR TITLE
Add flappy-bird-gym to third party environments

### DIFF
--- a/docs/third_party_environments.md
+++ b/docs/third_party_environments.md
@@ -2,6 +2,12 @@
 
 ## Video Game Environments
 
+### flappy-bird-gym: A Flappy Bird environment for OpenAI Gym
+
+https://github.com/Talendar/flappy-bird-gym
+
+A simple environment for single-agent reinforcement learning algorithms on a clone of [Flappy Bird](https://en.wikipedia.org/wiki/Flappy_Bird), the hugely popular arcade-style mobile game. Both state and pixel observation environments are available.
+
 ### gym-derk: GPU accelerated MOBA environment
 
 https://gym.derkgame.com


### PR DESCRIPTION
This commit adds the [flappy-bird-gym](https://github.com/Talendar/flappy-bird-gym) package to `third_party_environments.md`. It's the first result on Google when searching for "flappy bird gym environment".