### PR TITLE
Add types to gym.make("CartPole-v1") and such

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: flake8
         args:
-          - --ignore=E203,E402,E712,E722,E731,E741,F401,F403,F405,F524,F841,W503
+          - --ignore=E203,E402,E712,E722,E731,E741,F401,F403,F405,F524,F841,W503,E302,E704
           - --max-complexity=30
           - --max-line-length=456
           - --show-source

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -1,26 +1,10 @@
-from __future__ import annotations
-
-from typing import Sequence, SupportsFloat, overload, Any
-import sys
-
-import numpy as np
-
-from gym.core import Env
 from gym.envs.registration import (
     registry,
     register,
+    make,
     spec,
     load_env_plugins as _load_env_plugins,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-
-    class Literal:
-        def __class_getitem__(cls, item):
-            return Any
-
 
 # Hook to load plugins from entry points
 _load_env_plugins()
@@ -279,65 +263,3 @@ register(
     entry_point="gym.envs.mujoco:HumanoidStandupEnv",
     max_episode_steps=1000,
 )
-
-# fmt: off
-# Continuous
-# ----------------------------------------
-
-@overload
-def make(id: Literal["CartPole-v0", "CartPole-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
-@overload
-def make(id: Literal["MountainCar-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
-@overload
-def make(id: Literal["MountainCarContinuous-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | Sequence[SupportsFloat]]: ...
-@overload
-def make(id: Literal["Pendulum-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | Sequence[SupportsFloat]]: ...
-@overload
-def make(id: Literal["Acrobot-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
-
-# Box2d
-# ----------------------------------------
-
-@overload
-def make(id: Literal["LunarLander-v2", "LunarLanderContinuous-v2"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
-@overload
-def make(id: Literal["BipedalWalker-v3", "BipedalWalkerHardcore-v3"], **kwargs) -> Env[np.ndarray, np.ndarray | Sequence[SupportsFloat]]: ...
-@overload
-def make(id: Literal["CarRacing-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | Sequence[SupportsFloat]]: ...
-
-# Toy Text
-# ----------------------------------------
-
-@overload
-def make(id: Literal["Blackjack-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
-@overload
-def make(id: Literal["FrozenLake-v1", "FrozenLake8x8-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
-@overload
-def make(id: Literal["CliffWalking-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
-@overload
-def make(id: Literal["Taxi-v3"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
-
-# Mujoco
-# ----------------------------------------
-@overload
-def make(id: Literal[
-    "Reacher-v2",
-    "Pusher-v2",
-    "Thrower-v2",
-    "Striker-v2",
-    "InvertedPendulum-v2",
-    "InvertedDoublePendulum-v2",
-    "HalfCheetah-v2", "HalfCheetah-v3",
-    "Hopper-v2", "Hopper-v3",
-    "Swimmer-v2", "Swimmer-v3",
-    "Walker2d-v2", "Walker2d-v3",
-    "Ant-v2"
-], **kwargs) -> Env[np.ndarray, np.ndarray]: ...
-
-# ----------------------------------------
-
-@overload
-def make(id: str, **kwargs) -> "Env": ...
-# fmt: on
-def make(id: str, **kwargs) -> "Env":
-    return registry.make(id, **kwargs)

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
+from typing import Sequence, SupportsFloat, overload, Any
+import sys
+
+import numpy as np
+
+from gym.core import Env
 from gym.envs.registration import (
     registry,
     register,
     spec,
     load_env_plugins as _load_env_plugins,
 )
-from typing import overload, TYPE_CHECKING, Any
-import sys
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -15,36 +21,6 @@ else:
         def __class_getitem__(cls, item):
             return Any
 
-
-if TYPE_CHECKING:
-    from gym.envs.classic_control import (
-        CartPoleEnv,
-        PendulumEnv,
-        AcrobotEnv,
-        MountainCarEnv,
-        Continuous_MountainCarEnv,
-    )
-    from gym.envs.box2d import (
-        LunarLander,
-        CarRacing,
-        LunarLanderContinuous,
-        BipedalWalker,
-    )
-    from gym.envs.toy_text import TaxiEnv, BlackjackEnv, FrozenLakeEnv, CliffWalkingEnv
-    from gym.envs.mujoco import (
-        AntEnv,
-        HopperEnv,
-        StrikerEnv,
-        SwimmerEnv,
-        Walker2dEnv,
-        ThrowerEnv,
-        HalfCheetahEnv,
-        ReacherEnv,
-        PusherEnv,
-        InvertedPendulumEnv,
-        InvertedDoublePendulumEnv,
-    )
-    from gym import Env
 
 # Hook to load plugins from entry points
 _load_env_plugins()
@@ -309,62 +285,54 @@ register(
 # ----------------------------------------
 
 @overload
-def make(id: Literal["CartPole-v0", "CartPole-v1"], **kwargs) -> "CartPoleEnv": ...
+def make(id: Literal["CartPole-v0", "CartPole-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload
-def make(id: Literal["MountainCar-v0"], **kwargs) -> "MountainCarEnv": ...
+def make(id: Literal["MountainCar-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload
-def make(id: Literal["MountainCarContinuous-v0"], **kwargs) -> "Continuous_MountainCarEnv": ...
+def make(id: Literal["MountainCarContinuous-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | Sequence[SupportsFloat]]: ...
 @overload
-def make(id: Literal["Pendulum-v1"], **kwargs) -> "PendulumEnv": ...
+def make(id: Literal["Pendulum-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | Sequence[SupportsFloat]]: ...
 @overload
-def make(id: Literal["Acrobot-v1"], **kwargs) -> "AcrobotEnv": ...
+def make(id: Literal["Acrobot-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 
 # Box2d
 # ----------------------------------------
 
 @overload
-def make(id: Literal["LunarLander-v2", "LunarLanderContinuous-v2"], **kwargs) -> "LunarLander": ...
+def make(id: Literal["LunarLander-v2", "LunarLanderContinuous-v2"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload
-def make(id: Literal["BipedalWalker-v3", "BipedalWalkerHardcore-v3"], **kwargs) -> "BipedalWalker": ...
+def make(id: Literal["BipedalWalker-v3", "BipedalWalkerHardcore-v3"], **kwargs) -> Env[np.ndarray, np.ndarray | Sequence[SupportsFloat]]: ...
 @overload
-def make(id: Literal["CarRacing-v0"], **kwargs) -> "CarRacing": ...
+def make(id: Literal["CarRacing-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | Sequence[SupportsFloat]]: ...
 
 # Toy Text
 # ----------------------------------------
 
 @overload
-def make(id: Literal["Blackjack-v1"], **kwargs) -> "BlackjackEnv": ...
+def make(id: Literal["Blackjack-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload
-def make(id: Literal["FrozenLake-v1", "FrozenLake8x8-v1"], **kwargs) -> "FrozenLakeEnv": ...
+def make(id: Literal["FrozenLake-v1", "FrozenLake8x8-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload
-def make(id: Literal["CliffWalking-v0"], **kwargs) -> "CliffWalkingEnv": ...
+def make(id: Literal["CliffWalking-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload
-def make(id: Literal["Taxi-v3"], **kwargs) -> "TaxiEnv": ...
+def make(id: Literal["Taxi-v3"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 
 # Mujoco
 # ----------------------------------------
 @overload
-def make(id: Literal["Reacher-v2"], **kwargs) -> "ReacherEnv": ...
-@overload
-def make(id: Literal["Pusher-v2"], **kwargs) -> "PusherEnv": ...
-@overload
-def make(id: Literal["Thrower-v2"], **kwargs) -> "ThrowerEnv": ...
-@overload
-def make(id: Literal["Striker-v2"], **kwargs) -> "StrikerEnv": ...
-@overload
-def make(id: Literal["InvertedPendulum-v2"], **kwargs) -> "InvertedPendulumEnv": ...
-@overload
-def make(id: Literal["InvertedDoublePendulum-v2"], **kwargs) -> "InvertedDoublePendulumEnv": ...
-@overload
-def make(id: Literal["HalfCheetah-v2", "HalfCheetah-v3"], **kwargs) -> "HalfCheetahEnv": ...
-@overload
-def make(id: Literal["Hopper-v2", "Hopper-v3"], **kwargs) -> "HopperEnv": ...
-@overload
-def make(id: Literal["Swimmer-v2", "Swimmer-v3"], **kwargs) -> "SwimmerEnv": ...
-@overload
-def make(id: Literal["Walker2d-v2", "Walker2d-v3"], **kwargs) -> "Walker2dEnv": ...
-@overload
-def make(id: Literal["Ant-v2"], **kwargs) -> "AntEnv": ...
+def make(id: Literal[
+    "Reacher-v2",
+    "Pusher-v2",
+    "Thrower-v2",
+    "Striker-v2",
+    "InvertedPendulum-v2",
+    "InvertedDoublePendulum-v2",
+    "HalfCheetah-v2", "HalfCheetah-v3",
+    "Hopper-v2", "Hopper-v3",
+    "Swimmer-v2", "Swimmer-v3",
+    "Walker2d-v2", "Walker2d-v3",
+    "Ant-v2"
+], **kwargs) -> Env[np.ndarray, np.ndarray]: ...
 
 # ----------------------------------------
 

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -1,10 +1,50 @@
 from gym.envs.registration import (
     registry,
     register,
-    make,
     spec,
     load_env_plugins as _load_env_plugins,
 )
+from typing import overload, TYPE_CHECKING, Any
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+
+    class Literal:
+        def __getitem__(self, parameters):
+            return Any
+
+
+if TYPE_CHECKING:
+    from gym.envs.classic_control import (
+        CartPoleEnv,
+        PendulumEnv,
+        AcrobotEnv,
+        MountainCarEnv,
+        Continuous_MountainCarEnv,
+    )
+    from gym.envs.box2d import (
+        LunarLander,
+        CarRacing,
+        LunarLanderContinuous,
+        BipedalWalker,
+    )
+    from gym.envs.toy_text import TaxiEnv, BlackjackEnv, FrozenLakeEnv, CliffWalkingEnv
+    from gym.envs.mujoco import (
+        AntEnv,
+        HopperEnv,
+        StrikerEnv,
+        SwimmerEnv,
+        Walker2dEnv,
+        ThrowerEnv,
+        HalfCheetahEnv,
+        ReacherEnv,
+        PusherEnv,
+        InvertedPendulumEnv,
+        InvertedDoublePendulumEnv,
+    )
+    from gym import Env
 
 # Hook to load plugins from entry points
 _load_env_plugins()
@@ -263,3 +303,73 @@ register(
     entry_point="gym.envs.mujoco:HumanoidStandupEnv",
     max_episode_steps=1000,
 )
+
+# fmt: off
+# Continuous
+# ----------------------------------------
+
+@overload
+def make(id: Literal["CartPole-v0", "CartPole-v1"], **kwargs) -> "CartPoleEnv": ...
+@overload
+def make(id: Literal["MountainCar-v0"], **kwargs) -> "MountainCarEnv": ...
+@overload
+def make(id: Literal["MountainCarContinuous-v0"], **kwargs) -> "Continuous_MountainCarEnv": ...
+@overload
+def make(id: Literal["Pendulum-v1"], **kwargs) -> "PendulumEnv": ...
+@overload
+def make(id: Literal["Acrobot-v1"], **kwargs) -> "AcrobotEnv": ...
+
+# Box2d
+# ----------------------------------------
+
+@overload
+def make(id: Literal["LunarLander-v2", "LunarLanderContinuous-v2"], **kwargs) -> "LunarLander": ...
+@overload
+def make(id: Literal["BipedalWalker-v3", "BipedalWalkerHardcore-v3"], **kwargs) -> "BipedalWalker": ...
+@overload
+def make(id: Literal["CarRacing-v0"], **kwargs) -> "CarRacing": ...
+
+# Toy Text
+# ----------------------------------------
+
+@overload
+def make(id: Literal["Blackjack-v1"], **kwargs) -> "BlackjackEnv": ...
+@overload
+def make(id: Literal["FrozenLake-v1", "FrozenLake8x8-v1"], **kwargs) -> "FrozenLakeEnv": ...
+@overload
+def make(id: Literal["CliffWalking-v0"], **kwargs) -> "CliffWalkingEnv": ...
+@overload
+def make(id: Literal["Taxi-v3"], **kwargs) -> "TaxiEnv": ...
+
+# Mujoco
+# ----------------------------------------
+@overload
+def make(id: Literal["Reacher-v2"], **kwargs) -> "ReacherEnv": ...
+@overload
+def make(id: Literal["Pusher-v2"], **kwargs) -> "PusherEnv": ...
+@overload
+def make(id: Literal["Thrower-v2"], **kwargs) -> "ThrowerEnv": ...
+@overload
+def make(id: Literal["Striker-v2"], **kwargs) -> "StrikerEnv": ...
+@overload
+def make(id: Literal["InvertedPendulum-v2"], **kwargs) -> "InvertedPendulumEnv": ...
+@overload
+def make(id: Literal["InvertedDoublePendulum-v2"], **kwargs) -> "InvertedDoublePendulumEnv": ...
+@overload
+def make(id: Literal["HalfCheetah-v2", "HalfCheetah-v3"], **kwargs) -> "HalfCheetahEnv": ...
+@overload
+def make(id: Literal["Hopper-v2", "Hopper-v3"], **kwargs) -> "HopperEnv": ...
+@overload
+def make(id: Literal["Swimmer-v2", "Swimmer-v3"], **kwargs) -> "SwimmerEnv": ...
+@overload
+def make(id: Literal["Walker2d-v2", "Walker2d-v3"], **kwargs) -> "Walker2dEnv": ...
+@overload
+def make(id: Literal["Ant-v2"], **kwargs) -> "AntEnv": ...
+
+# ----------------------------------------
+
+@overload
+def make(id: str, **kwargs) -> "Env": ...
+# fmt: on
+def make(id: str, **kwargs) -> "Env":
+    return registry.make(id, **kwargs)

--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info >= (3, 8):
 else:
 
     class Literal:
-        def __getitem__(self, parameters):
+        def __class_getitem__(cls, item):
             return Any
 
 

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import sys
 import copy
@@ -5,7 +7,19 @@ import difflib
 import importlib
 import importlib.util
 import contextlib
-from typing import Callable, Type, Optional, Union, Tuple, Generator, Sequence, cast
+from typing import (
+    Callable,
+    Type,
+    Optional,
+    Union,
+    Tuple,
+    Generator,
+    Sequence,
+    cast,
+    SupportsFloat,
+    overload,
+    Any,
+)
 
 if sys.version_info < (3, 10):
     import importlib_metadata as metadata  # type: ignore
@@ -16,8 +30,19 @@ from dataclasses import dataclass, field, InitVar
 from collections import defaultdict
 from collections.abc import MutableMapping
 
+import numpy as np
+
 from gym import error, logger, Env
 from gym.envs.__relocated__ import internal_env_relocation_map
+
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+
+    class Literal:
+        def __class_getitem__(cls, item):
+            return Any
 
 
 ENV_ID_RE: re.Pattern = re.compile(
@@ -585,6 +610,69 @@ registry = EnvRegistry()
 
 def register(id: str, **kwargs) -> None:
     return registry.register(id, **kwargs)
+
+
+# fmt: off
+# Continuous
+# ----------------------------------------
+
+@overload
+def make(id: Literal["CartPole-v0", "CartPole-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
+@overload
+def make(id: Literal["MountainCar-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
+@overload
+def make(id: Literal["MountainCarContinuous-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | Sequence[SupportsFloat]]: ...
+@overload
+def make(id: Literal["Pendulum-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | Sequence[SupportsFloat]]: ...
+@overload
+def make(id: Literal["Acrobot-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
+
+# Box2d
+# ----------------------------------------
+
+@overload
+def make(id: Literal["LunarLander-v2", "LunarLanderContinuous-v2"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
+@overload
+def make(id: Literal["BipedalWalker-v3", "BipedalWalkerHardcore-v3"], **kwargs) -> Env[np.ndarray, np.ndarray | Sequence[SupportsFloat]]: ...
+@overload
+def make(id: Literal["CarRacing-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | Sequence[SupportsFloat]]: ...
+
+# Toy Text
+# ----------------------------------------
+
+@overload
+def make(id: Literal["Blackjack-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
+@overload
+def make(id: Literal["FrozenLake-v1", "FrozenLake8x8-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
+@overload
+def make(id: Literal["CliffWalking-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
+@overload
+def make(id: Literal["Taxi-v3"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
+
+# Mujoco
+# ----------------------------------------
+@overload
+def make(id: Literal[
+    "Reacher-v2",
+    "Pusher-v2",
+    "Thrower-v2",
+    "Striker-v2",
+    "InvertedPendulum-v2",
+    "InvertedDoublePendulum-v2",
+    "HalfCheetah-v2", "HalfCheetah-v3",
+    "Hopper-v2", "Hopper-v3",
+    "Swimmer-v2", "Swimmer-v3",
+    "Walker2d-v2", "Walker2d-v3",
+    "Ant-v2"
+], **kwargs) -> Env[np.ndarray, np.ndarray]: ...
+
+# ----------------------------------------
+
+@overload
+def make(id: str, **kwargs) -> "Env": ...
+# fmt: on
+def make(id: str, **kwargs) -> "Env":
+    return registry.make(id, **kwargs)
 
 
 def spec(id: str) -> EnvSpec:

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -40,7 +40,7 @@ if sys.version_info >= (3, 8):
     from typing import Literal
 else:
 
-    class Literal:
+    class Literal(str):
         def __class_getitem__(cls, item):
             return Any
 

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -587,10 +587,6 @@ def register(id: str, **kwargs) -> None:
     return registry.register(id, **kwargs)
 
 
-def make(id: str, **kwargs) -> Env:
-    return registry.make(id, **kwargs)
-
-
 def spec(id: str) -> EnvSpec:
     return registry.spec(id)
 


### PR DESCRIPTION
This uses Literal to type all registered IDs of `gym.make` factory function.

Although `Literal` is not available in python3.7, it can bring much value to users of later python versions.
The overrides are done as close as possible to registration of aliases to ease future maintenance. This necessitated moving definion of `make` alias for `registry.make` to `__init__.py`. This is described in more detail in https://mypy.readthedocs.io/en/stable/literal_types.html ("overrides need to be followed by implementation when done outside of a stub file). 

## Rejected ideas
I've considered adding a stub file but this needs to duplicate all the typing we've already put in the source code, so this idea was rejected.

Instead of moving definition of make into dunder init, it might have worked to just import it after overrides, but this would break even more conventions.

## Roadmap

* There's already a PR for partially typing classical environments: #2589
* Add typing to other families of environments (Box2D?, Toy-Text, Mujoco?) - if some will be moved out of gym - let me know, I'll skip them
* We can make type checking more strict by e.g. requiring typing all signatures.
