### PR TITLE
Fix the broken link to Creating Environments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Notably, we are not accepting these forms of contributions:
 - New features
 
 This may change in the future.
-If you wish to make a Gym environment, follow the instructions in [Creating Environments](https://github.com/openai/gym/blob/master/docs/creating_environments.md).  When your environment works, you can make a PR to add it to the bottom of the [List of Environments](https://github.com/openai/gym/blob/master/docs/environments.md).
+If you wish to make a Gym environment, follow the instructions in [Creating Environments](https://github.com/openai/gym/blob/master/docs/creating_environments.md).  When your environment works, you can make a PR to add it to the bottom of the [List of Environments](https://github.com/openai/gym/blob/master/docs/third_party_environments.md).
 
 
 Edit July 27, 2021: Please see https://github.com/openai/gym/issues/2259 for new contributing standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Notably, we are not accepting these forms of contributions:
 - New features
 
 This may change in the future.
-If you wish to make a Gym environment, follow the instructions in [Creating Environments](https://github.com/openai/gym/blob/master/docs/creating-environments.md).  When your environment works, you can make a PR to add it to the bottom of the [List of Environments](https://github.com/openai/gym/blob/master/docs/environments.md).
+If you wish to make a Gym environment, follow the instructions in [Creating Environments](https://github.com/openai/gym/blob/master/docs/creating_environments.md).  When your environment works, you can make a PR to add it to the bottom of the [List of Environments](https://github.com/openai/gym/blob/master/docs/environments.md).
 
 
 Edit July 27, 2021: Please see https://github.com/openai/gym/issues/2259 for new contributing standards


### PR DESCRIPTION
Changed *Creating Environments* link from https://github.com/openai/gym/blob/master/docs/creating-environments.md to https://github.com/openai/gym/blob/master/docs/creating_environments.md, as the change in file name isn't reflected in CONTRIBUTING.md.