### PR TITLE
Fix a typo in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ale-py~=0.7
-opencv-python>=3.
+opencv-python>=3.0
 box2d-py==2.3.5
 mujoco_py>=1.50, <2.0
 scipy>=1.4.1


### PR DESCRIPTION
Closes #2518

I am impressed how nobody noticed this for several months (including myself, because I recall looking at the requirements), but it is what it is.

There's a larger discussion to be had as to what should actually be put in these requirements, since a common "default" workflow is doing

```bash
pip install -r requirements.txt
pip install -e .
```

And this will install a whole bunch of stuff that's very optional to many users. That being said, an even more common workflow is `pip install gym` which seems to avoid this issue. In any case, the typo fix should be an obvious thing in the meantime.