### PR TITLE
Implement simplified Box representation

### DIFF
--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -4,6 +4,12 @@ from .space import Space
 from gym import logger
 
 
+def _short_repr(arr):
+    if arr.size != 0 and np.min(arr) == np.max(arr):
+        return str(np.min(arr))
+    return str(arr)
+
+
 class Box(Space):
     """
     A (possibly unbounded) box in R^n. Specifically, a Box represents the
@@ -154,7 +160,9 @@ class Box(Space):
         return [np.asarray(sample) for sample in sample_n]
 
     def __repr__(self):
-        return f"Box({self.low}, {self.high}, {self.shape}, {self.dtype})"
+        low_repr = _short_repr(self.low)
+        high_repr = _short_repr(self.high)
+        return f"Box({low_repr}, {high_repr}, {self.shape}, {self.dtype})"
 
     def __eq__(self, other):
         return (

--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -5,6 +5,11 @@ from gym import logger
 
 
 def _short_repr(arr):
+    """Create a shortened string representation of a numpy array.
+
+    If arr is a multiple of the all-ones vector, return a string representation of the multiplier.
+    Otherwise, return a string representation of the entire array.
+    """
     if arr.size != 0 and np.min(arr) == np.max(arr):
         return str(np.min(arr))
     return str(arr)
@@ -79,6 +84,9 @@ class Box(Space):
             logger.warn(f"Box bound precision lowered by casting to {self.dtype}")
         self.low = self.low.astype(self.dtype)
         self.high = self.high.astype(self.dtype)
+
+        self.low_repr = _short_repr(self.low)
+        self.high_repr = _short_repr(self.high)
 
         # Boolean arrays which indicate the interval type for each coordinate
         self.bounded_below = -np.inf < self.low
@@ -160,9 +168,7 @@ class Box(Space):
         return [np.asarray(sample) for sample in sample_n]
 
     def __repr__(self):
-        low_repr = _short_repr(self.low)
-        high_repr = _short_repr(self.high)
-        return f"Box({low_repr}, {high_repr}, {self.shape}, {self.dtype})"
+        return f"Box({self.low_repr}, {self.high_repr}, {self.shape}, {self.dtype})"
 
     def __eq__(self, other):
         return (


### PR DESCRIPTION
This pull request aims to simplify the string representation of Box spaces. 
If the lower (or analogously upper) limit is a multiple of the all-ones vector, we only print the multiplicand, instead of the entire vector. This was discussed in issue #2497.

The method `_short_repr` will return a possibly shortened string representation of an array, as outlined above. I will add a short comment to the method later.

Best,
Markus