### PR TITLE
Fix action dimension check bugs

### DIFF
--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -128,9 +128,8 @@ class MujocoEnv(gym.Env):
         return self.model.opt.timestep * self.frame_skip
 
     def do_simulation(self, ctrl, n_frames):
-        assert (
-            np.shape(ctrl)[-1] == self.action_space.shape[-1]
-        ), "Action dimension mismatch"
+        if np.array(ctrl).shape != self.action_space.shape:
+            raise ValueError("Action dimension mismatch")
 
         self.sim.data.ctrl[:] = ctrl
         for _ in range(n_frames):

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -128,8 +128,10 @@ class MujocoEnv(gym.Env):
         return self.model.opt.timestep * self.frame_skip
 
     def do_simulation(self, ctrl, n_frames):
-        assert np.shape(ctrl)[-1] == self.action_space.shape[-1], "Action dimension mismatch"
-        
+        assert (
+            np.shape(ctrl)[-1] == self.action_space.shape[-1]
+        ), "Action dimension mismatch"
+
         self.sim.data.ctrl[:] = ctrl
         for _ in range(n_frames):
             self.sim.step()

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -128,6 +128,8 @@ class MujocoEnv(gym.Env):
         return self.model.opt.timestep * self.frame_skip
 
     def do_simulation(self, ctrl, n_frames):
+        assert np.shape(ctrl)[-1] == self.action_space.shape[-1], "Action dimension mismatch"
+        
         self.sim.data.ctrl[:] = ctrl
         for _ in range(n_frames):
             self.sim.step()

--- a/gym/envs/robotics/robot_env.py
+++ b/gym/envs/robotics/robot_env.py
@@ -70,9 +70,8 @@ class RobotEnv(gym.GoalEnv):
         return [seed]
 
     def step(self, action):
-        assert (
-            np.shape(action)[-1] == self.action_space.shape[-1]
-        ), "Action dimension mismatch"
+        if np.array(action).shape != self.action_space.shape:
+            raise ValueError("Action dimension mismatch")
 
         action = np.clip(action, self.action_space.low, self.action_space.high)
         self._set_action(action)

--- a/gym/envs/robotics/robot_env.py
+++ b/gym/envs/robotics/robot_env.py
@@ -70,8 +70,10 @@ class RobotEnv(gym.GoalEnv):
         return [seed]
 
     def step(self, action):
-        assert np.shape(action)[-1] == self.action_space.shape[-1], "Action dimension mismatch"
-        
+        assert (
+            np.shape(action)[-1] == self.action_space.shape[-1]
+        ), "Action dimension mismatch"
+
         action = np.clip(action, self.action_space.low, self.action_space.high)
         self._set_action(action)
         self.sim.step()

--- a/gym/envs/robotics/robot_env.py
+++ b/gym/envs/robotics/robot_env.py
@@ -70,6 +70,8 @@ class RobotEnv(gym.GoalEnv):
         return [seed]
 
     def step(self, action):
+        assert np.shape(action)[-1] == self.action_space.shape[-1], "Action dimension mismatch"
+        
         action = np.clip(action, self.action_space.low, self.action_space.high)
         self._set_action(action)
         self.sim.step()

--- a/tests/envs/test_action_dim_check.py
+++ b/tests/envs/test_action_dim_check.py
@@ -1,0 +1,68 @@
+import pickle
+
+import pytest
+
+from gym import envs
+from tests.envs.spec_list import skip_mujoco, SKIP_MUJOCO_WARNING_MESSAGE
+
+
+ENVIRONMENT_IDS = (
+    "FetchPickAndPlace-v1",
+    "FetchPush-v1",
+    "FetchReach-v1",
+    "FetchSlide-v1",
+    "HandManipulatePen-v0",
+    "HandManipulateBlock-v0",
+    "HandManipulateEgg-v0",
+    "HandReach-v0",
+    "HandManipulateEggTouchSensors-v0",
+    "HandManipulateEggTouchSensors-v1",
+    "HandManipulatePenTouchSensors-v0",
+    "HandManipulatePenTouchSensors-v1",
+    "HandManipulateBlockTouchSensors-v0",
+    "HandManipulateBlockTouchSensors-v1",
+    "Hopper-v2",
+    "Walker2d-v2",
+    "Humanoid-v2",
+    "HumanoidStandup-v2",
+    "HalfCheetah-v2",
+    "Swimmer-v2",
+    "Ant-v2",
+    "Hopper-v3",
+    "Walker2d-v3",
+    "Humanoid-v3",
+    "HalfCheetah-v3",
+    "Swimmer-v3",
+    "Ant-v3",
+    "Reacher-v2",
+    "Pusher-v2",
+    "Thrower-v2",
+    "Striker-v2",
+)
+
+
+# @pytest.mark.skipif(skip_mujoco, reason=SKIP_MUJOCO_WARNING_MESSAGE)
+@pytest.mark.parametrize("environment_id", ENVIRONMENT_IDS)
+def test_serialize_deserialize(environment_id):
+    env = envs.make(environment_id)
+    print(
+        "Testing {}".format(
+            environment_id,
+        )
+    )
+    if env.action_space.shape[-1] <= 1:
+        return
+    env.reset()
+    obs = 0
+    try:
+        obs = env.step(0.1)
+    except:
+        pass
+    try:
+        obs = env.step([0.1])
+    except:
+        pass
+
+    assert not obs, "env {}: scalar input dimension does not check".format(
+        environment_id
+    )

