### PR TITLE
Py36+ syntax in gym/*.py

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -5,7 +5,7 @@ from gym import error
 from gym.utils import closer
 
 
-class Env(object):
+class Env:
     """The main OpenAI Gym class. It encapsulates an environment with
     arbitrary behind-the-scenes dynamics. An environment can be
     partially or fully observed.
@@ -149,9 +149,9 @@ class Env(object):
 
     def __str__(self):
         if self.spec is None:
-            return "<{} instance>".format(type(self).__name__)
+            return f"<{type(self).__name__} instance>"
         else:
-            return "<{}<{}>>".format(type(self).__name__, self.spec.id)
+            return f"<{type(self).__name__}<{self.spec.id}>>"
 
     def __enter__(self):
         """Support with-statement for the environment."""
@@ -232,9 +232,7 @@ class Wrapper(Env):
 
     def __getattr__(self, name):
         if name.startswith("_"):
-            raise AttributeError(
-                "attempted to get missing private attribute '{}'".format(name)
-            )
+            raise AttributeError(f"attempted to get missing private attribute '{name}'")
         return getattr(self.env, name)
 
     @property
@@ -304,7 +302,7 @@ class Wrapper(Env):
         return self.env.compute_reward(achieved_goal, desired_goal, info)
 
     def __str__(self):
-        return "<{}{}>".format(type(self).__name__, self.env)
+        return f"<{type(self).__name__}{self.env}>"
 
     def __repr__(self):
         return str(self)

--- a/gym/error.py
+++ b/gym/error.py
@@ -96,7 +96,7 @@ class APIError(Error):
         json_body=None,
         headers=None,
     ):
-        super(APIError, self).__init__(message)
+        super().__init__(message)
 
         if http_body and hasattr(http_body, "decode"):
             try:
@@ -117,7 +117,7 @@ class APIError(Error):
     def __unicode__(self):
         if self.request_id is not None:
             msg = self._message or "<empty message>"
-            return u"Request {0}: {1}".format(self.request_id, msg)
+            return f"Request {self.request_id}: {msg}"
         else:
             return self._message
 
@@ -142,9 +142,7 @@ class InvalidRequestError(APIError):
         json_body=None,
         headers=None,
     ):
-        super(InvalidRequestError, self).__init__(
-            message, http_body, http_status, json_body, headers
-        )
+        super().__init__(message, http_body, http_status, json_body, headers)
         self.param = param
 
 
@@ -194,7 +192,7 @@ class AlreadyPendingCallError(Exception):
     """
 
     def __init__(self, message, name):
-        super(AlreadyPendingCallError, self).__init__(message)
+        super().__init__(message)
         self.name = name
 
 
@@ -205,7 +203,7 @@ class NoAsyncCallError(Exception):
     """
 
     def __init__(self, message, name):
-        super(NoAsyncCallError, self).__init__(message)
+        super().__init__(message)
         self.name = name
 
 

--- a/gym/logger.py
+++ b/gym/logger.py
@@ -22,18 +22,18 @@ def set_level(level):
 
 def debug(msg, *args):
     if MIN_LEVEL <= DEBUG:
-        print("%s: %s" % ("DEBUG", msg % args), file=sys.stderr)
+        print(f"DEBUG: {msg % args}", file=sys.stderr)
 
 
 def info(msg, *args):
     if MIN_LEVEL <= INFO:
-        print("%s: %s" % ("INFO", msg % args), file=sys.stderr)
+        print(f"INFO: {msg % args}", file=sys.stderr)
 
 
 def warn(msg, *args, category=None, stacklevel=1):
     if MIN_LEVEL <= WARN:
         warnings.warn(
-            colorize("%s: %s" % ("WARN", msg % args), "yellow"),
+            colorize(f"WARN: {msg % args}", "yellow"),
             category=category,
             stacklevel=stacklevel + 1,
         )
@@ -45,7 +45,7 @@ def deprecation(msg, *args):
 
 def error(msg, *args):
     if MIN_LEVEL <= ERROR:
-        print(colorize("%s: %s" % ("ERROR", msg % args), "red"), file=sys.stderr)
+        print(colorize(f"ERROR: {msg % args}", "red"), file=sys.stderr)
 
 
 # DEPRECATED:


### PR DESCRIPTION
This PR upgrades syntax to use py36+ idioms in gym/*.py (no subfolders), as suggested in #2462.

It's derived automatically by running pyupgrade --py36-plus and flynt -ll 120, no manual modifications were done.

Quality control: visual inspection of the diff, unit tests pass.