### PR TITLE
Py36+ syntax in gym/spaces: part of #2462

### DIFF
--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -70,9 +70,7 @@ class Box(Space):
         high_precision = _get_precision(self.high.dtype)
         dtype_precision = _get_precision(self.dtype)
         if min(low_precision, high_precision) > dtype_precision:
-            logger.warn(
-                "Box bound precision lowered by casting to {}".format(self.dtype)
-            )
+            logger.warn(f"Box bound precision lowered by casting to {self.dtype}")
         self.low = self.low.astype(self.dtype)
         self.high = self.high.astype(self.dtype)
 
@@ -80,7 +78,7 @@ class Box(Space):
         self.bounded_below = -np.inf < self.low
         self.bounded_above = np.inf > self.high
 
-        super(Box, self).__init__(self.shape, self.dtype, seed)
+        super().__init__(self.shape, self.dtype, seed)
 
     def is_bounded(self, manner="both"):
         below = np.all(self.bounded_below)

--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -50,7 +50,7 @@ class Dict(Space, Mapping):
             assert isinstance(
                 space, Space
             ), "Values of the dict should be instances of gym.Space"
-        super(Dict, self).__init__(
+        super().__init__(
             None, None, seed
         )  # None for shape and dtype, since it'll require special handling
 
@@ -111,8 +111,7 @@ class Dict(Space, Mapping):
         self.spaces[key] = value
 
     def __iter__(self):
-        for key in self.spaces:
-            yield key
+        yield from self.spaces
 
     def __len__(self):
         return len(self.spaces)

--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -14,7 +14,7 @@ class Discrete(Space):
     def __init__(self, n, seed=None):
         assert n >= 0
         self.n = n
-        super(Discrete, self).__init__((), np.int64, seed)
+        super().__init__((), np.int64, seed)
 
     def sample(self):
         return self.np_random.randint(self.n)

--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -32,7 +32,7 @@ class MultiBinary(Space):
             input_n = n
         else:
             input_n = (n,)
-        super(MultiBinary, self).__init__(input_n, np.int8, seed)
+        super().__init__(input_n, np.int8, seed)
 
     def sample(self):
         return self.np_random.randint(low=0, high=2, size=self.n, dtype=self.dtype)
@@ -51,7 +51,7 @@ class MultiBinary(Space):
         return [np.asarray(sample) for sample in sample_n]
 
     def __repr__(self):
-        return "MultiBinary({})".format(self.n)
+        return f"MultiBinary({self.n})"
 
     def __eq__(self, other):
         return isinstance(other, MultiBinary) and self.n == other.n

--- a/gym/spaces/multi_discrete.py
+++ b/gym/spaces/multi_discrete.py
@@ -32,7 +32,7 @@ class MultiDiscrete(Space):
         assert (np.array(nvec) > 0).all(), "nvec (counts) have to be positive"
         self.nvec = np.asarray(nvec, dtype=dtype)
 
-        super(MultiDiscrete, self).__init__(self.nvec.shape, dtype, seed)
+        super().__init__(self.nvec.shape, dtype, seed)
 
     def sample(self):
         return (self.np_random.random_sample(self.nvec.shape) * self.nvec).astype(
@@ -53,7 +53,7 @@ class MultiDiscrete(Space):
         return np.array(sample_n)
 
     def __repr__(self):
-        return "MultiDiscrete({})".format(self.nvec)
+        return f"MultiDiscrete({self.nvec})"
 
     def __getitem__(self, index):
         nvec = self.nvec[index]

--- a/gym/spaces/space.py
+++ b/gym/spaces/space.py
@@ -1,7 +1,7 @@
 from gym.utils import seeding
 
 
-class Space(object):
+class Space:
     """Defines the observation and action spaces, so you can write generic
     code that applies to any Env. For example, you can choose a random
     action.

--- a/gym/spaces/tuple.py
+++ b/gym/spaces/tuple.py
@@ -16,7 +16,7 @@ class Tuple(Space):
             assert isinstance(
                 space, Space
             ), "Elements of the tuple must be instances of gym.Space"
-        super(Tuple, self).__init__(None, None, seed)
+        super().__init__(None, None, seed)
 
     def seed(self, seed=None):
         seeds = []
@@ -50,7 +50,7 @@ class Tuple(Space):
         return seeds
 
     def sample(self):
-        return tuple([space.sample() for space in self.spaces])
+        return tuple(space.sample() for space in self.spaces)
 
     def contains(self, x):
         if isinstance(x, list):

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -40,12 +40,12 @@ def flatdim_multidiscrete(space):
 
 @flatdim.register(Tuple)
 def flatdim_tuple(space):
-    return sum([flatdim(s) for s in space.spaces])
+    return sum(flatdim(s) for s in space.spaces)
 
 
 @flatdim.register(Dict)
 def flatdim_dict(space):
-    return sum([flatdim(s) for s in space.spaces.values()])
+    return sum(flatdim(s) for s in space.spaces.values())
 
 
 @singledispatch


### PR DESCRIPTION
This PR upgrades syntax to use py36+ idioms in gym/spaces, as suggested in #2462.

It's derived automatically by running `pyupgrade --py36-plus gym/spaces/**.py`, no manual modifications were done.

Quality control: visual inspection of the diff, unit tests pass.