--- a/tests/envs/test_action_dim_check.py
+++ b/tests/envs/test_action_dim_check.py
@@ -12,7 +12,7 @@ ENVIRONMENT_IDS = (
 )
 
 
-# @pytest.mark.skipif(skip_mujoco, reason=SKIP_MUJOCO_WARNING_MESSAGE)
+@pytest.mark.skipif(skip_mujoco, reason=SKIP_MUJOCO_WARNING_MESSAGE)
 @pytest.mark.parametrize("environment_id", ENVIRONMENT_IDS)
 def test_serialize_deserialize(environment_id):
     env = envs.make(environment_id)

--- a/tests/envs/test_action_dim_check.py
+++ b/tests/envs/test_action_dim_check.py
@@ -7,37 +7,8 @@ from tests.envs.spec_list import skip_mujoco, SKIP_MUJOCO_WARNING_MESSAGE
 
 
 ENVIRONMENT_IDS = (
-    "FetchPickAndPlace-v1",
-    "FetchPush-v1",
     "FetchReach-v1",
-    "FetchSlide-v1",
-    "HandManipulatePen-v0",
-    "HandManipulateBlock-v0",
-    "HandManipulateEgg-v0",
-    "HandReach-v0",
-    "HandManipulateEggTouchSensors-v0",
-    "HandManipulateEggTouchSensors-v1",
-    "HandManipulatePenTouchSensors-v0",
-    "HandManipulatePenTouchSensors-v1",
-    "HandManipulateBlockTouchSensors-v0",
-    "HandManipulateBlockTouchSensors-v1",
-    "Hopper-v2",
-    "Walker2d-v2",
-    "Humanoid-v2",
-    "HumanoidStandup-v2",
     "HalfCheetah-v2",
-    "Swimmer-v2",
-    "Ant-v2",
-    "Hopper-v3",
-    "Walker2d-v3",
-    "Humanoid-v3",
-    "HalfCheetah-v3",
-    "Swimmer-v3",
-    "Ant-v3",
-    "Reacher-v2",
-    "Pusher-v2",
-    "Thrower-v2",
-    "Striker-v2",
 )
 
 
@@ -45,24 +16,10 @@ ENVIRONMENT_IDS = (
 @pytest.mark.parametrize("environment_id", ENVIRONMENT_IDS)
 def test_serialize_deserialize(environment_id):
     env = envs.make(environment_id)
-    print(
-        "Testing {}".format(
-            environment_id,
-        )
-    )
-    if env.action_space.shape[-1] <= 1:
-        return
     env.reset()
-    obs = 0
-    try:
-        obs = env.step(0.1)
-    except:
-        pass
-    try:
-        obs = env.step([0.1])
-    except:
-        pass
 
-    assert not obs, "env {}: scalar input dimension does not check".format(
-        environment_id
-    )
+    with pytest.raises(ValueError, match="Action dimension mismatch"):
+        env.step([0.1])
+
+    with pytest.raises(ValueError, match="Action dimension mismatch"):
+        env.step(0.1)


### PR DESCRIPTION
- **Gym bugs**: Mujoco and Robotic envs do not check the scalar action dimension at all.

- **Description**: I find that Mujoco and Robotic envs accept scalar action without any warning or errors. For example, in ''FetchReach-v1", the action dimension is 4, however a scalar input "0.1" or "[0.1]" is also legal inputs. This can lead to difficult-to-find dimension bugs if people set a wrong action (because I've made one).

- **Ways to reproduce**: 
```
import gym
env = gym.make(''FetchReach-v1") # Try any Mujoco and Robotic envs
env.reset()
env.step(0.1) # This is a legal input
env.step([0.1]) # This is also a legal input
```

- **Reason**: Some numpy operations broadcast the dimension automatically. 
For example,
in [mujoco_env.py](https://github.com/openai/gym/blob/a5c0608efbadfd0a1097aaff284885be18129427/gym/envs/mujoco/mujoco_env.py#L130), the code `self.sim.data.ctrl[:] = ctrl` broadcasts the dimension;
in [robot_env.py](https://github.com/openai/gym/blob/a5c0608efbadfd0a1097aaff284885be18129427/gym/envs/robotics/robot_env.py#L73), the code `action = np.clip(action, self.action_space.low, self.action_space.high)` broadcasts the dimension.

- **My commit**: check the dimension before the above codes as: 
`assert np.shape(action)[-1] == self.action_space.shape[-1], "Action dimension mismatch"`



