### PR TITLE
Py36+ syntax in gym/vector

### DIFF
--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -100,7 +100,7 @@ class AsyncVectorEnv(VectorEnv):
             action_space = action_space or dummy_env.action_space
         dummy_env.close()
         del dummy_env
-        super(AsyncVectorEnv, self).__init__(
+        super().__init__(
             num_envs=len(env_fns),
             observation_space=observation_space,
             action_space=action_space,
@@ -138,7 +138,7 @@ class AsyncVectorEnv(VectorEnv):
                 parent_pipe, child_pipe = ctx.Pipe()
                 process = ctx.Process(
                     target=target,
-                    name="Worker<{0}>-{1}".format(type(self).__name__, idx),
+                    name=f"Worker<{type(self).__name__}>-{idx}",
                     args=(
                         idx,
                         CloudpickleWrapper(env_fn),
@@ -169,8 +169,7 @@ class AsyncVectorEnv(VectorEnv):
 
         if self._state != AsyncState.DEFAULT:
             raise AlreadyPendingCallError(
-                "Calling `seed` while waiting "
-                "for a pending call to `{0}` to complete.".format(self._state.value),
+                f"Calling `seed` while waiting for a pending call to `{self._state.value}` to complete.",
                 self._state.value,
             )
 
@@ -183,8 +182,7 @@ class AsyncVectorEnv(VectorEnv):
         self._assert_is_running()
         if self._state != AsyncState.DEFAULT:
             raise AlreadyPendingCallError(
-                "Calling `reset_async` while waiting "
-                "for a pending call to `{0}` to complete".format(self._state.value),
+                f"Calling `reset_async` while waiting for a pending call to `{self._state.value}` to complete",
                 self._state.value,
             )
 
@@ -215,8 +213,7 @@ class AsyncVectorEnv(VectorEnv):
         if not self._poll(timeout):
             self._state = AsyncState.DEFAULT
             raise mp.TimeoutError(
-                "The call to `reset_wait` has timed out after "
-                "{0} second{1}.".format(timeout, "s" if timeout > 1 else "")
+                f"The call to `reset_wait` has timed out after {timeout} second{'s' if timeout > 1 else ''}."
             )
 
         results, successes = zip(*[pipe.recv() for pipe in self.parent_pipes])
@@ -240,8 +237,7 @@ class AsyncVectorEnv(VectorEnv):
         self._assert_is_running()
         if self._state != AsyncState.DEFAULT:
             raise AlreadyPendingCallError(
-                "Calling `step_async` while waiting "
-                "for a pending call to `{0}` to complete.".format(self._state.value),
+                f"Calling `step_async` while waiting for a pending call to `{self._state.value}` to complete.",
                 self._state.value,
             )
 
@@ -281,8 +277,7 @@ class AsyncVectorEnv(VectorEnv):
         if not self._poll(timeout):
             self._state = AsyncState.DEFAULT
             raise mp.TimeoutError(
-                "The call to `step_wait` has timed out after "
-                "{0} second{1}.".format(timeout, "s" if timeout > 1 else "")
+                f"The call to `step_wait` has timed out after {timeout} second{'s' if timeout > 1 else ''}."
             )
 
         results, successes = zip(*[pipe.recv() for pipe in self.parent_pipes])
@@ -319,10 +314,9 @@ class AsyncVectorEnv(VectorEnv):
         try:
             if self._state != AsyncState.DEFAULT:
                 logger.warn(
-                    "Calling `close` while waiting for a pending "
-                    "call to `{0}` to complete.".format(self._state.value)
+                    f"Calling `close` while waiting for a pending call to `{self._state.value}` to complete."
                 )
-                function = getattr(self, "{0}_wait".format(self._state.value))
+                function = getattr(self, f"{self._state.value}_wait")
                 function(timeout)
         except mp.TimeoutError:
             terminate = True
@@ -368,7 +362,7 @@ class AsyncVectorEnv(VectorEnv):
         if not all(same_spaces):
             raise RuntimeError(
                 "Some environments have an observation space "
-                "different from `{0}`. In order to batch observations, the "
+                "different from `{}`. In order to batch observations, the "
                 "observation spaces from all environments must be "
                 "equal.".format(self.single_observation_space)
             )
@@ -376,8 +370,7 @@ class AsyncVectorEnv(VectorEnv):
     def _assert_is_running(self):
         if self.closed:
             raise ClosedEnvironmentError(
-                "Trying to operate on `{0}`, after a "
-                "call to `close()`.".format(type(self).__name__)
+                f"Trying to operate on `{type(self).__name__}`, after a call to `close()`."
             )
 
     def _raise_if_errors(self, successes):
@@ -389,10 +382,9 @@ class AsyncVectorEnv(VectorEnv):
         for _ in range(num_errors):
             index, exctype, value = self.error_queue.get()
             logger.error(
-                "Received the following error from Worker-{0}: "
-                "{1}: {2}".format(index, exctype.__name__, value)
+                f"Received the following error from Worker-{index}: {exctype.__name__}: {value}"
             )
-            logger.error("Shutting down Worker-{0}.".format(index))
+            logger.error(f"Shutting down Worker-{index}.")
             self.parent_pipes[index].close()
             self.parent_pipes[index] = None
 

--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -38,7 +38,7 @@ class SyncVectorEnv(VectorEnv):
         if (observation_space is None) or (action_space is None):
             observation_space = observation_space or self.envs[0].observation_space
             action_space = action_space or self.envs[0].action_space
-        super(SyncVectorEnv, self).__init__(
+        super().__init__(
             num_envs=len(env_fns),
             observation_space=observation_space,
             action_space=action_space,
@@ -107,7 +107,7 @@ class SyncVectorEnv(VectorEnv):
             return True
         raise RuntimeError(
             "Some environments have an observation space "
-            "different from `{0}`. In order to batch observations, the "
+            "different from `{}`. In order to batch observations, the "
             "observation spaces from all environments must be "
             "equal.".format(self.single_observation_space)
         )

--- a/gym/vector/utils/misc.py
+++ b/gym/vector/utils/misc.py
@@ -4,7 +4,7 @@ import os
 __all__ = ["CloudpickleWrapper", "clear_mpi_env_vars"]
 
 
-class CloudpickleWrapper(object):
+class CloudpickleWrapper:
     def __init__(self, fn):
         self.fn = fn
 

--- a/gym/vector/utils/numpy_utils.py
+++ b/gym/vector/utils/numpy_utils.py
@@ -47,8 +47,7 @@ def concatenate(items, out, space):
         return concatenate_custom(items, out, space)
     else:
         raise ValueError(
-            "Space of type `{0}` is not a valid `gym.Space` "
-            "instance.".format(type(space))
+            f"Space of type `{type(space)}` is not a valid `gym.Space` instance."
         )
 
 
@@ -119,8 +118,7 @@ def create_empty_array(space, n=1, fn=np.zeros):
         return create_empty_array_custom(space, n=n, fn=fn)
     else:
         raise ValueError(
-            "Space of type `{0}` is not a valid `gym.Space` "
-            "instance.".format(type(space))
+            f"Space of type `{type(space)}` is not a valid `gym.Space` instance."
         )
 
 

--- a/gym/vector/utils/shared_memory.py
+++ b/gym/vector/utils/shared_memory.py
@@ -41,7 +41,7 @@ def create_shared_memory(space, n=1, ctx=mp):
     else:
         raise CustomSpaceError(
             "Cannot create a shared memory for space with "
-            "type `{0}`. Shared memory only supports "
+            "type `{}`. Shared memory only supports "
             "default Gym spaces (e.g. `Box`, `Tuple`, "
             "`Dict`, etc...), and does not support custom "
             "Gym spaces.".format(type(space))
@@ -106,7 +106,7 @@ def read_from_shared_memory(shared_memory, space, n=1):
     else:
         raise CustomSpaceError(
             "Cannot read from a shared memory for space with "
-            "type `{0}`. Shared memory only supports "
+            "type `{}`. Shared memory only supports "
             "default Gym spaces (e.g. `Box`, `Tuple`, "
             "`Dict`, etc...), and does not support custom "
             "Gym spaces.".format(type(space))
@@ -166,7 +166,7 @@ def write_to_shared_memory(index, value, shared_memory, space):
     else:
         raise CustomSpaceError(
             "Cannot write to a shared memory for space with "
-            "type `{0}`. Shared memory only supports "
+            "type `{}`. Shared memory only supports "
             "default Gym spaces (e.g. `Box`, `Tuple`, "
             "`Dict`, etc...), and does not support custom "
             "Gym spaces.".format(type(space))

--- a/gym/vector/utils/spaces.py
+++ b/gym/vector/utils/spaces.py
@@ -44,8 +44,7 @@ def batch_space(space, n=1):
         return batch_space_custom(space, n=n)
     else:
         raise ValueError(
-            "Cannot batch space with type `{0}`. The space must "
-            "be a valid `gym.Space` instance.".format(type(space))
+            f"Cannot batch space with type `{type(space)}`. The space must be a valid `gym.Space` instance."
         )
 
 
@@ -67,7 +66,7 @@ def batch_space_base(space, n=1):
         return Box(low=0, high=1, shape=(n,) + space.shape, dtype=space.dtype)
 
     else:
-        raise ValueError("Space type `{0}` is not supported.".format(type(space)))
+        raise ValueError(f"Space type `{type(space)}` is not supported.")
 
 
 def batch_space_tuple(space, n=1):

--- a/gym/vector/vector_env.py
+++ b/gym/vector/vector_env.py
@@ -139,11 +139,9 @@ class VectorEnv(gym.Env):
 
     def __repr__(self):
         if self.spec is None:
-            return "{}({})".format(self.__class__.__name__, self.num_envs)
+            return f"{self.__class__.__name__}({self.num_envs})"
         else:
-            return "{}({}, {})".format(
-                self.__class__.__name__, self.spec.id, self.num_envs
-            )
+            return f"{self.__class__.__name__}({self.spec.id}, {self.num_envs})"
 
 
 class VectorEnvWrapper(VectorEnv):
@@ -189,9 +187,7 @@ class VectorEnvWrapper(VectorEnv):
     # implicitly forward all other methods and attributes to self.env
     def __getattr__(self, name):
         if name.startswith("_"):
-            raise AttributeError(
-                "attempted to get missing private attribute '{}'".format(name)
-            )
+            raise AttributeError(f"attempted to get missing private attribute '{name}'")
         return getattr(self.env, name)
 
     @property
@@ -199,4 +195,4 @@ class VectorEnvWrapper(VectorEnv):
         return self.env.unwrapped
 
     def __repr__(self):
-        return "<{}, {}>".format(self.__class__.__name__, self.env)
+        return f"<{self.__class__.__name__}, {self.env}>"


### PR DESCRIPTION
This PR upgrades syntax to use py36+ idioms in gym/vector, as suggested in #2462.

It's derived automatically by running pyupgrade --py36-plus and flynt -ll 120, no manual modifications were done.

Quality control: visual inspection of the diff, unit tests pass.