### PR TITLE
Py36+ syntax in gym/utils

### DIFF
--- a/gym/utils/atomic_write.py
+++ b/gym/utils/atomic_write.py
@@ -56,5 +56,5 @@ def atomic_write(filepath, binary=False, fsync=False):
     finally:
         try:
             os.remove(tmppath)
-        except (IOError, OSError):
+        except OSError:
             pass

--- a/gym/utils/closer.py
+++ b/gym/utils/closer.py
@@ -3,7 +3,7 @@ import threading
 import weakref
 
 
-class Closer(object):
+class Closer:
     """A registry that ensures your objects get closed, whether manually,
     upon garbage collection, or upon exit. To work properly, your
     objects need to cooperate and do something like the following:
@@ -49,7 +49,7 @@ class Closer(object):
         Returns:
             int: The registration ID of this object. It is the caller's responsibility to save this ID if early closing is desired.
         """
-        assert hasattr(closeable, "close"), "No close method for {}".format(closeable)
+        assert hasattr(closeable, "close"), f"No close method for {closeable}"
 
         next_id = self.generate_next_id()
         self.closeables[next_id] = closeable

--- a/gym/utils/colorize.py
+++ b/gym/utils/colorize.py
@@ -29,4 +29,4 @@ def colorize(string, color, bold=False, highlight=False):
     if bold:
         attr.append("1")
     attrs = ";".join(attr)
-    return "\x1b[%sm%s\x1b[0m" % (attrs, string)
+    return f"\x1b[{attrs}m{string}\x1b[0m"

--- a/gym/utils/ezpickle.py
+++ b/gym/utils/ezpickle.py
@@ -1,4 +1,4 @@
-class EzPickle(object):
+class EzPickle:
     """Objects that are pickled and unpickled via their constructor
     arguments.
 

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -8,7 +8,7 @@ try:
     matplotlib.use("TkAgg")
     import matplotlib.pyplot as plt
 except ImportError as e:
-    logger.warn("failed to set matplotlib backend, plotting will not work: %s" % str(e))
+    logger.warn(f"failed to set matplotlib backend, plotting will not work: {str(e)}")
     plt = None
 
 from collections import deque
@@ -143,7 +143,7 @@ def play(env, transpose=True, fps=30, zoom=None, callback=None, keys_to_action=N
     pygame.quit()
 
 
-class PlayPlot(object):
+class PlayPlot:
     def __init__(self, callback, horizon_timesteps, plot_names):
         self.data_callback = callback
         self.horizon_timesteps = horizon_timesteps

--- a/gym/utils/seeding.py
+++ b/gym/utils/seeding.py
@@ -10,9 +10,7 @@ from gym import error
 
 def np_random(seed=None):
     if seed is not None and not (isinstance(seed, int) and 0 <= seed):
-        raise error.Error(
-            "Seed must be a non-negative integer or omitted, not {}".format(seed)
-        )
+        raise error.Error(f"Seed must be a non-negative integer or omitted, not {seed}")
 
     seed = create_seed(seed)
 
@@ -65,7 +63,7 @@ def create_seed(a=None, max_bytes=8):
     elif isinstance(a, int):
         a = a % 2 ** (8 * max_bytes)
     else:
-        raise error.Error("Invalid type for seed: {} ({})".format(type(a), a))
+        raise error.Error(f"Invalid type for seed: {type(a)} ({a})")
 
     return a
 
@@ -76,7 +74,7 @@ def _bigint_from_bytes(bytes):
     padding = sizeof_int - len(bytes) % sizeof_int
     bytes += b"\0" * padding
     int_count = int(len(bytes) / sizeof_int)
-    unpacked = struct.unpack("{}I".format(int_count), bytes)
+    unpacked = struct.unpack(f"{int_count}I", bytes)
     accum = 0
     for i, val in enumerate(unpacked):
         accum += 2 ** (sizeof_int * 8 * i) * val
@@ -86,7 +84,7 @@ def _bigint_from_bytes(bytes):
 def _int_list_from_bigint(bigint):
     # Special case 0
     if bigint < 0:
-        raise error.Error("Seed must be non-negative, not {}".format(bigint))
+        raise error.Error(f"Seed must be non-negative, not {bigint}")
     elif bigint == 0:
         return [0]
 


### PR DESCRIPTION
This PR upgrades syntax to use py36+ idioms in gym/utils, as suggested in #2462.

It's derived automatically by running pyupgrade --py36-plus and flynt -ll 120, no manual modifications were done.

Quality control: visual inspection of the diff, unit tests pass.