### PR TITLE
Type cast in `spaces` families

### DIFF
--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 import numpy as np
 from .space import Space
 
@@ -42,9 +42,15 @@ class Dict(Space, Mapping):
         if spaces is None:
             spaces = spaces_kwargs
         if isinstance(spaces, dict) and not isinstance(spaces, OrderedDict):
-            spaces = OrderedDict(sorted(list(spaces.items())))
-        if isinstance(spaces, list):
+            try:
+                spaces = OrderedDict(sorted(spaces.items()))
+            except TypeError:  # raise when sort by different types of keys
+                spaces = OrderedDict(spaces.items())
+        if isinstance(spaces, Sequence):
             spaces = OrderedDict(spaces)
+
+        assert isinstance(spaces, OrderedDict), "spaces must be a dictionary"
+
         self.spaces = spaces
         for space in spaces.values():
             assert isinstance(

--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -16,8 +16,9 @@ class Discrete(Space):
     """
 
     def __init__(self, n, seed=None, start=0):
-        assert n >= 0 and isinstance(start, (int, np.integer))
-        self.n = n
+        assert n > 0, "n (counts) have to be positive"
+        assert isinstance(start, (int, np.integer))
+        self.n = int(n)
         self.start = int(start)
         super().__init__((), np.int64, seed)
 

--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 import numpy as np
 from .space import Space
 
@@ -14,9 +15,9 @@ class MultiBinary(Space):
 
     >> self.observation_space.sample()
 
-        array([0,1,0,1,0], dtype =int8)
+        array([0, 1, 0, 1, 0], dtype=int8)
 
-    >> self.observation_space = spaces.MultiBinary([3,2])
+    >> self.observation_space = spaces.MultiBinary([3, 2])
 
     >> self.observation_space.sample()
 
@@ -27,18 +28,21 @@ class MultiBinary(Space):
     """
 
     def __init__(self, n, seed=None):
-        self.n = n
-        if type(n) in [tuple, list, np.ndarray]:
-            input_n = n
+        if isinstance(n, (Sequence, np.ndarray)):
+            self.n = input_n = tuple(int(i) for i in n)
         else:
+            self.n = n = int(n)
             input_n = (n,)
+
+        assert (np.asarray(input_n) > 0).all(), "n (counts) have to be positive"
+
         super().__init__(input_n, np.int8, seed)
 
     def sample(self):
         return self.np_random.integers(low=0, high=2, size=self.n, dtype=self.dtype)
 
     def contains(self, x):
-        if isinstance(x, list) or isinstance(x, tuple):
+        if isinstance(x, Sequence):
             x = np.array(x)  # Promote list to array for contains check
         if self.shape != x.shape:
             return False

--- a/gym/spaces/multi_discrete.py
+++ b/gym/spaces/multi_discrete.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 import numpy as np
 from gym import logger
 from .space import Space
@@ -29,8 +30,8 @@ class MultiDiscrete(Space):
         """
         nvec: vector of counts of each categorical variable
         """
-        assert (np.array(nvec) > 0).all(), "nvec (counts) have to be positive"
-        self.nvec = np.asarray(nvec, dtype=dtype)
+        self.nvec = np.array(nvec, dtype=dtype, copy=True)
+        assert (self.nvec > 0).all(), "nvec (counts) have to be positive"
 
         super().__init__(self.nvec.shape, dtype, seed)
 
@@ -38,7 +39,7 @@ class MultiDiscrete(Space):
         return (self.np_random.random(self.nvec.shape) * self.nvec).astype(self.dtype)
 
     def contains(self, x):
-        if isinstance(x, list):
+        if isinstance(x, Sequence):
             x = np.array(x)  # Promote list to array for contains check
         # if nvec is uint32 and space dtype is uint32, then 0 <= x < self.nvec guarantees that x
         # is within correct bounds for space dtype (even though x does not have to be unsigned)

--- a/gym/spaces/tuple.py
+++ b/gym/spaces/tuple.py
@@ -11,6 +11,7 @@ class Tuple(Space):
     """
 
     def __init__(self, spaces, seed=None):
+        spaces = tuple(spaces)
         self.spaces = spaces
         for space in spaces:
             assert isinstance(
@@ -53,8 +54,8 @@ class Tuple(Space):
         return tuple(space.sample() for space in self.spaces)
 
     def contains(self, x):
-        if isinstance(x, list):
-            x = tuple(x)  # Promote list to tuple for contains check
+        if isinstance(x, (list, np.ndarray)):
+            x = tuple(x)  # Promote list and ndarray to tuple for contains check
         return (
             isinstance(x, tuple)
             and len(x) == len(self.spaces)


### PR DESCRIPTION
## 1. `spaces.Dict`
  
in `__init__`:

  - convert `tuple` to `OrderedDict` as well (same as `list`).
  - raise `AssertionError` when the user does not pass a `dict` or `list` / `tuple` of keyvalue pairs.

------

## 2. `spaces.Tuple`:

in `__init__`:

  - convert input spaces to `tuple`.

in `contains`:

  - convert the input sample to `tuple`.

Fixes #2140.
Fixes #2479.

------

## 3. `spaces.MultiBinary`

in `__init__`:

  - convert input shapes to tuple of `int`s.
  - raise `AssertionError` when any entry of the input shapes is not positive.

------

## 4. `spaces.MultiDiscrete`

in `__init__`:

  - make a copy of the input `nvec`.

    ```python
    >>> import numpy as np
    >>> a = np.array([1, 2, 3], np.int64)
    >>> np.asarray(a) is a
    True

    >>> np.asarray(a)[0] = 4
    >>> a
    array([4, 2, 3])
    ```

  - raise `AssertionError` when any entry of the input shapes is not positive (convert to `int`s first).

in `contains`:

  - convert `tuple` to `np.ndarray` as well (same as `list`).

------

## 5. `spaces.Discrete`

in `__init__`:

  - convert the input shape `int`.
  - raise `AssertionError` when the input shape is not positive (convert to `int`s first).
