### PR TITLE
Refactor Lunar Lander and Bipedal Walker to use Pygame

### DIFF
--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -614,10 +614,6 @@ class BipedalWalker(gym.Env, EzPickle):
             return self.isopen
 
     def close(self):
-        if self.viewer is not None:
-            self.viewer.close()
-            self.viewer = None
-
         if self.screen is not None:
             pygame.quit()
             self.isopen = False

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -197,7 +197,7 @@ class BipedalWalker(gym.Env, EzPickle):
                 ]
                 self.fd_polygon.shape.vertices = poly
                 t = self.world.CreateStaticBody(fixtures=self.fd_polygon)
-                t.color1, t.color2 = (1, 1, 1), (0.6, 0.6, 0.6)
+                t.color1, t.color2 = (255, 255, 255), (153, 153, 153)
                 self.terrain.append(t)
 
                 self.fd_polygon.shape.vertices = [

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -492,17 +492,19 @@ class BipedalWalker(gym.Env, EzPickle):
         pygame.init()
 
         self.screen = pygame.display.set_mode((VIEWPORT_W, VIEWPORT_H))
-        self.surf = pygame.Surface((VIEWPORT_W + self.scroll*SCALE, VIEWPORT_H))
+        self.surf = pygame.Surface((VIEWPORT_W + self.scroll * SCALE, VIEWPORT_H))
 
         pygame.transform.scale(self.surf, (SCALE, SCALE))
 
         pygame.draw.polygon(
             self.surf,
             color=(215, 215, 255),
-            points=[(self.scroll*SCALE, 0),
-                    (self.scroll*SCALE + VIEWPORT_W, 0),
-                    (self.scroll*SCALE + VIEWPORT_W, VIEWPORT_H),
-                    (self.scroll*SCALE, VIEWPORT_H)]
+            points=[
+                (self.scroll * SCALE, 0),
+                (self.scroll * SCALE + VIEWPORT_W, 0),
+                (self.scroll * SCALE + VIEWPORT_W, VIEWPORT_H),
+                (self.scroll * SCALE, VIEWPORT_H),
+            ],
         )
 
         for poly, x1, x2 in self.cloud_poly:
@@ -513,10 +515,15 @@ class BipedalWalker(gym.Env, EzPickle):
             pygame.draw.polygon(
                 self.surf,
                 color=(255, 255, 255),
-                points=[(p[0]*SCALE + self.scroll*SCALE / 2, p[1]*SCALE) for p in poly]
+                points=[
+                    (p[0] * SCALE + self.scroll * SCALE / 2, p[1] * SCALE) for p in poly
+                ],
             )
-            gfxdraw.aapolygon(self.surf, [(p[0]*SCALE + self.scroll*SCALE / 2, p[1]*SCALE) for p in poly],
-                              (255, 255, 255))
+            gfxdraw.aapolygon(
+                self.surf,
+                [(p[0] * SCALE + self.scroll * SCALE / 2, p[1] * SCALE) for p in poly],
+                (255, 255, 255),
+            )
         for poly, color in self.terrain_poly:
             if poly[1][0] < self.scroll:
                 continue
@@ -524,12 +531,8 @@ class BipedalWalker(gym.Env, EzPickle):
                 continue
             scaled_poly = []
             for coord in poly:
-                scaled_poly.append(([coord[0]*SCALE, coord[1]*SCALE]))
-            pygame.draw.polygon(
-                self.surf,
-                color=color,
-                points=scaled_poly
-            )
+                scaled_poly.append(([coord[0] * SCALE, coord[1] * SCALE]))
+            pygame.draw.polygon(self.surf, color=color, points=scaled_poly)
             gfxdraw.aapolygon(self.surf, scaled_poly, color)
 
         self.lidar_render = (self.lidar_render + 1) % 100
@@ -540,50 +543,73 @@ class BipedalWalker(gym.Env, EzPickle):
                 if i < len(self.lidar)
                 else self.lidar[len(self.lidar) - i - 1]
             )
