### PR TITLE
Fix close_extras not implemented by default in VectorEnv

### DIFF
--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -477,6 +477,10 @@ class AsyncVectorEnv(VectorEnv):
         logger.error("Raising the last exception back to the main process.")
         raise exctype(value)
 
+    def __del__(self):
+        if not getattr(self, "closed", True):
+            self.close(terminate=True)
+
 
 def _worker(index, env_fn, pipe, parent_pipe, shared_memory, error_queue):
     assert shared_memory is None

--- a/gym/vector/vector_env.py
+++ b/gym/vector/vector_env.py
@@ -94,7 +94,7 @@ class VectorEnv(gym.Env):
 
     def close_extras(self, **kwargs):
         r"""Clean up the extra resources e.g. beyond what's in this base class."""
-        raise NotImplementedError()
+        pass
 
     def close(self, **kwargs):
         r"""Close all sub-environments and release resources.
@@ -136,7 +136,7 @@ class VectorEnv(gym.Env):
 
     def __del__(self):
         if not getattr(self, "closed", True):
-            self.close(terminate=True)
+            self.close()
 
     def __repr__(self):
         if self.spec is None:


### PR DESCRIPTION
 - Fix `close_extras` not implemented by default in `VectorEnv`. For example:
```python
class CustomVectorEnv(gym.vector.VectorEnv):
    def __init__(self, num_envs):
        observation_space = gym.spaces.Box(0., 1., shape=(2,))
        action_space = gym.spaces.Discrete(3)
        super().__init__(num_envs, observation_space, action_space)

env = CustomVectorEnv(num_envs=5)
# Before:
# Traceback (most recent call last):
#   File "gym/vector/vector_env.py", line 139, in __del__
#     self.close(terminate=True)
#   File "gym/vector/vector_env.py", line 120, in close
#     self.close_extras(**kwargs)
#   File "gym/vector/vector_env.py", line 97, in close_extras
#     raise NotImplementedError()
# NotImplementedError:
```