### PR TITLE
Removed mypy from CI tests

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -13,21 +13,21 @@ jobs:
       - run: pytest --doctest-modules . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
 
-pyright:
-  name: Check types with pyright
-  runs-on: ubuntu-latest
-  strategy:
-    matrix:
-      python-platform: [ "Linux" ]
-      python-version: [ "3.7"]
-    fail-fast: false
-  env:
-    PYRIGHT_VERSION: 1.1.183
-  steps:
-    - uses: actions/checkout@v2
-    - uses: jakebailey/pyright-action@v1
-      with:
-        version: ${{ env.PYRIGHT_VERSION }}
-        python-platform: ${{ matrix.python-platform }}
-        python-version: ${{ matrix.python-version }}
-        no-comments: ${{ matrix.python-version != '3.9' || matrix.python-platform != 'Linux' }}  # Having each job create the same comment is too noisy.
+  pyright:
+    name: Check types with pyright
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-platform: [ "Linux" ]
+        python-version: [ "3.7"]
+      fail-fast: false
+    env:
+      PYRIGHT_VERSION: 1.1.183
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jakebailey/pyright-action@v1
+        with:
+          version: ${{ env.PYRIGHT_VERSION }}
+          python-platform: ${{ matrix.python-platform }}
+          python-version: ${{ matrix.python-version }}
+          no-comments: ${{ matrix.python-version != '3.9' || matrix.python-platform != 'Linux' }}  # Having each job create the same comment is too noisy.

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,26 +9,25 @@ jobs:
       - run: pip install isort mypy pytest pyupgrade safety
       - run: isort --check-only --profile black . || true
       - run: pip install -e .[nomujoco]
-      - run: mypy --install-types --non-interactive . || true
       - run: pytest . || true
       - run: pytest --doctest-modules . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
 
-  pyright:
-    name: Check types with pyright
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-platform: [ "Linux" ]
-        python-version: [ "3.7"]
-      fail-fast: false
-    env:
-      PYRIGHT_VERSION: 1.1.183
-    steps:
-      - uses: actions/checkout@v2
-      - uses: jakebailey/pyright-action@v1
-        with:
-          version: ${{ env.PYRIGHT_VERSION }}
-          python-platform: ${{ matrix.python-platform }}
-          python-version: ${{ matrix.python-version }}
-          no-comments: ${{ matrix.python-version != '3.9' || matrix.python-platform != 'Linux' }}  # Having each job create the same comment is too noisy.
+pyright:
+  name: Check types with pyright
+  runs-on: ubuntu-latest
+  strategy:
+    matrix:
+      python-platform: [ "Linux" ]
+      python-version: [ "3.7"]
+    fail-fast: false
+  env:
+    PYRIGHT_VERSION: 1.1.183
+  steps:
+    - uses: actions/checkout@v2
+    - uses: jakebailey/pyright-action@v1
+      with:
+        version: ${{ env.PYRIGHT_VERSION }}
+        python-platform: ${{ matrix.python-platform }}
+        python-version: ${{ matrix.python-version }}
+        no-comments: ${{ matrix.python-version != '3.9' || matrix.python-platform != 'Linux' }}  # Having each job create the same comment is too noisy.

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - run: pip install isort mypy pytest pyupgrade safety
+      - run: pip install isort pytest pyupgrade safety
       - run: isort --check-only --profile black . || true
       - run: pip install -e .[nomujoco]
       - run: pytest . || true

--- a/gym/logger.py
+++ b/gym/logger.py
@@ -11,7 +11,7 @@ ERROR = 40
 DISABLED = 50
 
 min_level = 30
-# delete this comment
+
 
 def set_level(level: int) -> None:
     """

--- a/gym/logger.py
+++ b/gym/logger.py
@@ -11,7 +11,7 @@ ERROR = 40
 DISABLED = 50
 
 min_level = 30
-
+# delete this comment
 
 def set_level(level: int) -> None:
     """


### PR DESCRIPTION
Removed the installation and running of mypy from `.github/workflows/lint_python.yml`. 

This was done as `pyright` is now being used for type checking (as per `CONTRIBUTING.md`) and already has a functional test which is limited to specified files. The mypy test is then redundant, and incredibly inefficient due to checking EVERYTHING. Removing mypy from CI testing shaves ~11 minutes off.

Unless I'm mistaken and mypy is used in testing for some other reason that I'm not seeing. At the very least, if mypy must be used in test, I think it should use a more proper configuration to limit what it searches to a reasonable time (just as the pyright test does).