-            pygame.draw.line(self.surf, color=(255, 0, 0),
-                             start_pos=(l.p1[0]*SCALE, l.p1[1]*SCALE),
-                             end_pos=(l.p2[0]*SCALE, l.p2[1]*SCALE),
-                             width=1)
+            pygame.draw.line(
+                self.surf,
+                color=(255, 0, 0),
+                start_pos=(l.p1[0] * SCALE, l.p1[1] * SCALE),
+                end_pos=(l.p2[0] * SCALE, l.p2[1] * SCALE),
+                width=1,
+            )
 
         for obj in self.drawlist:
             for f in obj.fixtures:
                 trans = f.body.transform
                 if type(f.shape) is circleShape:
-                    pygame.draw.circle(self.surf, color=obj.color1,
-                                       center=trans*f.shape.pos*SCALE, radius=f.shape.radius*SCALE)
-                    pygame.draw.circle(self.surf, color=obj.color2,
-                                       center=trans*f.shape.pos*SCALE, radius=f.shape.radius*SCALE)
+                    pygame.draw.circle(
+                        self.surf,
+                        color=obj.color1,
+                        center=trans * f.shape.pos * SCALE,
+                        radius=f.shape.radius * SCALE,
+                    )
+                    pygame.draw.circle(
+                        self.surf,
+                        color=obj.color2,
+                        center=trans * f.shape.pos * SCALE,
+                        radius=f.shape.radius * SCALE,
+                    )
                 else:
                     path = [trans * v * SCALE for v in f.shape.vertices]
                     if len(path) > 2:
                         pygame.draw.polygon(self.surf, color=obj.color1, points=path)
                         gfxdraw.aapolygon(self.surf, path, obj.color1)
                         path.append(path[0])
-                        pygame.draw.polygon(self.surf, color=obj.color2, points=path, width=1)
+                        pygame.draw.polygon(
+                            self.surf, color=obj.color2, points=path, width=1
+                        )
                         gfxdraw.aapolygon(self.surf, path, obj.color2)
                     else:
-                        pygame.draw.aaline(self.surf, start_pos=path[0], end_pos=path[1], color=obj.color1)
+                        pygame.draw.aaline(
+                            self.surf,
+                            start_pos=path[0],
+                            end_pos=path[1],
+                            color=obj.color1,
+                        )
 
         flagy1 = TERRAIN_HEIGHT * SCALE
         flagy2 = flagy1 + 50
         x = TERRAIN_STEP * 3 * SCALE
-        pygame.draw.aaline(self.surf, color=(0, 0, 0),
-                           start_pos=(x, flagy1), end_pos=(x, flagy2))
+        pygame.draw.aaline(
+            self.surf, color=(0, 0, 0), start_pos=(x, flagy1), end_pos=(x, flagy2)
+        )
         f = [
             (x, flagy2),
             (x, flagy2 - 10),
             (x + 25, flagy2 - 5),
         ]
         pygame.draw.polygon(self.surf, color=(230, 51, 0), points=f)
-        pygame.draw.lines(self.surf, color=(0, 0, 0), points=f + [f[0]], width=1, closed=False)
+        pygame.draw.lines(
+            self.surf, color=(0, 0, 0), points=f + [f[0]], width=1, closed=False
+        )
 
         self.surf = pygame.transform.flip(self.surf, False, True)
-        self.screen.blit(self.surf, (-self.scroll*SCALE, 0))
+        self.screen.blit(self.surf, (-self.scroll * SCALE, 0))
         if mode == "human":
             pygame.display.flip()
 
         if mode == "rgb_array":
-            return np.transpose(np.array(pygame.surfarray.pixels3d(self.screen)), axes=(1, 0, 2))
+            return np.transpose(
+                np.array(pygame.surfarray.pixels3d(self.screen)), axes=(1, 0, 2)
+            )
         else:
             return self.isopen
 

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -3,6 +3,9 @@ import math
 from typing import Optional
 
 import numpy as np
