### PR TITLE
Py36+ syntax in gym/envs: part of #2462

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -279,28 +279,28 @@ for reward_type in ["sparse", "dense"]:
 
     # Fetch
     register(
-        id="FetchSlide{}-v1".format(suffix),
+        id=f"FetchSlide{suffix}-v1",
         entry_point="gym.envs.robotics:FetchSlideEnv",
         kwargs=kwargs,
         max_episode_steps=50,
     )
 
     register(
-        id="FetchPickAndPlace{}-v1".format(suffix),
+        id=f"FetchPickAndPlace{suffix}-v1",
         entry_point="gym.envs.robotics:FetchPickAndPlaceEnv",
         kwargs=kwargs,
         max_episode_steps=50,
     )
 
     register(
-        id="FetchReach{}-v1".format(suffix),
+        id=f"FetchReach{suffix}-v1",
         entry_point="gym.envs.robotics:FetchReachEnv",
         kwargs=kwargs,
         max_episode_steps=50,
     )
 
     register(
-        id="FetchPush{}-v1".format(suffix),
+        id=f"FetchPush{suffix}-v1",
         entry_point="gym.envs.robotics:FetchPushEnv",
         kwargs=kwargs,
         max_episode_steps=50,
@@ -308,21 +308,21 @@ for reward_type in ["sparse", "dense"]:
 
     # Hand
     register(
-        id="HandReach{}-v0".format(suffix),
+        id=f"HandReach{suffix}-v0",
         entry_point="gym.envs.robotics:HandReachEnv",
         kwargs=kwargs,
         max_episode_steps=50,
     )
 
     register(
-        id="HandManipulateBlockRotateZ{}-v0".format(suffix),
+        id=f"HandManipulateBlockRotateZ{suffix}-v0",
         entry_point="gym.envs.robotics:HandBlockEnv",
         kwargs=_merge({"target_position": "ignore", "target_rotation": "z"}, kwargs),
         max_episode_steps=100,
     )
 
     register(
-        id="HandManipulateBlockRotateZTouchSensors{}-v0".format(suffix),
+        id=f"HandManipulateBlockRotateZTouchSensors{suffix}-v0",
         entry_point="gym.envs.robotics:HandBlockTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -336,7 +336,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulateBlockRotateZTouchSensors{}-v1".format(suffix),
+        id=f"HandManipulateBlockRotateZTouchSensors{suffix}-v1",
         entry_point="gym.envs.robotics:HandBlockTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -350,7 +350,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulateBlockRotateParallel{}-v0".format(suffix),
+        id=f"HandManipulateBlockRotateParallel{suffix}-v0",
         entry_point="gym.envs.robotics:HandBlockEnv",
         kwargs=_merge(
             {"target_position": "ignore", "target_rotation": "parallel"}, kwargs
@@ -359,7 +359,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulateBlockRotateParallelTouchSensors{}-v0".format(suffix),
+        id=f"HandManipulateBlockRotateParallelTouchSensors{suffix}-v0",
         entry_point="gym.envs.robotics:HandBlockTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -373,7 +373,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulateBlockRotateParallelTouchSensors{}-v1".format(suffix),
+        id=f"HandManipulateBlockRotateParallelTouchSensors{suffix}-v1",
         entry_point="gym.envs.robotics:HandBlockTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -387,14 +387,14 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulateBlockRotateXYZ{}-v0".format(suffix),
+        id=f"HandManipulateBlockRotateXYZ{suffix}-v0",
         entry_point="gym.envs.robotics:HandBlockEnv",
         kwargs=_merge({"target_position": "ignore", "target_rotation": "xyz"}, kwargs),
         max_episode_steps=100,
     )
 
     register(
-        id="HandManipulateBlockRotateXYZTouchSensors{}-v0".format(suffix),
+        id=f"HandManipulateBlockRotateXYZTouchSensors{suffix}-v0",
         entry_point="gym.envs.robotics:HandBlockTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -408,7 +408,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulateBlockRotateXYZTouchSensors{}-v1".format(suffix),
+        id=f"HandManipulateBlockRotateXYZTouchSensors{suffix}-v1",
         entry_point="gym.envs.robotics:HandBlockTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -422,7 +422,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulateBlockFull{}-v0".format(suffix),
+        id=f"HandManipulateBlockFull{suffix}-v0",
         entry_point="gym.envs.robotics:HandBlockEnv",
         kwargs=_merge({"target_position": "random", "target_rotation": "xyz"}, kwargs),
         max_episode_steps=100,
@@ -430,14 +430,14 @@ for reward_type in ["sparse", "dense"]:
 
     # Alias for "Full"
     register(
-        id="HandManipulateBlock{}-v0".format(suffix),
+        id=f"HandManipulateBlock{suffix}-v0",
         entry_point="gym.envs.robotics:HandBlockEnv",
         kwargs=_merge({"target_position": "random", "target_rotation": "xyz"}, kwargs),
         max_episode_steps=100,
     )
 
     register(
-        id="HandManipulateBlockTouchSensors{}-v0".format(suffix),
+        id=f"HandManipulateBlockTouchSensors{suffix}-v0",
         entry_point="gym.envs.robotics:HandBlockTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -451,7 +451,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulateBlockTouchSensors{}-v1".format(suffix),
+        id=f"HandManipulateBlockTouchSensors{suffix}-v1",
         entry_point="gym.envs.robotics:HandBlockTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -465,14 +465,14 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulateEggRotate{}-v0".format(suffix),
+        id=f"HandManipulateEggRotate{suffix}-v0",
         entry_point="gym.envs.robotics:HandEggEnv",
         kwargs=_merge({"target_position": "ignore", "target_rotation": "xyz"}, kwargs),
         max_episode_steps=100,
     )
 
     register(
-        id="HandManipulateEggRotateTouchSensors{}-v0".format(suffix),
+        id=f"HandManipulateEggRotateTouchSensors{suffix}-v0",
         entry_point="gym.envs.robotics:HandEggTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -486,7 +486,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulateEggRotateTouchSensors{}-v1".format(suffix),
+        id=f"HandManipulateEggRotateTouchSensors{suffix}-v1",
         entry_point="gym.envs.robotics:HandEggTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -500,7 +500,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulateEggFull{}-v0".format(suffix),
+        id=f"HandManipulateEggFull{suffix}-v0",
         entry_point="gym.envs.robotics:HandEggEnv",
         kwargs=_merge({"target_position": "random", "target_rotation": "xyz"}, kwargs),
         max_episode_steps=100,
@@ -508,14 +508,14 @@ for reward_type in ["sparse", "dense"]:
 
     # Alias for "Full"
     register(
-        id="HandManipulateEgg{}-v0".format(suffix),
+        id=f"HandManipulateEgg{suffix}-v0",
         entry_point="gym.envs.robotics:HandEggEnv",
         kwargs=_merge({"target_position": "random", "target_rotation": "xyz"}, kwargs),
         max_episode_steps=100,
     )
 
     register(
-        id="HandManipulateEggTouchSensors{}-v0".format(suffix),
+        id=f"HandManipulateEggTouchSensors{suffix}-v0",
         entry_point="gym.envs.robotics:HandEggTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -529,7 +529,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulateEggTouchSensors{}-v1".format(suffix),
+        id=f"HandManipulateEggTouchSensors{suffix}-v1",
         entry_point="gym.envs.robotics:HandEggTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -543,14 +543,14 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulatePenRotate{}-v0".format(suffix),
+        id=f"HandManipulatePenRotate{suffix}-v0",
         entry_point="gym.envs.robotics:HandPenEnv",
         kwargs=_merge({"target_position": "ignore", "target_rotation": "xyz"}, kwargs),
         max_episode_steps=100,
     )
 
     register(
-        id="HandManipulatePenRotateTouchSensors{}-v0".format(suffix),
+        id=f"HandManipulatePenRotateTouchSensors{suffix}-v0",
         entry_point="gym.envs.robotics:HandPenTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -564,7 +564,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulatePenRotateTouchSensors{}-v1".format(suffix),
+        id=f"HandManipulatePenRotateTouchSensors{suffix}-v1",
         entry_point="gym.envs.robotics:HandPenTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -578,7 +578,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulatePenFull{}-v0".format(suffix),
+        id=f"HandManipulatePenFull{suffix}-v0",
         entry_point="gym.envs.robotics:HandPenEnv",
         kwargs=_merge({"target_position": "random", "target_rotation": "xyz"}, kwargs),
         max_episode_steps=100,
@@ -586,14 +586,14 @@ for reward_type in ["sparse", "dense"]:
 
     # Alias for "Full"
     register(
-        id="HandManipulatePen{}-v0".format(suffix),
+        id=f"HandManipulatePen{suffix}-v0",
         entry_point="gym.envs.robotics:HandPenEnv",
         kwargs=_merge({"target_position": "random", "target_rotation": "xyz"}, kwargs),
         max_episode_steps=100,
     )
 
     register(
-        id="HandManipulatePenTouchSensors{}-v0".format(suffix),
+        id=f"HandManipulatePenTouchSensors{suffix}-v0",
         entry_point="gym.envs.robotics:HandPenTouchSensorsEnv",
         kwargs=_merge(
             {
@@ -607,7 +607,7 @@ for reward_type in ["sparse", "dense"]:
     )
 
     register(
-        id="HandManipulatePenTouchSensors{}-v1".format(suffix),
+        id=f"HandManipulatePenTouchSensors{suffix}-v1",
         entry_point="gym.envs.robotics:HandPenTouchSensorsEnv",
         kwargs=_merge(
             {

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -308,8 +308,8 @@ class BipedalWalker(gym.Env, EzPickle):
                 )
                 for a in range(5)
             ]
-            x1 = min([p[0] for p in poly])
-            x2 = max([p[0] for p in poly])
+            x1 = min(p[0] for p in poly)
+            x2 = max(p[0] for p in poly)
             self.cloud_poly.append((poly, x1, x2))
 
     def reset(self):
@@ -591,11 +591,11 @@ if __name__ == "__main__":
         s, r, done, info = env.step(a)
         total_reward += r
         if steps % 20 == 0 or done:
-            print("\naction " + str(["{:+0.2f}".format(x) for x in a]))
-            print("step {} total_reward {:+0.2f}".format(steps, total_reward))
-            print("hull " + str(["{:+0.2f}".format(x) for x in s[0:4]]))
-            print("leg0 " + str(["{:+0.2f}".format(x) for x in s[4:9]]))
-            print("leg1 " + str(["{:+0.2f}".format(x) for x in s[9:14]]))
+            print("\naction " + str([f"{x:+0.2f}" for x in a]))
+            print(f"step {steps} total_reward {total_reward:+0.2f}")
+            print("hull " + str([f"{x:+0.2f}" for x in s[0:4]]))
+            print("leg0 " + str([f"{x:+0.2f}" for x in s[4:9]]))
+            print("leg1 " + str([f"{x:+0.2f}" for x in s[9:14]]))
         steps += 1
 
         contact0 = s[8]

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -643,8 +643,8 @@ if __name__ == "__main__":
             s, r, done, info = env.step(a)
             total_reward += r
             if steps % 200 == 0 or done:
-                print("\naction " + str(["{:+0.2f}".format(x) for x in a]))
-                print("step {} total_reward {:+0.2f}".format(steps, total_reward))
+                print("\naction " + str([f"{x:+0.2f}" for x in a]))
+                print(f"step {steps} total_reward {total_reward:+0.2f}")
             steps += 1
             isopen = env.render()
             if done or restart or isopen == False:

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -265,10 +265,9 @@ class LunarLander(gym.Env, EzPickle):
         if self.continuous:
             action = np.clip(action, -1, +1).astype(np.float32)
         else:
-            assert self.action_space.contains(action), "%r (%s) invalid " % (
-                action,
-                type(action),
-            )
+            assert self.action_space.contains(
+                action
+            ), f"{action!r} ({type(action)}) invalid "
 
         # Engines
         tip = (math.sin(self.lander.angle), math.cos(self.lander.angle))
@@ -520,8 +519,8 @@ def demo_heuristic_lander(env, seed=None, render=False):
                 break
 
         if steps % 20 == 0 or done:
-            print("observations:", " ".join(["{:+0.2f}".format(x) for x in s]))
-            print("step {} total_reward {:+0.2f}".format(steps, total_reward))
+            print("observations:", " ".join([f"{x:+0.2f}" for x in s]))
+            print(f"step {steps} total_reward {total_reward:+0.2f}")
         steps += 1
         if done:
             break

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -101,7 +101,7 @@ class CartPoleEnv(gym.Env):
         return [seed]
 
     def step(self, action):
-        err_msg = "%r (%s) invalid" % (action, type(action))
+        err_msg = f"{action!r} ({type(action)}) invalid"
         assert self.action_space.contains(action), err_msg
 
         x, x_dot, theta, theta_dot = self.state

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 @author: Olivier Sigaud
 

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -79,10 +79,9 @@ class MountainCarEnv(gym.Env):
         return [seed]
 
     def step(self, action):
-        assert self.action_space.contains(action), "%r (%s) invalid" % (
-            action,
-            type(action),
-        )
+        assert self.action_space.contains(
+            action
+        ), f"{action!r} ({type(action)}) invalid"
 
         position, velocity = self.state
         velocity += (action - 1) * self.force + math.cos(3 * position) * (-self.gravity)

--- a/gym/envs/classic_control/rendering.py
+++ b/gym/envs/classic_control/rendering.py
@@ -55,9 +55,7 @@ def get_display(spec):
         return pyglet.canvas.Display(spec)
     else:
         raise error.Error(
-            "Invalid display specification: {}. (Must be a string like :0 or None.)".format(
-                spec
-            )
+            f"Invalid display specification: {spec}. (Must be a string like :0 or None.)"
         )
 
 
@@ -75,11 +73,11 @@ def get_window(width, height, display, **kwargs):
         display=display,
         config=config,
         context=context,
-        **kwargs
+        **kwargs,
     )
 
 
-class Viewer(object):
+class Viewer:
     def __init__(self, width, height, display=None):
         display = get_display(display)
 
@@ -192,7 +190,7 @@ def _add_attrs(geom, attrs):
         geom.set_linewidth(attrs["linewidth"])
 
 
-class Geom(object):
+class Geom:
     def __init__(self):
         self._color = Color((0, 0, 0, 1.0))
         self.attrs = [self._color]
@@ -214,7 +212,7 @@ class Geom(object):
         self._color.vec4 = (r, g, b, 1)
 
 
-class Attr(object):
+class Attr:
     def enable(self):
         raise NotImplementedError
 
@@ -400,7 +398,7 @@ class Image(Geom):
 # ================================================================
 
 
-class SimpleImageViewer(object):
+class SimpleImageViewer:
     def __init__(self, display=None, maxwidth=500):
         self.window = None
         self.isopen = False

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -49,7 +49,7 @@ class MujocoEnv(gym.Env):
         else:
             fullpath = os.path.join(os.path.dirname(__file__), "assets", model_path)
         if not path.exists(fullpath):
-            raise IOError("File %s does not exist" % fullpath)
+            raise OSError(f"File {fullpath} does not exist")
         self.frame_skip = frame_skip
         self.model = mujoco_py.load_model_from_path(fullpath)
         self.sim = mujoco_py.MjSim(self.model)

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -29,7 +29,7 @@ def load(name):
     return fn
 
 
-class EnvSpec(object):
+class EnvSpec:
     """A specification for a particular instance of the environment. Used
     to register the parameters for official evaluations.
 
@@ -75,9 +75,7 @@ class EnvSpec(object):
         """Instantiates an instance of the environment with appropriate kwargs"""
         if self.entry_point is None:
             raise error.Error(
-                "Attempting to make deprecated env {}. (HINT: is there a newer registered version of this env?)".format(
-                    self.id
-                )
+                f"Attempting to make deprecated env {self.id}. (HINT: is there a newer registered version of this env?)"
             )
 
         _kwargs = self._kwargs.copy()
@@ -105,10 +103,10 @@ class EnvSpec(object):
         return env
 
     def __repr__(self):
-        return "EnvSpec({})".format(self.id)
+        return f"EnvSpec({self.id})"
 
 
-class EnvRegistry(object):
+class EnvRegistry:
     """Register an env by ID. IDs remain stable over time and are
     guaranteed to resolve to the same environment dynamics (or be
     desupported). The goal is that results on a particular environment
@@ -183,9 +181,7 @@ class EnvRegistry(object):
             ]
             if matching_envs:
                 raise error.DeprecatedEnv(
-                    "Env {} not found (valid versions include {})".format(
-                        id, matching_envs
-                    )
+                    f"Env {id} not found (valid versions include {matching_envs})"
                 )
             elif env_name in algorithmic_envs:
                 raise error.UnregisteredEnv(
@@ -200,7 +196,7 @@ class EnvRegistry(object):
                     )
                 )
             else:
-                raise error.UnregisteredEnv("No registered env with id: {}".format(id))
+                raise error.UnregisteredEnv(f"No registered env with id: {id}")
 
     def register(self, id, **kwargs):
         if self._ns is not None:
@@ -213,7 +209,7 @@ class EnvRegistry(object):
                 )
             id = f"{self._ns}/{id}"
         if id in self.env_specs:
-            logger.warn("Overriding environment {}".format(id))
+            logger.warn(f"Overriding environment {id}")
         self.env_specs[id] = EnvSpec(id, **kwargs)
 
     @contextlib.contextmanager

--- a/gym/envs/robotics/fetch_env.py
+++ b/gym/envs/robotics/fetch_env.py
@@ -52,7 +52,7 @@ class FetchEnv(robot_env.RobotEnv):
         self.distance_threshold = distance_threshold
         self.reward_type = reward_type
 
-        super(FetchEnv, self).__init__(
+        super().__init__(
             model_path=model_path,
             n_substeps=n_substeps,
             n_actions=4,
@@ -227,4 +227,4 @@ class FetchEnv(robot_env.RobotEnv):
             self.height_offset = self.sim.data.get_site_xpos("object0")[2]
 
     def render(self, mode="human", width=500, height=500):
-        return super(FetchEnv, self).render(mode, width, height)
+        return super().render(mode, width, height)

--- a/gym/envs/robotics/hand/manipulate.py
+++ b/gym/envs/robotics/hand/manipulate.py
@@ -196,7 +196,7 @@ class ManipulateEnv(hand_env.HandEnv):
                 pass
             else:
                 raise error.Error(
-                    'Unknown target_rotation option "{}".'.format(self.target_rotation)
+                    f'Unknown target_rotation option "{self.target_rotation}".'
                 )
 
         # Randomize initial position.
@@ -238,7 +238,7 @@ class ManipulateEnv(hand_env.HandEnv):
             target_pos = self.sim.data.get_joint_qpos("object:joint")[:3]
         else:
             raise error.Error(
-                'Unknown target_position option "{}".'.format(self.target_position)
+                f'Unknown target_position option "{self.target_position}".'
             )
         assert target_pos is not None
         assert target_pos.shape == (3,)
@@ -265,7 +265,7 @@ class ManipulateEnv(hand_env.HandEnv):
             target_quat = self.sim.data.get_joint_qpos("object:joint")
         else:
             raise error.Error(
-                'Unknown target_rotation option "{}".'.format(self.target_rotation)
+                f'Unknown target_rotation option "{self.target_rotation}".'
             )
         assert target_quat is not None
         assert target_quat.shape == (4,)

--- a/gym/envs/robotics/hand/manipulate_touch_sensors.py
+++ b/gym/envs/robotics/hand/manipulate_touch_sensors.py
@@ -106,7 +106,7 @@ class ManipulateTouchSensorsEnv(manipulate.ManipulateEnv):
         )
 
     def _render_callback(self):
-        super(ManipulateTouchSensorsEnv, self)._render_callback()
+        super()._render_callback()
         if self.touch_visualisation == "on_touch":
             for touch_sensor_id, site_id in self._touch_sensor_id_site_id:
                 if self.sim.data.sensordata[touch_sensor_id] != 0.0:

--- a/gym/envs/robotics/hand/reach.py
+++ b/gym/envs/robotics/hand/reach.py
@@ -146,14 +146,14 @@ class HandReachEnv(hand_env.HandEnv, utils.EzPickle):
         sites_offset = (self.sim.data.site_xpos - self.sim.model.site_pos).copy()
         goal = self.goal.reshape(5, 3)
         for finger_idx in range(5):
-            site_name = "target{}".format(finger_idx)
+            site_name = f"target{finger_idx}"
             site_id = self.sim.model.site_name2id(site_name)
             self.sim.model.site_pos[site_id] = goal[finger_idx] - sites_offset[site_id]
 
         # Visualize finger positions.
         achieved_goal = self._get_achieved_goal().reshape(5, 3)
         for finger_idx in range(5):
-            site_name = "finger{}".format(finger_idx)
+            site_name = f"finger{finger_idx}"
             site_id = self.sim.model.site_name2id(site_name)
             self.sim.model.site_pos[site_id] = (
                 achieved_goal[finger_idx] - sites_offset[site_id]

--- a/gym/envs/robotics/hand_env.py
+++ b/gym/envs/robotics/hand_env.py
@@ -12,7 +12,7 @@ class HandEnv(robot_env.RobotEnv):
     def __init__(self, model_path, n_substeps, initial_qpos, relative_control):
         self.relative_control = relative_control
 
-        super(HandEnv, self).__init__(
+        super().__init__(
             model_path=model_path,
             n_substeps=n_substeps,
             n_actions=20,
@@ -34,11 +34,9 @@ class HandEnv(robot_env.RobotEnv):
                     self.sim.model.actuator_names[i].replace(":A_", ":")
                 )
             for joint_name in ["FF", "MF", "RF", "LF"]:
-                act_idx = self.sim.model.actuator_name2id(
-                    "robot0:A_{}J1".format(joint_name)
-                )
+                act_idx = self.sim.model.actuator_name2id(f"robot0:A_{joint_name}J1")
                 actuation_center[act_idx] += self.sim.data.get_joint_qpos(
-                    "robot0:{}J0".format(joint_name)
+                    f"robot0:{joint_name}J0"
                 )
         else:
             actuation_center = (ctrlrange[:, 1] + ctrlrange[:, 0]) / 2.0
@@ -57,4 +55,4 @@ class HandEnv(robot_env.RobotEnv):
         self.viewer.cam.elevation = -25.0
 
     def render(self, mode="human", width=500, height=500):
-        return super(HandEnv, self).render(mode, width, height)
+        return super().render(mode, width, height)

--- a/gym/envs/robotics/robot_env.py
+++ b/gym/envs/robotics/robot_env.py
@@ -25,7 +25,7 @@ class RobotEnv(gym.GoalEnv):
         else:
             fullpath = os.path.join(os.path.dirname(__file__), "assets", model_path)
         if not os.path.exists(fullpath):
-            raise IOError("File {} does not exist".format(fullpath))
+            raise OSError(f"File {fullpath} does not exist")
 
         model = mujoco_py.load_model_from_path(fullpath)
         self.sim = mujoco_py.MjSim(model, nsubsteps=n_substeps)
@@ -89,7 +89,7 @@ class RobotEnv(gym.GoalEnv):
         # Gimbel lock) or we may not achieve an initial condition (e.g. an object is within the hand).
         # In this case, we just keep randomizing until we eventually achieve a valid initial
         # configuration.
-        super(RobotEnv, self).reset()
+        super().reset()
         did_reset_sim = False
         while not did_reset_sim:
             did_reset_sim = self._reset_sim()

--- a/gym/envs/robotics/rotations.py
+++ b/gym/envs/robotics/rotations.py
@@ -111,7 +111,7 @@ _EPS4 = _FLOAT_EPS * 4.0
 def euler2mat(euler):
     """Convert Euler Angles to Rotation Matrix.  See rotation.py for notes"""
     euler = np.asarray(euler, dtype=np.float64)
-    assert euler.shape[-1] == 3, "Invalid shaped euler {}".format(euler)
+    assert euler.shape[-1] == 3, f"Invalid shaped euler {euler}"
 
     ai, aj, ak = -euler[..., 2], -euler[..., 1], -euler[..., 0]
     si, sj, sk = np.sin(ai), np.sin(aj), np.sin(ak)
@@ -135,7 +135,7 @@ def euler2mat(euler):
 def euler2quat(euler):
     """Convert Euler Angles to Quaternions.  See rotation.py for notes"""
     euler = np.asarray(euler, dtype=np.float64)
-    assert euler.shape[-1] == 3, "Invalid shape euler {}".format(euler)
+    assert euler.shape[-1] == 3, f"Invalid shape euler {euler}"
 
     ai, aj, ak = euler[..., 2] / 2, -euler[..., 1] / 2, euler[..., 0] / 2
     si, sj, sk = np.sin(ai), np.sin(aj), np.sin(ak)
@@ -154,7 +154,7 @@ def euler2quat(euler):
 def mat2euler(mat):
     """Convert Rotation Matrix to Euler Angles.  See rotation.py for notes"""
     mat = np.asarray(mat, dtype=np.float64)
-    assert mat.shape[-2:] == (3, 3), "Invalid shape matrix {}".format(mat)
+    assert mat.shape[-2:] == (3, 3), f"Invalid shape matrix {mat}"
 
     cy = np.sqrt(mat[..., 2, 2] * mat[..., 2, 2] + mat[..., 1, 2] * mat[..., 1, 2])
     condition = cy > _EPS4
@@ -176,7 +176,7 @@ def mat2euler(mat):
 def mat2quat(mat):
     """Convert Rotation Matrix to Quaternion.  See rotation.py for notes"""
     mat = np.asarray(mat, dtype=np.float64)
-    assert mat.shape[-2:] == (3, 3), "Invalid shape matrix {}".format(mat)
+    assert mat.shape[-2:] == (3, 3), f"Invalid shape matrix {mat}"
 
     Qxx, Qyx, Qzx = mat[..., 0, 0], mat[..., 0, 1], mat[..., 0, 2]
     Qxy, Qyy, Qzy = mat[..., 1, 0], mat[..., 1, 1], mat[..., 1, 2]
@@ -227,7 +227,7 @@ def subtract_euler(e1, e2):
 def quat2mat(quat):
     """Convert Quaternion to Euler Angles.  See rotation.py for notes"""
     quat = np.asarray(quat, dtype=np.float64)
-    assert quat.shape[-1] == 4, "Invalid shape quat {}".format(quat)
+    assert quat.shape[-1] == 4, f"Invalid shape quat {quat}"
 
     w, x, y, z = quat[..., 0], quat[..., 1], quat[..., 2], quat[..., 3]
     Nq = np.sum(quat * quat, axis=-1)

--- a/gym/envs/toy_text/cliffwalking.py
+++ b/gym/envs/toy_text/cliffwalking.py
@@ -59,7 +59,7 @@ class CliffWalkingEnv(discrete.DiscreteEnv):
         isd = np.zeros(nS)
         isd[self.start_state_index] = 1.0
 
-        super(CliffWalkingEnv, self).__init__(nS, nA, P, isd)
+        super().__init__(nS, nA, P, isd)
 
     def _limit_coordinates(self, coord):
         """

--- a/gym/envs/toy_text/frozen_lake.py
+++ b/gym/envs/toy_text/frozen_lake.py
@@ -147,7 +147,7 @@ class FrozenLakeEnv(discrete.DiscreteEnv):
                         else:
                             li.append((1.0, *update_probability_matrix(row, col, a)))
 
-        super(FrozenLakeEnv, self).__init__(nS, nA, P, isd)
+        super().__init__(nS, nA, P, isd)
 
     def render(self, mode="human"):
         outfile = StringIO() if mode == "ansi" else sys.stdout
@@ -157,9 +157,7 @@ class FrozenLakeEnv(discrete.DiscreteEnv):
         desc = [[c.decode("utf-8") for c in line] for line in desc]
         desc[row][col] = utils.colorize(desc[row][col], "red", highlight=True)
         if self.lastaction is not None:
-            outfile.write(
-                "  ({})\n".format(["Left", "Down", "Right", "Up"][self.lastaction])
-            )
+            outfile.write(f"  ({['Left', 'Down', 'Right', 'Up'][self.lastaction]})\n")
         else:
             outfile.write("\n")
         outfile.write("\n".join("".join(line) for line in desc) + "\n")

--- a/gym/envs/toy_text/taxi.py
+++ b/gym/envs/toy_text/taxi.py
@@ -185,11 +185,7 @@ class TaxiEnv(discrete.DiscreteEnv):
         outfile.write("\n".join(["".join(row) for row in out]) + "\n")
         if self.lastaction is not None:
             outfile.write(
-                "  ({})\n".format(
-                    ["South", "North", "East", "West", "Pickup", "Dropoff"][
-                        self.lastaction
-                    ]
-                )
+                f"  ({['South', 'North', 'East', 'West', 'Pickup', 'Dropoff'][self.lastaction]})\n"
             )
         else:
             outfile.write("\n")

--- a/gym/envs/unittest/cube_crash.py
+++ b/gym/envs/unittest/cube_crash.py
@@ -156,7 +156,7 @@ class CubeCrash(gym.Env):
             return self.viewer.isopen
 
         else:
-            assert 0, "Render mode '%s' is not supported" % mode
+            assert 0, f"Render mode '{mode}' is not supported"
 
     def close(self):
         if self.viewer is not None:

--- a/gym/envs/unittest/memorize_digits.py
+++ b/gym/envs/unittest/memorize_digits.py
@@ -138,7 +138,7 @@ class MemorizeDigits(gym.Env):
             return self.viewer.isopen
 
         else:
-            assert 0, "Render mode '%s' is not supported" % mode
+            assert 0, f"Render mode '{mode}' is not supported"
 
     def close(self):
         if self.viewer is not None:


### PR DESCRIPTION
This PR upgrades syntax to use py36+ idioms in gym/envs, as suggested in #2462.

It's derived automatically by running pyupgrade --py36-plus gym/envs/**.py and flynt gym/envs --ll 120, no manual modifications were done.

Quality control: visual inspection of the diff, unit tests pass.