### PR TITLE
Fix minor bug with Cartpole

### DIFF
--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -194,6 +194,9 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         cartwidth = 50.0
         cartheight = 30.0
 
+        if self.state is None:
+            return None
+
         x = self.state
 
         if self.screen is None:


### PR DESCRIPTION
For render, the state might be `None`, hence we should just return `None` if that is the case