+import pygame
+from pygame import gfxdraw
+
 import Box2D
 from Box2D.b2 import (
     edgeShape,
@@ -121,7 +124,8 @@ class BipedalWalker(gym.Env, EzPickle):
 
     def __init__(self, hardcore: bool = False):
         EzPickle.__init__(self)
-        self.viewer = None
+        self.screen = None
+        self.isopen = True
 
         self.world = Box2D.b2World()
         self.terrain = None
@@ -200,7 +204,7 @@ class BipedalWalker(gym.Env, EzPickle):
                     (p[0] + TERRAIN_STEP * counter, p[1]) for p in poly
                 ]
                 t = self.world.CreateStaticBody(fixtures=self.fd_polygon)
-                t.color1, t.color2 = (1, 1, 1), (0.6, 0.6, 0.6)
+                t.color1, t.color2 = (255, 255, 255), (153, 153, 153)
                 self.terrain.append(t)
                 counter += 2
                 original_y = y
@@ -220,7 +224,7 @@ class BipedalWalker(gym.Env, EzPickle):
                 ]
                 self.fd_polygon.shape.vertices = poly
                 t = self.world.CreateStaticBody(fixtures=self.fd_polygon)
-                t.color1, t.color2 = (1, 1, 1), (0.6, 0.6, 0.6)
+                t.color1, t.color2 = (255, 255, 255), (153, 153, 153)
                 self.terrain.append(t)
 
             elif state == STAIRS and oneshot:
@@ -249,7 +253,7 @@ class BipedalWalker(gym.Env, EzPickle):
                     ]
                     self.fd_polygon.shape.vertices = poly
                     t = self.world.CreateStaticBody(fixtures=self.fd_polygon)
-                    t.color1, t.color2 = (1, 1, 1), (0.6, 0.6, 0.6)
+                    t.color1, t.color2 = (255, 255, 255), (153, 153, 153)
                     self.terrain.append(t)
                 counter = stair_steps * stair_width
 
@@ -278,11 +282,11 @@ class BipedalWalker(gym.Env, EzPickle):
             ]
             self.fd_edge.shape.vertices = poly
             t = self.world.CreateStaticBody(fixtures=self.fd_edge)
-            color = (0.3, 1.0 if i % 2 == 0 else 0.8, 0.3)
+            color = (76, 255 if i % 2 == 0 else 204, 76)
             t.color1 = color
             t.color2 = color
             self.terrain.append(t)
-            color = (0.4, 0.6, 0.3)
+            color = (102, 153, 76)
             poly += [(poly[1][0], 0), (poly[0][0], 0)]
             self.terrain_poly.append((poly, color))
         self.terrain.reverse()
@@ -329,8 +333,8 @@ class BipedalWalker(gym.Env, EzPickle):
         self.hull = self.world.CreateDynamicBody(
             position=(init_x, init_y), fixtures=HULL_FD
         )
-        self.hull.color1 = (0.5, 0.4, 0.9)
-        self.hull.color2 = (0.3, 0.3, 0.5)
+        self.hull.color1 = (127, 51, 229)
+        self.hull.color2 = (76, 76, 127)
         self.hull.ApplyForceToCenter(
             (self.np_random.uniform(-INITIAL_RANDOM, INITIAL_RANDOM), 0), True
         )
@@ -343,8 +347,8 @@ class BipedalWalker(gym.Env, EzPickle):
                 angle=(i * 0.05),
                 fixtures=LEG_FD,
             )
