### PR TITLE
Consolidate LunarLander and BipedalWalker envs

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -66,7 +66,8 @@ register(
 
 register(
     id="LunarLanderContinuous-v2",
-    entry_point="gym.envs.box2d:LunarLanderContinuous",
+    entry_point="gym.envs.box2d:LunarLander",
+    kwargs={"continuous": True},
     max_episode_steps=1000,
     reward_threshold=200,
 )
@@ -80,7 +81,8 @@ register(
 
 register(
     id="BipedalWalkerHardcore-v3",
-    entry_point="gym.envs.box2d:BipedalWalkerHardcore",
+    entry_point="gym.envs.box2d:BipedalWalker",
+    kwargs={"hardcore": True},
     max_episode_steps=2000,
     reward_threshold=300,
 )

--- a/gym/envs/box2d/__init__.py
+++ b/gym/envs/box2d/__init__.py
@@ -1,7 +1,7 @@
 try:
     import Box2D
-    from gym.envs.box2d.lunar_lander import LunarLander
-    from gym.envs.box2d.bipedal_walker import BipedalWalker
+    from gym.envs.box2d.lunar_lander import LunarLander, LunarLanderContinuous
+    from gym.envs.box2d.bipedal_walker import BipedalWalker, BipedalWalkerHardcore
     from gym.envs.box2d.car_racing import CarRacing
 except ImportError:
     Box2D = None

--- a/gym/envs/box2d/__init__.py
+++ b/gym/envs/box2d/__init__.py
@@ -1,8 +1,7 @@
 try:
     import Box2D
     from gym.envs.box2d.lunar_lander import LunarLander
-    from gym.envs.box2d.lunar_lander import LunarLanderContinuous
-    from gym.envs.box2d.bipedal_walker import BipedalWalker, BipedalWalkerHardcore
+    from gym.envs.box2d.bipedal_walker import BipedalWalker
     from gym.envs.box2d.car_racing import CarRacing
 except ImportError:
     Box2D = None

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -119,9 +119,7 @@ class ContactDetector(contactListener):
 class BipedalWalker(gym.Env, EzPickle):
     metadata = {"render.modes": ["human", "rgb_array"], "video.frames_per_second": FPS}
 
-    hardcore = False
-
-    def __init__(self):
+    def __init__(self, hardcore=False):
         EzPickle.__init__(self)
         self.viewer = None
 
@@ -130,6 +128,8 @@ class BipedalWalker(gym.Env, EzPickle):
         self.hull = None
 
         self.prev_shaping = None
+
+        self.hardcore = hardcore
 
         self.fd_polygon = fixtureDef(
             shape=polygonShape(vertices=[(0, 0), (1, 0), (1, -1), (0, -1)]),
@@ -564,10 +564,6 @@ class BipedalWalker(gym.Env, EzPickle):
         if self.viewer is not None:
             self.viewer.close()
             self.viewer = None
-
-
-class BipedalWalkerHardcore(BipedalWalker):
-    hardcore = True
 
 
 if __name__ == "__main__":

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -14,7 +14,7 @@ from Box2D.b2 import (
 )
 
 import gym
-from gym import spaces
+from gym import error, spaces
 from gym.utils import colorize, seeding, EzPickle
 
 # This is simple 4-joints walker robot environment.
@@ -564,6 +564,16 @@ class BipedalWalker(gym.Env, EzPickle):
         if self.viewer is not None:
             self.viewer.close()
             self.viewer = None
+
+
+class BipedalWalkerHardcore:
+    def __init__(self):
+        raise error.Error(
+            "Error initializing BipedalWalkerHardcore Environment.\n"
+            "Currently, we do not support initializing this mode of environment by calling the class directly.\n"
+            "To use this environment, instead create it by specifying the hardcore keyword in gym.make, i.e.\n"
+            "gym.make(\"BipedalWalker-v3\", hardcore=True)"
+        )
 
 
 if __name__ == "__main__":

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -572,7 +572,7 @@ class BipedalWalkerHardcore:
             "Error initializing BipedalWalkerHardcore Environment.\n"
             "Currently, we do not support initializing this mode of environment by calling the class directly.\n"
             "To use this environment, instead create it by specifying the hardcore keyword in gym.make, i.e.\n"
-            "gym.make(\"BipedalWalker-v3\", hardcore=True)"
+            'gym.make("BipedalWalker-v3", hardcore=True)'
         )
 
 

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -119,7 +119,7 @@ class ContactDetector(contactListener):
 class BipedalWalker(gym.Env, EzPickle):
     metadata = {"render.modes": ["human", "rgb_array"], "video.frames_per_second": FPS}
 
-    def __init__(self, hardcore=False):
+    def __init__(self, hardcore: bool = False):
         EzPickle.__init__(self)
         self.viewer = None
 

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -91,9 +91,7 @@ class ContactDetector(contactListener):
 class LunarLander(gym.Env, EzPickle):
     metadata = {"render.modes": ["human", "rgb_array"], "video.frames_per_second": FPS}
 
-    continuous = False
-
-    def __init__(self):
+    def __init__(self, continuous=False):
         EzPickle.__init__(self)
         self.viewer = None
 
@@ -103,6 +101,8 @@ class LunarLander(gym.Env, EzPickle):
         self.particles = []
 
         self.prev_reward = None
+
+        self.continuous = continuous
 
         # useful range is -1 .. +1, but spikes can be higher
         self.observation_space = spaces.Box(
@@ -442,10 +442,6 @@ class LunarLander(gym.Env, EzPickle):
         if self.viewer is not None:
             self.viewer.close()
             self.viewer = None
-
-
-class LunarLanderContinuous(LunarLander):
-    continuous = True
 
 
 def heuristic(env, s):

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -528,7 +528,7 @@ class LunarLanderContinuous:
             "Error initializing LunarLanderContinuous Environment.\n"
             "Currently, we do not support initializing this mode of environment by calling the class directly.\n"
             "To use this environment, instead create it by specifying the continuous keyword in gym.make, i.e.\n"
-            "gym.make(\"LunarLander-v2\", continuous=True)"
+            'gym.make("LunarLander-v2", continuous=True)'
         )
 
 

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -91,7 +91,7 @@ class ContactDetector(contactListener):
 class LunarLander(gym.Env, EzPickle):
     metadata = {"render.modes": ["human", "rgb_array"], "video.frames_per_second": FPS}
 
-    def __init__(self, continuous=False):
+    def __init__(self, continuous: bool = False):
         EzPickle.__init__(self)
         self.viewer = None
 

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -43,7 +43,7 @@ from Box2D.b2 import (
 )
 
 import gym
-from gym import spaces
+from gym import error, spaces
 from gym.utils import seeding, EzPickle
 
 FPS = 50
@@ -520,6 +520,16 @@ def demo_heuristic_lander(env, seed=None, render=False):
     if render:
         env.close()
     return total_reward
+
+
+class LunarLanderContinuous:
+    def __init__(self):
+        raise error.Error(
+            "Error initializing LunarLanderContinuous Environment.\n"
+            "Currently, we do not support initializing this mode of environment by calling the class directly.\n"
+            "To use this environment, instead create it by specifying the continuous keyword in gym.make, i.e.\n"
+            "gym.make(\"LunarLander-v2\", continuous=True)"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/envs/test_lunar_lander.py
+++ b/tests/envs/test_lunar_lander.py
@@ -4,7 +4,6 @@ try:
     import Box2D
     from gym.envs.box2d.lunar_lander import (
         LunarLander,
-        LunarLanderContinuous,
         demo_heuristic_lander,
     )
 except ImportError:
@@ -18,7 +17,7 @@ def test_lunar_lander():
 
 @pytest.mark.skipif(Box2D is None, reason="Box2D not installed")
 def test_lunar_lander_continuous():
-    _test_lander(LunarLanderContinuous(), seed=0)
+    _test_lander(LunarLander(continuous=True), seed=0)
 
 
 @pytest.mark.skipif(Box2D is None, reason="Box2D not installed")


### PR DESCRIPTION
This merges the different environment types for LunarLander (continuous) and BipedalWalker (hardcore), and adds kwargs to specify the specific environment.

This maintains backwards compatibility as the id for these environments remain the same.

Specifically, the `LunarLanderContinuous` and `BipedalWalkerHardcore` classes were removed, and their functionality was merged into their parent class. They can be instantiated by specifying the relevant keywords in `env.make` (using `"continuous"=True` and `"hardcore"=True`, respectively).