### PR TITLE
Remove reset enforceing in the `TimeLimit` wrapper

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -109,15 +109,14 @@ class EnvSpec:
         spec = copy.deepcopy(self)
         spec._kwargs = _kwargs
         env.unwrapped.spec = spec
+        if self.order_enforce:
+            from gym.wrappers.order_enforcing import OrderEnforcing
+
+            env = OrderEnforcing(env)
         if env.spec.max_episode_steps is not None:
             from gym.wrappers.time_limit import TimeLimit
 
             env = TimeLimit(env, max_episode_steps=env.spec.max_episode_steps)
-        else:
-            if self.order_enforce:
-                from gym.wrappers.order_enforcing import OrderEnforcing
-
-                env = OrderEnforcing(env)
         return env
 
     def __repr__(self):

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -11,6 +11,7 @@ class TimeLimit(gym.Wrapper):
         if self.env.spec is not None:
             self.env.spec.max_episode_steps = max_episode_steps
         self._max_episode_steps = max_episode_steps
+        self._elapsed_steps = None
 
     def step(self, action):
         observation, reward, done, info = self.env.step(action)
@@ -21,4 +22,5 @@ class TimeLimit(gym.Wrapper):
         return observation, reward, done, info
 
     def reset(self, seed: Optional[int] = None, **kwargs):
+        self._elapsed_steps = 0
         return self.env.reset(seed=seed, **kwargs)

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -11,12 +11,8 @@ class TimeLimit(gym.Wrapper):
         if self.env.spec is not None:
             self.env.spec.max_episode_steps = max_episode_steps
         self._max_episode_steps = max_episode_steps
-        self._elapsed_steps = None
 
     def step(self, action):
-        assert (
-            self._elapsed_steps is not None
-        ), "Cannot call env.step() before calling reset()"
         observation, reward, done, info = self.env.step(action)
         self._elapsed_steps += 1
         if self._elapsed_steps >= self._max_episode_steps:
@@ -25,5 +21,4 @@ class TimeLimit(gym.Wrapper):
         return observation, reward, done, info
 
     def reset(self, seed: Optional[int] = None, **kwargs):
-        self._elapsed_steps = 0
         return self.env.reset(seed=seed, **kwargs)


### PR DESCRIPTION
Per #2460, the `OrderEnforcing` is already applied to all the envs, so we no longer need to enforce the order in the `TimeLimit` wrapper.