-            leg.color1 = (0.6 - i / 10.0, 0.3 - i / 10.0, 0.5 - i / 10.0)
-            leg.color2 = (0.4 - i / 10.0, 0.2 - i / 10.0, 0.3 - i / 10.0)
+            leg.color1 = (153 - i * 25, 76 - i * 25, 127 - i * 25)
+            leg.color2 = (102 - i * 25, 51 - i * 25, 76 - i * 25)
             rjd = revoluteJointDef(
                 bodyA=self.hull,
                 bodyB=leg,
@@ -365,8 +369,8 @@ class BipedalWalker(gym.Env, EzPickle):
                 angle=(i * 0.05),
                 fixtures=LOWER_FD,
             )
-            lower.color1 = (0.6 - i / 10.0, 0.3 - i / 10.0, 0.5 - i / 10.0)
-            lower.color2 = (0.4 - i / 10.0, 0.2 - i / 10.0, 0.3 - i / 10.0)
+            lower.color1 = (153 - i * 25, 76 - i * 25, 127 - i * 25)
+            lower.color2 = (102 - i * 25, 51 - i * 25, 76 - i * 25)
             rjd = revoluteJointDef(
                 bodyA=leg,
                 bodyB=lower,
@@ -485,37 +489,48 @@ class BipedalWalker(gym.Env, EzPickle):
         return np.array(state, dtype=np.float32), reward, done, {}
 
     def render(self, mode="human"):
-        from gym.utils import pyglet_rendering
+        pygame.init()
 
-        if self.viewer is None:
-            self.viewer = pyglet_rendering.Viewer(VIEWPORT_W, VIEWPORT_H)
-        self.viewer.set_bounds(
-            self.scroll, VIEWPORT_W / SCALE + self.scroll, 0, VIEWPORT_H / SCALE
+        self.screen = pygame.display.set_mode((VIEWPORT_W, VIEWPORT_H))
+        self.surf = pygame.Surface((VIEWPORT_W + self.scroll*SCALE, VIEWPORT_H))
+
+        pygame.transform.scale(self.surf, (SCALE, SCALE))
+
+        pygame.draw.polygon(
+            self.surf,
+            color=(215, 215, 255),
+            points=[(self.scroll*SCALE, 0),
+                    (self.scroll*SCALE + VIEWPORT_W, 0),
+                    (self.scroll*SCALE + VIEWPORT_W, VIEWPORT_H),
+                    (self.scroll*SCALE, VIEWPORT_H)]
         )
 
-        self.viewer.draw_polygon(
-            [
-                (self.scroll, 0),
-                (self.scroll + VIEWPORT_W / SCALE, 0),
-                (self.scroll + VIEWPORT_W / SCALE, VIEWPORT_H / SCALE),
-                (self.scroll, VIEWPORT_H / SCALE),
-            ],
-            color=(0.9, 0.9, 1.0),
-        )
         for poly, x1, x2 in self.cloud_poly:
             if x2 < self.scroll / 2:
                 continue
             if x1 > self.scroll / 2 + VIEWPORT_W / SCALE:
                 continue
-            self.viewer.draw_polygon(
-                [(p[0] + self.scroll / 2, p[1]) for p in poly], color=(1, 1, 1)
+            pygame.draw.polygon(
+                self.surf,
+                color=(255, 255, 255),
+                points=[(p[0]*SCALE + self.scroll*SCALE / 2, p[1]*SCALE) for p in poly]
             )
+            gfxdraw.aapolygon(self.surf, [(p[0]*SCALE + self.scroll*SCALE / 2, p[1]*SCALE) for p in poly],
+                              (255, 255, 255))
         for poly, color in self.terrain_poly:
             if poly[1][0] < self.scroll:
                 continue
             if poly[0][0] > self.scroll + VIEWPORT_W / SCALE:
                 continue
-            self.viewer.draw_polygon(poly, color=color)
+            scaled_poly = []
+            for coord in poly:
+                scaled_poly.append(([coord[0]*SCALE, coord[1]*SCALE]))
+            pygame.draw.polygon(
+                self.surf,
+                color=color,
+                points=scaled_poly
+            )
+            gfxdraw.aapolygon(self.surf, scaled_poly, color)
 
         self.lidar_render = (self.lidar_render + 1) % 100
         i = self.lidar_render
@@ -525,45 +540,61 @@ class BipedalWalker(gym.Env, EzPickle):
                 if i < len(self.lidar)
                 else self.lidar[len(self.lidar) - i - 1]
             )
-            self.viewer.draw_polyline([l.p1, l.p2], color=(1, 0, 0), linewidth=1)
+            pygame.draw.line(self.surf, color=(255, 0, 0),
+                             start_pos=(l.p1[0]*SCALE, l.p1[1]*SCALE),
+                             end_pos=(l.p2[0]*SCALE, l.p2[1]*SCALE),
+                             width=1)
 
         for obj in self.drawlist:
             for f in obj.fixtures:
                 trans = f.body.transform
                 if type(f.shape) is circleShape:
-                    t = pyglet_rendering.Transform(translation=trans * f.shape.pos)
-                    self.viewer.draw_circle(
-                        f.shape.radius, 30, color=obj.color1
-                    ).add_attr(t)
-                    self.viewer.draw_circle(
-                        f.shape.radius, 30, color=obj.color2, filled=False, linewidth=2
-                    ).add_attr(t)
+                    pygame.draw.circle(self.surf, color=obj.color1,
+                                       center=trans*f.shape.pos*SCALE, radius=f.shape.radius*SCALE)
+                    pygame.draw.circle(self.surf, color=obj.color2,
+                                       center=trans*f.shape.pos*SCALE, radius=f.shape.radius*SCALE)
                 else:
-                    path = [trans * v for v in f.shape.vertices]
-                    self.viewer.draw_polygon(path, color=obj.color1)
-                    path.append(path[0])
-                    self.viewer.draw_polyline(path, color=obj.color2, linewidth=2)
+                    path = [trans * v * SCALE for v in f.shape.vertices]
+                    if len(path) > 2:
+                        pygame.draw.polygon(self.surf, color=obj.color1, points=path)
+                        gfxdraw.aapolygon(self.surf, path, obj.color1)
+                        path.append(path[0])
+                        pygame.draw.polygon(self.surf, color=obj.color2, points=path, width=1)
+                        gfxdraw.aapolygon(self.surf, path, obj.color2)
+                    else:
+                        pygame.draw.aaline(self.surf, start_pos=path[0], end_pos=path[1], color=obj.color1)
 
-        flagy1 = TERRAIN_HEIGHT
-        flagy2 = flagy1 + 50 / SCALE
-        x = TERRAIN_STEP * 3
-        self.viewer.draw_polyline(
-            [(x, flagy1), (x, flagy2)], color=(0, 0, 0), linewidth=2
-        )
+        flagy1 = TERRAIN_HEIGHT * SCALE
+        flagy2 = flagy1 + 50
+        x = TERRAIN_STEP * 3 * SCALE
+        pygame.draw.aaline(self.surf, color=(0, 0, 0),
+                           start_pos=(x, flagy1), end_pos=(x, flagy2))
         f = [
             (x, flagy2),
-            (x, flagy2 - 10 / SCALE),
-            (x + 25 / SCALE, flagy2 - 5 / SCALE),
+            (x, flagy2 - 10),
+            (x + 25, flagy2 - 5),
         ]
-        self.viewer.draw_polygon(f, color=(0.9, 0.2, 0))
-        self.viewer.draw_polyline(f + [f[0]], color=(0, 0, 0), linewidth=2)
+        pygame.draw.polygon(self.surf, color=(230, 51, 0), points=f)
+        pygame.draw.lines(self.surf, color=(0, 0, 0), points=f + [f[0]], width=1, closed=False)
 
-        return self.viewer.render(return_rgb_array=mode == "rgb_array")
+        self.surf = pygame.transform.flip(self.surf, False, True)
+        self.screen.blit(self.surf, (-self.scroll*SCALE, 0))
+        if mode == "human":
+            pygame.display.flip()
+
+        if mode == "rgb_array":
+            return np.transpose(np.array(pygame.surfarray.pixels3d(self.screen)), axes=(1, 0, 2))
+        else:
+            return self.isopen
 
     def close(self):
         if self.viewer is not None:
             self.viewer.close()
             self.viewer = None
+
+        if self.screen is not None:
+            pygame.quit()
+            self.isopen = False
 
 
 class BipedalWalkerHardcore:

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -489,9 +489,11 @@ class BipedalWalker(gym.Env, EzPickle):
         return np.array(state, dtype=np.float32), reward, done, {}
 
     def render(self, mode="human"):
-        pygame.init()
 
-        self.screen = pygame.display.set_mode((VIEWPORT_W, VIEWPORT_H))
+        if self.screen is None:
+            pygame.init()
+            self.screen = pygame.display.set_mode((VIEWPORT_W, VIEWPORT_H))
+
         self.surf = pygame.Surface((VIEWPORT_W + self.scroll * SCALE, VIEWPORT_H))
 
         pygame.transform.scale(self.surf, (SCALE, SCALE))

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -384,9 +384,10 @@ class LunarLander(gym.Env, EzPickle):
         return np.array(state, dtype=np.float32), reward, done, {}
 
     def render(self, mode="human"):
-        pygame.init()
+        if self.screen is None:
+            pygame.init()
+            self.screen = pygame.display.set_mode((VIEWPORT_W, VIEWPORT_H))
 
-        self.screen = pygame.display.set_mode((VIEWPORT_W, VIEWPORT_H))
         self.surf = pygame.Surface(self.screen.get_size())
 
         pygame.transform.scale(self.surf, (SCALE, SCALE))

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -398,7 +398,7 @@ class LunarLander(gym.Env, EzPickle):
                 int(max(0.2, 0.15 + obj.ttl) * 255),
                 int(max(0.2, 0.5 * obj.ttl) * 255),
                 int(max(0.2, 0.5 * obj.ttl) * 255),
-                )
+            )
             obj.color2 = (
                 int(max(0.2, 0.15 + obj.ttl) * 255),
                 int(max(0.2, 0.5 * obj.ttl) * 255),
@@ -418,35 +418,52 @@ class LunarLander(gym.Env, EzPickle):
             for f in obj.fixtures:
                 trans = f.body.transform
                 if type(f.shape) is circleShape:
-                    pygame.draw.circle(self.surf, color=obj.color1,
-                                       center=trans*f.shape.pos*SCALE, radius=f.shape.radius*SCALE)
-                    pygame.draw.circle(self.surf, color=obj.color2,
-                                       center=trans*f.shape.pos*SCALE, radius=f.shape.radius*SCALE)
+                    pygame.draw.circle(
+                        self.surf,
+                        color=obj.color1,
+                        center=trans * f.shape.pos * SCALE,
+                        radius=f.shape.radius * SCALE,
+                    )
+                    pygame.draw.circle(
+                        self.surf,
+                        color=obj.color2,
+                        center=trans * f.shape.pos * SCALE,
+                        radius=f.shape.radius * SCALE,
+                    )
 
                 else:
                     path = [trans * v * SCALE for v in f.shape.vertices]
                     pygame.draw.polygon(self.surf, color=obj.color1, points=path)
                     gfxdraw.aapolygon(self.surf, path, obj.color1)
-                    pygame.draw.aalines(self.surf, color=obj.color2, points=path, closed=True)
+                    pygame.draw.aalines(
+                        self.surf, color=obj.color2, points=path, closed=True
+                    )
 
                 for x in [self.helipad_x1, self.helipad_x2]:
                     x = x * SCALE
                     flagy1 = self.helipad_y * SCALE
                     flagy2 = flagy1 + 50
-                    pygame.draw.line(self.surf, color=(255, 255, 255),
-                                     start_pos=(x, flagy1), end_pos=(x, flagy2), width=1)
+                    pygame.draw.line(
+                        self.surf,
+                        color=(255, 255, 255),
+                        start_pos=(x, flagy1),
+                        end_pos=(x, flagy2),
+                        width=1,
+                    )
                     pygame.draw.polygon(
                         self.surf,
                         color=(204, 204, 0),
-                        points=
-                        [
+                        points=[
                             (x, flagy2),
                             (x, flagy2 - 10),
                             (x + 25, flagy2 - 5),
                         ],
                     )
-                    gfxdraw.aapolygon(self.surf, [(x, flagy2), (x, flagy2 - 10), (x + 25, flagy2 - 5)],
-                                      (204, 204, 0))
+                    gfxdraw.aapolygon(
+                        self.surf,
+                        [(x, flagy2), (x, flagy2 - 10), (x + 25, flagy2 - 5)],
+                        (204, 204, 0),
+                    )
 
         self.surf = pygame.transform.flip(self.surf, False, True)
         self.screen.blit(self.surf, (0, 0))
@@ -455,7 +472,9 @@ class LunarLander(gym.Env, EzPickle):
             pygame.display.flip()
 
         if mode == "rgb_array":
-            return np.transpose(np.array(pygame.surfarray.pixels3d(self.surf)), axes=(1, 0, 2))
+            return np.transpose(
+                np.array(pygame.surfarray.pixels3d(self.surf)), axes=(1, 0, 2)
+            )
         else:
             return self.isopen
 

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -427,9 +427,7 @@ class LunarLander(gym.Env, EzPickle):
                     path = [trans * v * SCALE for v in f.shape.vertices]
                     pygame.draw.polygon(self.surf, color=obj.color1, points=path)
                     gfxdraw.aapolygon(self.surf, path, obj.color1)
-                    path.append(path[0])
-                    pygame.draw.polygon(self.surf, color=obj.color2, points=path, width=1)
-                    gfxdraw.aapolygon(self.surf, path, obj.color1)
+                    pygame.draw.aalines(self.surf, color=obj.color2, points=path, closed=True)
 
                 for x in [self.helipad_x1, self.helipad_x2]:
                     x = x * SCALE

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ numpy>=1.18.0
 pyglet>=1.4.0
 cloudpickle>=1.2.0
 lz4>=3.1.0
+pygame==2.1.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from version import VERSION
 extras = {
     "atari": ["ale-py~=0.7.1"],
     "accept-rom-license": ["autorom[accept-rom-license]~=0.4.2"],
-    "box2d": ["box2d-py==2.3.5", "pyglet>=1.4.0"],
+    "box2d": ["box2d-py==2.3.5", "pygame==2.1.0"],
     "classic_control": ["pyglet>=1.4.0"],
     "mujoco": ["mujoco_py>=1.50, <2.0"],
     "toy_text": ["scipy>=1.4.1"],


### PR DESCRIPTION
This PR refactors the rendering function of the two environments to use pygame instead of pyglet. The refactored rendering is consistent with the previous pyglet rendering, with some changes to the `rgb_array` output of the `render` method.

Here is a side by side comparison of the two environments. Left is the old pyglet version, and right is the new pygame version
![Bipedal Walker](https://user-images.githubusercontent.com/25740538/148677168-25bec64c-e1d6-408c-942b-5e835162a5e5.png)

![Lunar Lander](https://user-images.githubusercontent.com/25740538/148677341-a43106b4-299a-474b-bf4e-eb148a343e85.png)

One point to note is that the current output of the `render` method when `mode="rgb_array"` is now of shape `(400, 600, 3)`, which is consistent with the specified display dimensions. The old render method output had a shape of `(800, 1200, 3)`. For simplicity sake, we use `np.transpose(np.array(pygame.surfarray.pixels3d(self.screen)), axes=(1, 0, 2))`, where previously the output was obtained from using the pyglet color buffer. 
