### PR TITLE
Update importlib_metadata entry_point calls

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -5,7 +5,7 @@ import importlib
 import contextlib
 from typing import Callable, Type, Optional, Union, Dict, Set, Tuple, Generator
 
-if sys.version_info < (3, 8):
+if sys.version_info < (3, 10):
     import importlib_metadata as metadata  # type: ignore
 else:
     import importlib.metadata as metadata
@@ -794,7 +794,7 @@ def namespace(ns: str):
 
 def load_env_plugins(entry_point: str = "gym.envs") -> None:
     # Load third-party environments
-    for plugin in metadata.entry_points().get(entry_point, []):
+    for plugin in metadata.entry_points(group=entry_point):
         # Python 3.8 doesn't support plugin.module, plugin.attr
         # So we'll have to try and parse this ourselves
         try:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         "numpy>=1.18.0",
         "cloudpickle>=1.2.0",
-        "importlib_metadata>=4.8.1; python_version < '3.8'",
+        "importlib_metadata>=4.10.0; python_version < '3.10'",
     ],
     extras_require=extras,
     package_data={


### PR DESCRIPTION
On Python 3.10+ there are deprecation warnings for using `.get()` on `EntryPoints`. If we use an updated version of the backport library `importlib_metadata` and the native `importlib.metadata` for Py310+ this shouldn't be an issue.