### PR TITLE
Make AtariPreprocessing frameskip setting compatible with v5 envs.

### DIFF
--- a/gym/wrappers/atari_preprocessing.py
+++ b/gym/wrappers/atari_preprocessing.py
@@ -60,10 +60,14 @@ class AtariPreprocessing(gym.Wrapper):
         assert screen_size > 0
         assert noop_max >= 0
         if frame_skip > 1:
-            assert "NoFrameskip" in env.spec.id, (
-                "disable frame-skipping in the original env. for more than one"
-                " frame-skip as it will be done by the wrapper"
-            )
+            if (
+                "NoFrameskip" not in env.spec.id
+                and getattr(env.unwrapped, "_frameskip", None) != 1
+            ):
+                raise ValueError(
+                    "disable frame-skipping in the original env. Otherwise, more than one"
+                    " frame-skip will happen as through this wrapper"
+                )
         self.noop_max = noop_max
         assert env.unwrapped.get_action_meanings()[0] == "NOOP"
 


### PR DESCRIPTION
This makes the `frame_skip` (= action repeat) setting of the `AtariPreprocessing` wrapper compatible with the `ALE/*-v5` versions of the game.

The reason one might want to do that is that the wrapper applies random no-ops, which should happen at a low-level, before frame skipping.

The access to the private `_frameskip` is unfortunate but necessary with the current version of `atari-py`. If required, I can create a PR for the ALE repository that adds a `frameskip` `@property` to [AtariEnv](https://github.com/mgbellemare/Arcade-Learning-Environment/blob/8705b917e7bdadac133efe5069221ca060c49b31/src/gym/envs/atari/environment.py#L108)