### PR TITLE
gym.spaces.Dict inherits from collections.abc.Mapping

### DIFF
--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -1,9 +1,9 @@
-from collections import OrderedDict
+from collections import OrderedDict, Mapping
 import numpy as np
 from .space import Space
 
 
-class Dict(Space):
+class Dict(Space, Mapping):
     """
     A dictionary of simpler spaces.
 
@@ -144,15 +144,3 @@ class Dict(Space):
                 entry[key] = value[i]
             ret.append(entry)
         return ret
-
-    def __eq__(self, other):
-        return isinstance(other, Dict) and self.spaces == other.spaces
-
-    def keys(self):
-        return self.spaces.keys()
-
-    def values(self):
-        return self.spaces.values()
-
-    def items(self):
-        return self.spaces.items()

--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -117,9 +117,6 @@ class Dict(Space, Mapping):
     def __len__(self):
         return len(self.spaces)
 
-    def __contains__(self, item):
-        return self.contains(item)
-
     def __repr__(self):
         return (
             "Dict("

--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -1,4 +1,5 @@
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
+from collections.abc import Mapping
 import numpy as np
 from .space import Space
 


### PR DESCRIPTION
It would be very convenient to have `gym.spaces.Dict` inheriting from `collections.abc.Mapping` so that it can be used in conjunction with [dmtree](https://github.com/deepmind/tree) to perform operations on complex spaces conveniently. It also simplifies the implementation which is good.

I just don't like the fact that the `__contains__` method behavior is not consistent with what it should be doing if it was a proper mapping but I don't think it is an issue.

Note that this patch is NOT removing any existing feature. So it should not break compatibility.