### PR TITLE
Remove python 3.6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To install the base Gym library, use `pip install gym`.
 
 This does not include dependencies for all families of environments (there's a massive number, and some can be problematic to install on certain systems). You can install these dependencies for one family like `pip install gym[atari]` or use `pip install gym[all]` to install all dependencies.
 
-We support Python 3.6, 3.7, 3.8 and 3.9 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
+We support Python 3.7, 3.8 and 3.9 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
 
 ## API
 

--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,9 @@ setup(
         ]
     },
     tests_require=["pytest", "mock"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
This should've been done sooner:

-Python 3.6 is EOL in about a month, Numpy etc. no longer support it
-ALE-Py has never supported Python 3.6 for technical reasons, leading to issues when people try to use Gym with it it
-Gym CI never tested on Python 3.6 either (this was an accident dating back to when I merged/closed 70 PRs in like one day)