### PR TITLE
Suppress PyGame import message

### DIFF
--- a/gym/__init__.py
+++ b/gym/__init__.py
@@ -13,5 +13,8 @@ from gym.envs import make, spec, register
 from gym import logger
 from gym import vector
 from gym import wrappers
+import os
 
 __all__ = ["Env", "Space", "Wrapper", "make", "spec", "register"]
+
+os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"


### PR DESCRIPTION
This pull request adds two lines to `__init__.py` to suppress a message that is printed whenever `pygame` is imported.
Exactly as in https://github.com/Farama-Foundation/PettingZoo/pull/577.