### PR TITLE
Improvements to Reacher Documentation

### DIFF
--- a/gym/envs/mujoco/reacher.py
+++ b/gym/envs/mujoco/reacher.py
@@ -10,7 +10,7 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     target that is spawned at a random position.
 
     ### Action Space
-    The action space is [-1, 1]<sup>2</sup>. An action `(a, b)` represents the torques applied at the hinge joints.
+    The action space is a `Box(-1, 1, (2,), float32)`. An action `(a, b)` represents the torques applied at the hinge joints.
 
     | Num | Action                                                                          | Control Min | Control Max | Name (in corresponding XML file) | Joint | Unit |
     |-----|---------------------------------------------------------------------------------|-------------|-------------|--------------------------|-------|------|
@@ -70,6 +70,11 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     Euclidean norm of the action, i.e. as *- sum(action<sup>2</sup>)*.
 
     The total reward returned is ***reward*** *=* *reward_distance + reward_control*
+
+    Unlike other environments, Reacher does not allow you to specify weights for the individual reward terms.
+    However, `info` does contain the keys *reward_dist* and *reward_ctrl*. Thus, if you'd like to weight the terms,
+    you should create a wrapper that computes the weighted reward from `info`.
+
 
     ### Starting State
     All observations start in state

--- a/gym/envs/mujoco/reacher.py
+++ b/gym/envs/mujoco/reacher.py
@@ -6,12 +6,11 @@ from gym.envs.mujoco import mujoco_env
 class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     """
     ### Description
+    "Reacher" is a two-jointed robot arm. The goal is to move the robot's end effector (called *fingertip*) close to a
+    target that is spawned at a random position.
 
     ### Action Space
-    The agent take a 2-element vector for actions.
-    The action space is a continuous `(action, action)` all in
-    `[-1, 1]`, where `action` represents the numerical torques
-    applied at the hinge joints.
+    The action space is [-1, 1]<sup>2</sup>. An action `(a, b)` represents the torques applied at the hinge joints.
 
     | Num | Action                                                                          | Control Min | Control Max | Name (in corresponding XML file) | Joint | Unit |
     |-----|---------------------------------------------------------------------------------|-------------|-------------|--------------------------|-------|------|
@@ -20,9 +19,13 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Observation Space
 
-    The state space consists of positional values of different body parts of the
-    hopper, followed by the velocities of those individual parts (their derivatives)
-    with all the positions ordered before all the velocities.
+    Observations consist of
+
+    - The cosine of the angles of the two arms
+    - The sine of the angles of the two arms
+    - The coordinates of the target
+    - The angular velocities of the arms
+    - The vector between the target and the reacher's fingertip (3 dimensional with the last element being 0)
 
     The observation is a `ndarray` with shape `(11,)` where the elements correspond to the following:
 
@@ -30,8 +33,8 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     |-----|-----------------------|----------------------|--------------------|----------------------|--------------------|--------------------|
     | 0   | cosine of the angle of the first arm                                                            | -Inf                 | Inf                | cos(joint0) | hinge | unitless |
     | 1   | cosine of the angle of the second arm                                                           | -Inf                 | Inf                | cos(joint1) | hinge | unitless |
-    | 2   | cosine of the angle of the first arm                                                            | -Inf                 | Inf                | cos(joint0) | hinge | unitless |
-    | 3   | cosine of the angle of the second arm                                                           | -Inf                 | Inf                | cos(joint1) | hinge | unitless |
+    | 2   | sine of the angle of the first arm                                                              | -Inf                 | Inf                | cos(joint0) | hinge | unitless |
+    | 3   | sine of the angle of the second arm                                                             | -Inf                 | Inf                | cos(joint1) | hinge | unitless |
     | 4   |  x-coorddinate of the target                                                                    | -Inf                 | Inf                | target_x | slide | position (m) |
     | 5   |  y-coorddinate of the target                                                                    | -Inf                 | Inf                | target_y | slide | position (m) |
     | 6   | angular velocity of the first arm                                                               | -Inf                 | Inf                | joint0 | hinge | angular velocity (rad/s) |
@@ -46,10 +49,11 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     reacher the state is created by combining only certain elements of the
     position and velocity, and performing some function transformations on them.
     If one is to read the `.xml` for reacher then they will find 4 joints:
+
     | Num | Observation                 | Min      | Max      | Name (in corresponding XML file) | Joint | Unit               |
     |-----|-----------------------------|----------|----------|----------------------------------|-------|--------------------|
-    | 0   | angle of the first arm      | -Inf     | Inf      | joint0                           | hinge | angle (rad         |
-    | 1   | angle of the second arm     | -Inf     | Inf      | joint1                           | hinge | angle (rad         |
+    | 0   | angle of the first arm      | -Inf     | Inf      | joint0                           | hinge | angle (rad)        |
+    | 1   | angle of the second arm     | -Inf     | Inf      | joint1                           | hinge | angle (rad)        |
     | 2   | x-coordinate of the target  | -Inf     | Inf      | target_x                         | slide | position (m)       |
     | 3   | y-coordinate of the target  | -Inf     | Inf      | target_y                         | slide | position (m)       |
 
@@ -58,14 +62,12 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     The reward consists of two parts:
     - *reward_distance*: This reward is a measure of how far the *fingertip*
     of the reacher (the unattached end) is from the target, with a more negative
-    value assigned for when the reacher *fingertip* is further away from the
-    target. It is ccalculated as the negative of vector norm of (position of
+    value assigned for when the reacher's *fingertip* is further away from the
+    target. It is calculated as the negative vector norm of (position of
     the fingertip - position of target), or *-norm("fingertip" - "target")*.
     - *reward_control*: A negative reward for penalising the walker if
-    it takes actions that are too large. It is measured as
-    *- **x** sum(action<sup>2</sup>)* (unlike otther enviroonments,
-    where *coefficient* is a parameter set for the control, the value
-    here is static and fixed to 1. It can be tweakedd by using a default class).
+    it takes actions that are too large. It is measured as the negative squared
+    Euclidean norm of the action, i.e. as *- sum(action<sup>2</sup>)*.
 
     The total reward returned is ***reward*** *=* *reward_distance + reward_control*
 
@@ -73,11 +75,12 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     All observations start in state
     (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
     with a noise added for stochasticity. A uniform noise in the range
-    [-0.1, 0.1] is added to the posititional attributes, while the target
-    is selecting uniformly in the range [-0.2, 0.2]. A uniform noise in the
-    range of [-0.005, 0.005] is added to the velocity elements, and the last
-    index ("fingertip" - "target" distance) is calculated at the end once everything
-    is set. The default setting has a framerate of 2 and a *dt = 4 * 0.01 = 0.02*
+    [-0.1, 0.1] is added to the positional attributes, while the target position
+    is selected uniformly at random in a disk of radius 0.2 around the origin.
+    Independent, uniform noise in the
+    range of [-0.005, 0.005] is added to the velocities, and the last
+    element ("fingertip" - "target") is calculated at the end once everything
+    is set. The default setting has a framerate of 2 and a *dt = 2 * 0.01 = 0.02*
 
     ### Episode Termination
 
@@ -102,7 +105,6 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Version History
 
-    * v3: support for gym.make kwargs such as xml_file, ctrl_cost_weight, reset_noise_scale etc. rgb rendering comes from tracking camera (so agent does not run away from screen)
     * v2: All continuous control environments now use mujoco_py >= 1.50
     * v1: max_time_steps raised to 1000 for robot based tasks (not including reacher, which has a max_time_steps of 50). Added reward_threshold to environments.
     * v0: Initial versions release (1.0.0)


### PR DESCRIPTION
This pull request aims to make some improvements to the documentation of Reacher. I have made the following changes:

### General
- Corrected some typos and some grammar. I'm not a native speaker and didn't want to introduce new mistakes, so I didn't make all the changes I believe would be necessary. Someone else might want to check this.

### Description
- Description was missing. I provided a brief description

### Action Space
- The first paragraph was quite confusing because it talked about an agent and denoted actions as `(action, action)`, implying that actions are only permitted to be on the main diagonal of R<sup>2</sup>.

### Observation Space
- The first paragraph wasn't accurate since observations also include the position of the target and the vector between the target and the reacher's fingertip 
- The second table of this section only listed cosines of the angles. This appears to be a copy-paste mistake, and the rows corresponding to Num 2,3 probably should be "sine".
- The third table of this section wasn't rendered correctly in HTML, seemingly because there is a missing line break
- Some closing parentheses were missing in the third table

### Rewards
- "Walker" was mentioned in the description of *reward_control*. Moreover, a weight for *reward_control* was mentioned. While such a weight exists for Walker, I don't believe it exists for Reacher. @RushivArora  correct me if I'm wrong.

### Starting State
- It was stated that the target is selected uniformly at random in [-0.2, 0.2]. However, it is chosen uniformly at random in a disk of radius 0.2 around the origin.
- "and the last index (“fingertip” - “target” distance)" -> "and the last element (“fingertip” - “target”)"
- The calculation *dt = 4 * 0.01 = 0.02* is obviously wrong. *dt=0.2* seems to be correct and I believe that the *4* should be a *2* (for frameskip) so I replaced it.

### Versions
- I don't believe there is a v3 of Reacher, so I removed *v3. The information for v1 is quite confusing since it is supposed to pertain to Reacher but explicitly excludes Reacher. I was not sure whether to remove the sentence "max_time_steps raised to 1000 for robot based tasks (not including reacher, which has a max_time_steps of 50)." and I left it in for now. I'm not sure how accurate the other version information is.