### PR TITLE
Updating MuJoCo docstrings

### DIFF
--- a/gym/envs/mujoco/ant_v3.py
+++ b/gym/envs/mujoco/ant_v3.py
@@ -102,7 +102,7 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Rewards
     The reward consists of three parts:
-    - *survive_reward*: Every timestep that the ant is healthy, it gets a reward of fixed value `healthy_reward`
+    - *survive_reward*: Every timestep that the ant is healthy (see definition in section "Episode Termination"), it gets a reward of fixed value `healthy_reward`
     - *forward_reward*: A reward of moving forward which is measured as
     *(x-coordinate before action - x-coordinate after action)/dt*. *dt* is the time
     between actions and is dependent on the `frame_skip` parameter (default is 5),
@@ -127,20 +127,22 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     is designed to make it face forward as well.
 
     ### Episode Termination
+    The ant is said to be unhealthy if any of the following happens:
+
+    1. Any of the state space values is no longer finite
+    2. The z-coordinate of the torso is **not** in the closed interval given by `healthy_z_range` (defaults to [0.2, 1.0])
+
     If `terminate_when_unhealthy=True` is passed during construction (which is the default),
     the episode terminates when any of the following happens:
 
     1. The episode duration reaches a 1000 timesteps
-    2. Any of the state space values is no longer finite
-    3. The z-coordinate of the torso is **not** in the closed interval given by `healthy_z_range` (defaults to [0.2, 1.0])
+    2. The ant is unhealthy
 
-    Otherwise (i.e., if `terminate_when_unhealthy=False` is passed), the episode is terminated only when 1000 timesteps are exceeded.
+    If `terminate_when_unhealthy=False` is passed, the episode is terminated only when 1000 timesteps are exceeded.
 
     ### Arguments
 
-    No additional arguments are currently supported in v2 and lower, but modifications
-    can be made to the XML file in the assets folder (or by changing the path to a modified
-    XML file in another folder).
+    No additional arguments are currently supported in v2 and lower.
 
     ```
     env = gym.make('Ant-v2')

--- a/gym/envs/mujoco/ant_v3.py
+++ b/gym/envs/mujoco/ant_v3.py
@@ -22,11 +22,7 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     (nine parts and eight hinges).
 
     ### Action Space
-    The agent take a 8-element vector for actions.
-
-    The action space is a continuous `(action, action, action, action, action, action,
-    action, action)` all in `[-1, 1]`, where `action` represents the numerical torques
-    applied at the hinge joints.
+    The action space is a `Box(-1, 1, (8,), float32)`. An action represents the torques applied at the hinge joints.
 
     | Num | Action                    | Control Min | Control Max | Name (in corresponding XML file) | Joint | Unit |
     |-----|----------------------|---------------|----------------|---------------------------------------|-------|------|
@@ -41,46 +37,50 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Observation Space
 
-    The state space consists of positional values of different body parts of the ant,
+    Observations consist of positional values of different body parts of the ant,
     followed by the velocities of those individual parts (their derivatives) with all
     the positions ordered before all the velocities.
 
-    The observation is a `ndarray` with shape `(111,)` where the elements correspond to the following:
+    By default, observations do not include the x- and y-coordinates of the ant's torso. These may
+    be included by passing `exclude_current_positions_from_observation=False` during construction.
+    In that case, the observation space will have 113 dimensions where the first two dimensions
+    represent the x- and y- coordinates of the ant's torso.
+
+    However, by default, an observation is a `ndarray` with shape `(111,)`
+    where the elements correspond to the following:
 
     | Num | Observation                                                 | Min                | Max                | Name (in corresponding XML file) | Joint | Unit |
     |-----|-------------------------------------------------------------|----------------|-----------------|----------------------------------------|-------|------|
-    | 0   | x-coordinate of the torso (centre)                          | -Inf                 | Inf                | torso      | free | position (m) |
-    | 1   | y-coordinate of the torso (centre)                          | -Inf                 | Inf                | torso      | free | position (m) |
-    | 2   | z-coordinate of the torso (centre)                          | -Inf                 | Inf                | torso      | free | position (m) |
-    | 3   | x-orientation of the torso (centre)                         | -Inf                 | Inf                | torso      | free | angle (rad) |
-    | 4   | y-orientation of the torso (centre)                         | -Inf                 | Inf                | torso      | free | angle (rad) |
-    | 5   | z-orientation of the torso (centre)                         | -Inf                 | Inf                | torso      | free | angle (rad) |
-    | 6   | w-orientation of the torso (centre)                         | -Inf                 | Inf               | torso       | free | angle (rad) |
-    | 7   | angle between torso and first link on front left            | -Inf                 | Inf               | hip_1 (front_left_leg) | hinge | angle (rad) |
-    | 8   | angle between the two links on the front left               | -Inf                 | Inf               | ankle_1 (front_left_leg) | hinge | angle (rad) |
-    | 9   | angle between torso and first link on front right           | -Inf                 | Inf               | hip_2 (front_right_leg) | hinge | angle (rad) |
-    | 10  | angle between the two links on the front right              | -Inf                 | Inf               | ankle_2 (front_right_leg) | hinge | angle (rad) |
-    | 11  | angle between torso and first link on back left             | -Inf                 | Inf               | hip_3 (back_leg) | hinge | angle (rad) |
-    | 12  | angle between the two links on the back left                | -Inf                 | Inf               | ankle_3 (back_leg) | hinge | angle (rad) |
-    | 13  | angle between torso and first link on back right            | -Inf                 | Inf               | hip_4 (right_back_leg) | hinge | angle (rad) |
-    | 14  | angle between the two links on the back right               | -Inf                 | Inf               | ankle_4 (right_back_leg) | hinge | angle (rad) |
-    | 15  | x-coordinate velocity of the torso                          | -Inf                 | Inf                | torso      | free | velocity (m/s) |
-    | 16  | y-coordinate velocity of the torso                          | -Inf                 | Inf                | torso      | free | velocity (m/s) |
-    | 17  | z-coordinate velocity of the torso                          | -Inf                 | Inf                | torso      | free | velocity (m/s) |
-    | 18  | x-coordinate angular velocity of the torso                  | -Inf                 | Inf                | torso      | free | angular velocity (rad/s) |
-    | 19  | y-coordinate angular velocity of the torso                  | -Inf                 | Inf                | torso      | free | angular velocity (rad/s) |
-    | 20  | z-coordinate angular velocity of the torso                  | -Inf                 | Inf                | torso      | free | angular velocity (rad/s) |
-    | 21  | angular velocity of angle between torso and front left link | -Inf                 | Inf               | hip_1 (front_left_leg) | hinge | angle (rad) |
-    | 22  | angular velocity of the angle between front left links      | -Inf                 | Inf               | ankle_1 (front_left_leg) | hinge | angle (rad) |
-    | 23  | angular velocity of angle between torso and front right link| -Inf                 | Inf               | hip_2 (front_right_leg) | hinge | angle (rad) |
-    | 24  | angular velocity of the angle between front right links     | -Inf                 | Inf               | ankle_2 (front_right_leg) | hinge | angle (rad) |
-    | 25  | angular velocity of angle between torso and back left link  | -Inf                 | Inf               | hip_3 (back_leg) | hinge | angle (rad) |
-    | 26  | angular velocity of the angle between back left links       | -Inf                 | Inf               | ankle_3 (back_leg) | hinge | angle (rad) |
-    | 27  | angular velocity of angle between torso and back right link | -Inf                 | Inf               | hip_4 (right_back_leg) | hinge | angle (rad) |
-    | 28  |angular velocity of the angle between back right links       | -Inf                 | Inf               | ankle_4 (right_back_leg) | hinge | angle (rad) |
+    | 0   | z-coordinate of the torso (centre)                          | -Inf                 | Inf                | torso      | free | position (m) |
+    | 1   | x-orientation of the torso (centre)                         | -Inf                 | Inf                | torso      | free | angle (rad) |
+    | 2   | y-orientation of the torso (centre)                         | -Inf                 | Inf                | torso      | free | angle (rad) |
+    | 3   | z-orientation of the torso (centre)                         | -Inf                 | Inf                | torso      | free | angle (rad) |
+    | 4   | w-orientation of the torso (centre)                         | -Inf                 | Inf               | torso       | free | angle (rad) |
+    | 5   | angle between torso and first link on front left            | -Inf                 | Inf               | hip_1 (front_left_leg) | hinge | angle (rad) |
+    | 6   | angle between the two links on the front left               | -Inf                 | Inf               | ankle_1 (front_left_leg) | hinge | angle (rad) |
+    | 7   | angle between torso and first link on front right           | -Inf                 | Inf               | hip_2 (front_right_leg) | hinge | angle (rad) |
+    | 8  | angle between the two links on the front right              | -Inf                 | Inf               | ankle_2 (front_right_leg) | hinge | angle (rad) |
+    | 9  | angle between torso and first link on back left             | -Inf                 | Inf               | hip_3 (back_leg) | hinge | angle (rad) |
+    | 10  | angle between the two links on the back left                | -Inf                 | Inf               | ankle_3 (back_leg) | hinge | angle (rad) |
+    | 11 | angle between torso and first link on back right            | -Inf                 | Inf               | hip_4 (right_back_leg) | hinge | angle (rad) |
+    | 12  | angle between the two links on the back right               | -Inf                 | Inf               | ankle_4 (right_back_leg) | hinge | angle (rad) |
+    | 13  | x-coordinate velocity of the torso                          | -Inf                 | Inf                | torso      | free | velocity (m/s) |
+    | 14  | y-coordinate velocity of the torso                          | -Inf                 | Inf                | torso      | free | velocity (m/s) |
+    | 15  | z-coordinate velocity of the torso                          | -Inf                 | Inf                | torso      | free | velocity (m/s) |
+    | 16  | x-coordinate angular velocity of the torso                  | -Inf                 | Inf                | torso      | free | angular velocity (rad/s) |
+    | 17  | y-coordinate angular velocity of the torso                  | -Inf                 | Inf                | torso      | free | angular velocity (rad/s) |
+    | 18  | z-coordinate angular velocity of the torso                  | -Inf                 | Inf                | torso      | free | angular velocity (rad/s) |
+    | 19  | angular velocity of angle between torso and front left link | -Inf                 | Inf               | hip_1 (front_left_leg) | hinge | angle (rad) |
+    | 20  | angular velocity of the angle between front left links      | -Inf                 | Inf               | ankle_1 (front_left_leg) | hinge | angle (rad) |
+    | 21  | angular velocity of angle between torso and front right link| -Inf                 | Inf               | hip_2 (front_right_leg) | hinge | angle (rad) |
+    | 22  | angular velocity of the angle between front right links     | -Inf                 | Inf               | ankle_2 (front_right_leg) | hinge | angle (rad) |
+    | 23  | angular velocity of angle between torso and back left link  | -Inf                 | Inf               | hip_3 (back_leg) | hinge | angle (rad) |
+    | 24  | angular velocity of the angle between back left links       | -Inf                 | Inf               | ankle_3 (back_leg) | hinge | angle (rad) |
+    | 25  | angular velocity of angle between torso and back right link | -Inf                 | Inf               | hip_4 (right_back_leg) | hinge | angle (rad) |
+    | 26  |angular velocity of the angle between back right links       | -Inf                 | Inf               | ankle_4 (right_back_leg) | hinge | angle (rad) |
 
 
-    The remaining 14*6 = 84 elements in the state are contact forces
+    The remaining 14*6 = 84 elements of the observation are contact forces
     (external forces - force x, y, z and torque x, y, z) applied to the
     center of mass of each of the links. The 14 links are: the ground link,
     the torso link, and 3 links for each leg (1 + 1 + 12) with the 6 external forces.
@@ -88,12 +88,12 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     The (x,y,z) coordinates are translational DOFs while the orientations are rotational
     DOFs expressed as quaternions. One can read more about free joints on the [Mujoco Documentation](https://mujoco.readthedocs.io/en/latest/XMLreference.html).
 
-    **Note:** There are 29 elements in the table above - giving rise to `(113,)` elements
-    in the state space. In practice (and Gym implementation), the first two positional
-    elements are omitted from the state space since the reward function is calculated based
+    **Note:** The first two positional
+    coordinates of the torso are omitted from the observation by default since the reward function is calculated based
     on the x-coordinate value. This value is hidden from the algorithm, which in turn has to
-    develop an abstract understanding of it from the observed rewards. Therefore, observation
-    space has shape `(111,)` instead of `(113,)` and the table should not have the first two rows.
+    develop an abstract understanding of it from the observed rewards.
+    Regardless of whether `exclude_current_positions_from_observation` was set to true or false, the x- and y-coordinates
+    of the torso will be returned in `info` with keys `x_position` and `y_position`, respectively.
 
     **Note:** There have been reported issues that using a Mujoco-Py version > 2.0 results
     in the contact forces always being 0. As such we recommend to use a Mujoco-Py version < 2.0
@@ -102,40 +102,43 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Rewards
     The reward consists of three parts:
-    - *survive_reward*: Every timestep that the ant is alive, it gets a reward of 1.
+    - *survive_reward*: Every timestep that the ant is healthy, it gets a reward of fixed value `healthy_reward`
     - *forward_reward*: A reward of moving forward which is measured as
     *(x-coordinate before action - x-coordinate after action)/dt*. *dt* is the time
-    between actions and is dependent on the frame_skip parameter (default is 5),
-    where the *dt* for one frame is 0.01 - making the default *dt = 5 * 0.01 = 0.05*.
-    This reward would be positive if the ant moves forward (right) desired.
+    between actions and is dependent on the `frame_skip` parameter (default is 5),
+    where the frametime is 0.01 - making the default *dt = 5 * 0.01 = 0.05*.
+    This reward would be positive if the ant moves forward (in positive x direction).
     - *ctrl_cost*: A negative reward for penalising the ant if it takes actions
-    that are too large. It is measured as *coefficient **x** sum(action<sup>2</sup>)*
-    where *coefficient* is a parameter set for the control and has a default value of 0.5.
+    that are too large. It is measured as *`ctrl_cost_weight` * sum(action<sup>2</sup>)*
+    where *`ctr_cost_weight`* is a parameter set for the control and has a default value of 0.5.
     - *contact_cost*: A negative reward for penalising the ant if the external contact
-    force is too large. It is calculated *0.5 * 0.001 * sum(clip(external contact
-    force to [-1,1])<sup>2</sup>)*.
+    force is too large. It is calculated *`contact_cost_weight` * sum(clip(external contact
+    force to `contact_force_range`)<sup>2</sup>)*.
 
     The total reward returned is ***reward*** *=* *alive survive_reward + forward_reward - ctrl_cost - contact_cost*
 
     ### Starting State
     All observations start in state
     (0.0, 0.0,  0.75, 1.0, 0.0  ... 0.0) with a uniform noise in the range
-    of [-0.1, 0.1] added to the positional values and standard normal noise
-    with 0 mean and 0.1 standard deviation added to the velocity values for
+    of [-`reset_noise_scale`, `reset_noise_scale`] added to the positional values and standard normal noise
+    with mean 0 and standard deviation `reset_noise_scale` added to the velocity values for
     stochasticity. Note that the initial z coordinate is intentionally selected
     to be slightly high, thereby indicating a standing up ant. The initial orientation
     is designed to make it face forward as well.
 
     ### Episode Termination
-    The episode terminates when any of the following happens:
+    If `terminate_when_unhealthy=True` is passed during construction (which is the default),
+    the episode terminates when any of the following happens:
 
     1. The episode duration reaches a 1000 timesteps
     2. Any of the state space values is no longer finite
-    3. The y-orientation (index 2) in the state is **not** in the range `[0.2, 1.0]`
+    3. The z-coordinate of the torso is **not** in the closed interval given by `healthy_z_range` (defaults to [0.2, 1.0])
+
+    Otherwise (i.e., if `terminate_when_unhealthy=False` is passed), the episode is terminated only when 1000 timesteps are exceeded.
 
     ### Arguments
 
-    No additional arguments are currently supported (in v2 and lower), but modifications
+    No additional arguments are currently supported in v2 and lower, but modifications
     can be made to the XML file in the assets folder (or by changing the path to a modified
     XML file in another folder).
 
@@ -148,6 +151,18 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     ```
     env = gym.make('Ant-v3', ctrl_cost_weight=0.1, ...)
     ```
+
+    | Parameter               | Type       | Default      |Description                    |
+    |-------------------------|------------|--------------|-------------------------------|
+    | `xml_file`              | **str**    | `"ant.xml"`  | Path to a MuJoCo model |
+    | `ctrl_cost_weight`      | **float**  | `0.5`        | Weight for control cost in reward (see section on reward) |
+    | `contact_cost_weight`   | **float**  | `5e-4`       | Weight for contact cost in reward (see section on reward) |
+    | `healthy_reward`        | **float**  | `1`          | Constant reward given if the ant is "healthy" after timestep |
+    | `terminate_when_unhealthy` | **bool**| `True`       | If true, issue a done signal if the z-coordinate of the torso is no longer in the `healthy_z_range` |
+    | `healthy_z_range`       | **tuple**  | `(0.2, 1)`   | The ant is considered healthy if the z-coordinate of the torso is in this range |
+    | `contact_force_range`   | **tuple**  | `(-1, 1)`    | Contact forces are clipped to this range in the computation of *contact_cost* |
+    | `reset_noise_scale`     | **float**  | `0.1`        | Scale of random perturbations of initial position and velocity (see section on Starting State) |
+    | `exclude_current_positions_from_observation`| **bool** | `True`| Whether or not to omit the x- and y-coordinates from observations. Excluding the position can serve as an inductive bias to induce position-agnostic behavior in policies |
 
     ### Version History
 

--- a/gym/envs/mujoco/half_cheetah_v3.py
+++ b/gym/envs/mujoco/half_cheetah_v3.py
@@ -45,6 +45,8 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     be included by passing `exclude_current_positions_from_observation=False` during construction.
     In that case, the observation space will have 18 dimensions where the first dimension
     represents the x-coordinate of the cheetah's center of mass.
+    Regardless of whether `exclude_current_positions_from_observation` was set to true or false, the x-coordinate
+    will be returned in `info` with key `"x_position"`.
 
     However, by default, the observation is a `ndarray` with shape `(17,)` where the elements correspond to the following:
 
@@ -71,18 +73,18 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Rewards
     The reward consists of two parts:
-    - *reward_run*: A reward of moving forward which is measured
+    - *forward_reward*: A reward of moving forward which is measured
     as *`forward_reward_weight` * (x-coordinate before action - x-coordinate after action)/dt*. *dt* is
     the time between actions and is dependent on the frame_skip parameter
     (fixed to 5), where the frametime is 0.01 - making the
     default *dt = 5 * 0.01 = 0.05*. This reward would be positive if the cheetah
     runs forward (right).
-    - *reward_control*: A negative reward for penalising the cheetah if it takes
-    actions that are too large. It is measured as *-`ctrl_cost_weight` *
+    - *ctrl_cost*: A cost for penalising the cheetah if it takes
+    actions that are too large. It is measured as *`ctrl_cost_weight` *
     sum(action<sup>2</sup>)* where *`ctrl_cost_weight`* is a parameter set for the
     control and has a default value of 0.1
 
-    The total reward returned is ***reward*** *=* *reward_run + reward_control*
+    The total reward returned is ***reward*** *=* *forward_reward - ctrl_cost* and `info` will also contain the individual reward terms
 
     ### Starting State
     All observations start in state (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -113,8 +115,8 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     | Parameter               | Type       | Default              |Description                    |
     |-------------------------|------------|----------------------|-------------------------------|
     | `xml_file`              | **str**    | `"half_cheetah.xml"` | Path to a MuJoCo model |
-    | `forward_reward_weight` | **float**  | `1.0`                | Weight for *reward_run* in reward (see section on reward) |
-    | `ctrl_cost_weight`      | **float**  | `0.1`                | Weight for control cost in reward (see section on reward) |
+    | `forward_reward_weight` | **float**  | `1.0`                | Weight for *forward_reward* term (see section on reward) |
+    | `ctrl_cost_weight`      | **float**  | `0.1`                | Weight for *ctrl_cost* weight (see section on reward) |
     | `reset_noise_scale`     | **float**  | `0.1`                | Scale of random perturbations of initial position and velocity (see section on Starting State) |
     | `exclude_current_positions_from_observation`| **bool** | `True` | Whether or not to omit the x-coordinate from observations. Excluding the position can serve as an inductive bias to induce position-agnostic behavior in policies |
 

--- a/gym/envs/mujoco/half_cheetah_v3.py
+++ b/gym/envs/mujoco/half_cheetah_v3.py
@@ -25,8 +25,7 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     (connecting to the thighs) and feet (connecting to the shins).
 
     ### Action Space
-    The agent take a 6-element vector for actions.
-    The action space is a continuous `(action, action, action, action, action, action)` all in `[-1.0, 1.0]`, where `action` represents the numerical torques applied between *links*
+    The action space is a `Box(-1, 1, (6,), float32)`. An action represents the torques applied between *links*.
 
     | Num | Action                                 | Control Min | Control Max | Name (in corresponding XML file) | Joint | Unit |
     |-------|--------------------------------------|---------------|----------------|---------------------------------------|-------|------|
@@ -39,43 +38,20 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Observation Space
 
-    The state space consists of positional values of different body parts of the
+    Observations consist of positional values of different body parts of the
     cheetah, followed by the velocities of those individual parts (their derivatives) with all the positions ordered before all the velocities.
 
-    The observation is a `ndarray` with shape `(17,)` where the elements correspond to the following:
+    By default, observations do not include the x-coordinate of the cheetah's center of mass. It may
+    be included by passing `exclude_current_positions_from_observation=False` during construction.
+    In that case, the observation space will have 18 dimensions where the first dimension
+    represents the x-coordinate of the cheetah's center of mass.
+
+    However, by default, the observation is a `ndarray` with shape `(17,)` where the elements correspond to the following:
+
 
     | Num | Observation           | Min                  | Max                | Name (in corresponding XML file) | Joint| Unit |
     |-----|-----------------------|----------------------|--------------------|----------------------|--------------------|--------------------|
-    | 0     | x-coordinate of the center of mass         | -Inf                 | Inf                | rootx | slide | position (m) |
-    | 1     | y-coordinate of the center of mass         | -Inf                 | Inf                | rootz | slide | position (m) |
-    | 2     | angle of the front tip                     | -Inf                 | Inf                | rooty | hinge | angle (rad) |
-    | 3     | angle of the back thigh rotor              | -Inf                 | Inf                | bthigh | hinge | angle (rad) |
-    | 4     | angle of the back shin rotor               | -Inf                 | Inf                | bshin | hinge | angle (rad) |
-    | 5     | angle of the back foot rotor               | -Inf                 | Inf                | bfoot | hinge | angle (rad) |
-    | 6     | velocity of the tip along the y-axis       | -Inf                 | Inf                | fthigh | hinge | angle (rad) |
-    | 7     | angular velocity of front tip              | -Inf                 | Inf                | fshin | hinge | angle (rad) |
-    | 8     | angular velocity of second rotor           | -Inf                 | Inf                | ffoot | hinge | angle (rad) |
-    | 9     | x-coordinate of the front tip              | -Inf                 | Inf                | rootx | slide | velocity (m/s) |
-    | 10   | y-coordinate of the front tip               | -Inf                 | Inf                | rootz | slide | velocity (m/s) |
-    | 11   | angle of the front tip                      | -Inf                 | Inf                | rooty | hinge | angular velocity (rad/s) |
-    | 12   | angle of the second rotor                   | -Inf                 | Inf                | bthigh | hinge | angular velocity (rad/s) |
-    | 13   | angle of the second rotor                   | -Inf                 | Inf                | bshin | hinge | angular velocity (rad/s) |
-    | 14   | velocity of the tip along the x-axis        | -Inf                 | Inf                | bfoot | hinge | angular velocity (rad/s) |
-    | 15   | velocity of the tip along the y-axis        | -Inf                 | Inf                | fthigh | hinge |angular velocity (rad/s) |
-    | 16   | angular velocity of front tip               | -Inf                 | Inf                | fshin | hinge | angular velocity (rad/s) |
-    | 17   | angular velocity of second rotor            | -Inf                 | Inf                | ffoot | hinge | angular velocity (rad/s) |
-
-
-    **Note:**
-    In practice (and Gym implementation), the first positional element is
-    omitted from the state space since the reward function is calculated based
-    on that value. This value is hidden from the algorithm, which in turn has
-    to develop an abstract understanding of it from the observed rewards.
-    Therefore, observation space has shape `(8,)` and looks like:
-
-    | Num | Observation           | Min                  | Max                | Name (in corresponding XML file) | Joint| Unit |
-    |-----|-----------------------|----------------------|--------------------|----------------------|--------------------|--------------------|
-    | 0     | y-coordinate of the front tip              | -Inf                 | Inf                | rootz | slide | position (m) |
+    | 0     | z-coordinate of the front tip              | -Inf                 | Inf                | rootz | slide | position (m) |
     | 1     | angle of the front tip                     | -Inf                 | Inf                | rooty | hinge | angle (rad) |
     | 2     | angle of the second rotor                  | -Inf                 | Inf                | bthigh | hinge | angle (rad) |
     | 3     | angle of the second rotor                  | -Inf                 | Inf                | bshin | hinge | angle (rad) |
@@ -96,14 +72,14 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     ### Rewards
     The reward consists of two parts:
     - *reward_run*: A reward of moving forward which is measured
-    as *(x-coordinate before action - x-coordinate after action)/dt*. *dt* is
-    the time between actions and is dependeent on the frame_skip parameter
-    (default is 5), where the *dt* for one frame is 0.01 - making the
-    default *dt = 5*0.01 = 0.05*. This reward would be positive if the cheetah
-    runs forward (right) desired.
+    as *`forward_reward_weight` \times (x-coordinate before action - x-coordinate after action)/dt*. *dt* is
+    the time between actions and is dependent on the frame_skip parameter
+    (fixed to 5), where the frametime is 0.01 - making the
+    default *dt = 5 * 0.01 = 0.05*. This reward would be positive if the cheetah
+    runs forward (right).
     - *reward_control*: A negative reward for penalising the cheetah if it takes
-    actions that are too large. It is measured as *-coefficient x
-    sum(action<sup>2</sup>)* where *coefficient* is a parameter set for the
+    actions that are too large. It is measured as *-`ctrl_cost_weight` *
+    sum(action<sup>2</sup>)* where *`ctrl_cost_weight`* is a parameter set for the
     control and has a default value of 0.1
 
     The total reward returned is ***reward*** *=* *reward_run + reward_control*
@@ -113,8 +89,8 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,) with a noise added to the
     initial state for stochasticity. As seen before, the first 8 values in the
     state are positional and the last 9 values are velocity. A uniform noise in
-    the range of [-0.1, 0.1] is added to the positional values while a standard
-    normal noise with a mean of 0 and standard deviation of 0.1 is added to the
+    the range of [-`reset_noise_scale`, `reset_noise_scale`] is added to the positional values while a standard
+    normal noise with a mean of 0 and standard deviation of `reset_noise_scale` is added to the
     initial velocity values of all zeros.
 
     ### Episode Termination
@@ -122,7 +98,7 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Arguments
 
-    No additional arguments are currently supported (in v2 and lower), but
+    No additional arguments are currently supported in v2 and lower, but
     modifications can be made to the XML file in the assets folder at
     `gym/envs/mujoco/assets/half_cheetah.xml` (or by changing the path to a
     modified XML file in another folder).
@@ -136,6 +112,14 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     ```
     env = gym.make('HalfCheetah-v3', ctrl_cost_weight=0.1, ....)
     ```
+
+    | Parameter               | Type       | Default      |Description                    |
+    |-------------------------|------------|--------------|-------------------------------|
+    | `xml_file`              | **str**    | `"ant.xml"`  | Path to a MuJoCo model |
+    | `forward_reward_weight` | **float**  | `1.0`        | Weight for *reward_run* in reward (see section on reward) |
+    | `ctrl_cost_weight`      | **float**  | `0.1`        | Weight for control cost in reward (see section on reward) |
+    | `reset_noise_scale`     | **float**  | `0.1`        | Scale of random perturbations of initial position and velocity (see section on Starting State) |
+    | `exclude_current_positions_from_observation`| **bool** | `True` | Whether or not to omit the x- and y-coordinates from observations. Excluding the position can serve as an inductive bias to induce position-agnostic behavior in policies |
 
 
     ### Version History

--- a/gym/envs/mujoco/half_cheetah_v3.py
+++ b/gym/envs/mujoco/half_cheetah_v3.py
@@ -72,7 +72,7 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     ### Rewards
     The reward consists of two parts:
     - *reward_run*: A reward of moving forward which is measured
-    as *`forward_reward_weight` \times (x-coordinate before action - x-coordinate after action)/dt*. *dt* is
+    as *`forward_reward_weight` * (x-coordinate before action - x-coordinate after action)/dt*. *dt* is
     the time between actions and is dependent on the frame_skip parameter
     (fixed to 5), where the frametime is 0.01 - making the
     default *dt = 5 * 0.01 = 0.05*. This reward would be positive if the cheetah
@@ -98,10 +98,7 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Arguments
 
-    No additional arguments are currently supported in v2 and lower, but
-    modifications can be made to the XML file in the assets folder at
-    `gym/envs/mujoco/assets/half_cheetah.xml` (or by changing the path to a
-    modified XML file in another folder).
+    No additional arguments are currently supported in v2 and lower.
 
     ```
     env = gym.make('HalfCheetah-v2')
@@ -113,13 +110,13 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     env = gym.make('HalfCheetah-v3', ctrl_cost_weight=0.1, ....)
     ```
 
-    | Parameter               | Type       | Default      |Description                    |
-    |-------------------------|------------|--------------|-------------------------------|
-    | `xml_file`              | **str**    | `"ant.xml"`  | Path to a MuJoCo model |
-    | `forward_reward_weight` | **float**  | `1.0`        | Weight for *reward_run* in reward (see section on reward) |
-    | `ctrl_cost_weight`      | **float**  | `0.1`        | Weight for control cost in reward (see section on reward) |
-    | `reset_noise_scale`     | **float**  | `0.1`        | Scale of random perturbations of initial position and velocity (see section on Starting State) |
-    | `exclude_current_positions_from_observation`| **bool** | `True` | Whether or not to omit the x- and y-coordinates from observations. Excluding the position can serve as an inductive bias to induce position-agnostic behavior in policies |
+    | Parameter               | Type       | Default              |Description                    |
+    |-------------------------|------------|----------------------|-------------------------------|
+    | `xml_file`              | **str**    | `"half_cheetah.xml"` | Path to a MuJoCo model |
+    | `forward_reward_weight` | **float**  | `1.0`                | Weight for *reward_run* in reward (see section on reward) |
+    | `ctrl_cost_weight`      | **float**  | `0.1`                | Weight for control cost in reward (see section on reward) |
+    | `reset_noise_scale`     | **float**  | `0.1`                | Scale of random perturbations of initial position and velocity (see section on Starting State) |
+    | `exclude_current_positions_from_observation`| **bool** | `True` | Whether or not to omit the x-coordinate from observations. Excluding the position can serve as an inductive bias to induce position-agnostic behavior in policies |
 
 
     ### Version History

--- a/gym/envs/mujoco/hopper_v3.py
+++ b/gym/envs/mujoco/hopper_v3.py
@@ -46,6 +46,8 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     be included by passing `exclude_current_positions_from_observation=False` during construction.
     In that case, the observation space will have 12 dimensions where the first dimension
     represents the x-coordinate of the hopper.
+    Regardless of whether `exclude_current_positions_from_observation` was set to true or false, the x-coordinate
+    will be returned in `info` with key `"x_position"`.
 
     However, by default, the observation is a `ndarray` with shape `(11,)` where the elements
     correspond to the following:
@@ -67,18 +69,18 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     ### Rewards
     The reward consists of three parts:
     - *healthy_reward*: Every timestep that the hopper is healthy (see definition in section "Episode Termination"), it gets a reward of fixed value `healthy_reward`.
-    - *reward_forward*: A reward of hopping forward which is measured
+    - *forward_reward*: A reward of hopping forward which is measured
     as *`forward_reward_weight` * (x-coordinate before action - x-coordinate after action)/dt*. *dt* is
     the time between actions and is dependent on the frame_skip parameter
     (fixed to 4), where the frametime is 0.002 - making the
     default *dt = 4 * 0.002 = 0.008*. This reward would be positive if the hopper
     hops forward (positive x direction).
-    - *reward_control*: A negative reward for penalising the hopper if it takes
-    actions that are too large. It is measured as *-`ctrl_cost_weight` *
+    - *ctrl_cost*: A cost for penalising the hopper if it takes
+    actions that are too large. It is measured as *`ctrl_cost_weight` *
     sum(action<sup>2</sup>)* where *`ctrl_cost_weight`* is a parameter set for the
     control and has a default value of 0.001
 
-    The total reward returned is ***reward*** *=* *healthy_reward + reward_forward + reward_control*
+    The total reward returned is ***reward*** *=* *healthy_reward + forward_reward - ctrl_cost* and `info` will also contain the individual reward terms
 
     ### Starting State
     All observations start in state
@@ -117,8 +119,8 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     | Parameter               | Type       | Default        |Description                    |
     |-------------------------|------------|----------------|-------------------------------|
     | `xml_file`              | **str**    | `"hopper.xml"` | Path to a MuJoCo model |
-    | `forward_reward_weight` | **float**  | `1.0`          | Weight for forward reward (see section on reward) |
-    | `ctrl_cost_weight`      | **float**  | `0.001`        | Weight for control cost in reward (see section on reward) |
+    | `forward_reward_weight` | **float**  | `1.0`          | Weight for *forward_reward* term (see section on reward) |
+    | `ctrl_cost_weight`      | **float**  | `0.001`        | Weight for *ctrl_cost* reward (see section on reward) |
     | `healthy_reward`        | **float**  | `1`            | Constant reward given if the ant is "healthy" after timestep |
     | `terminate_when_unhealthy` | **bool**| `True`         | If true, issue a done signal if the hopper is no longer healthy |
     | `healthy_state_range`   | **tuple**  | `(-100, 100)`  | The elements of `observation[1:]` (if  `exclude_current_positions_from_observation=True`, else `observation[2:]`) must be in this range for the hopper to be considered healthy |

--- a/gym/envs/mujoco/hopper_v3.py
+++ b/gym/envs/mujoco/hopper_v3.py
@@ -28,9 +28,7 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     connecting the four body parts.
 
     ### Action Space
-    The agent take a 3-element vector for actions.
-    The action space is a continuous `(action, action, action)` all in `[-1, 1]`
-    , where `action` represents the numerical torques applied between *links*
+    The action space is a `Box(-1, 1, (3,), float32)`. An action represents the torques applied between *links*
 
     | Num | Action                             | Control Min | Control Max | Name (in corresponding XML file) | Joint | Unit         |
     |-----|------------------------------------|-------------|-------------|----------------------------------|-------|--------------|
@@ -40,36 +38,17 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Observation Space
 
-    The state space consists of positional values of different body parts of the
+    Observations consist of positional values of different body parts of the
     hopper, followed by the velocities of those individual parts
     (their derivatives) with all the positions ordered before all the velocities.
 
-    The observation is a `ndarray` with shape `(11,)` where the elements
+    By default, observations do not include the x-coordinate of the hopper. It may
+    be included by passing `exclude_current_positions_from_observation=False` during construction.
+    In that case, the observation space will have 12 dimensions where the first dimension
+    represents the x-coordinate of the hopper.
+
+    However, by default, the observation is a `ndarray` with shape `(11,)` where the elements
     correspond to the following:
-
-    | Num | Observation           | Min                  | Max                | Name (in corresponding XML file) | Joint| Unit |
-    |-----|-----------------------|----------------------|--------------------|----------------------|--------------------|--------------------|
-    | 0   | x-coordinate of the top                          | -Inf                 | Inf                | rootx | slide | position (m) |
-    | 1   | z-coordinate of the top (height of hopper)       | -Inf                 | Inf                | rootz | slide | position (m) |
-    | 2   | angle of the top                                 | -Inf                 | Inf                | rooty | hinge | angle (rad) |
-    | 3   | angle of the thigh joint                         | -Inf                 | Inf                | thigh_joint | hinge | angle (rad) |
-    | 4   | angle of the leg joint                           | -Inf                 | Inf                | leg_joint | hinge | angle (rad) |
-    | 5   | angle of the foot joint                          | -Inf                 | Inf                | foot_joint | hinge | angle (rad) |
-    | 6   | velocity of the x-coordinate of the top          | -Inf                 | Inf                | rootx | slide | velocity (m/s) |
-    | 7   | velocity of the z-coordinate (height) of the top | -Inf                 | Inf                | rootz | slide | velocity (m/s)  |
-    | 8   | angular velocity of the angle of the top         | -Inf                 | Inf                | rooty | hinge | angular velocity (rad/s) |
-    | 9   | angular velocity of the thigh hinge              | -Inf                 | Inf                | thigh_joint | hinge | angular velocity (rad/s) |
-    | 10  | angular velocity of the leg hinge                | -Inf                 | Inf                | leg_joint | hinge | angular velocity (rad/s) |
-    | 11  | angular velocity of the foot hinge               | -Inf                 | Inf                | foot_joint | hinge | angular velocity (rad/s) |
-
-
-
-    **Note:**
-    In practice (and Gym implementation), the first positional element is
-    omitted from the state space since the reward function is calculated based
-    on that value. This value is hidden from the algorithm, which in turn has
-    to develop an abstract understanding of it from the observed rewards.
-    Therefore, observation space has shape `(11,)` instead of `(12,)` and looks like:
 
     | Num | Observation           | Min                  | Max                | Name (in corresponding XML file) | Joint| Unit |
     |-----|-----------------------|----------------------|--------------------|----------------------|--------------------|--------------------|
@@ -87,39 +66,43 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Rewards
     The reward consists of three parts:
-    - *alive bonus*: Every timestep that the hopper is alive, it gets a reward of 1,
+    - *healthy_reward*: Every timestep that the hopper is healthy (see definition in section "Episode Termination"), it gets a reward of fixed value `healthy_reward`.
     - *reward_forward*: A reward of hopping forward which is measured
-    as *(x-coordinate before action - x-coordinate after action)/dt*. *dt* is
-    the time between actions and is dependeent on the frame_skip parameter
-    (default is 4), where the *dt* for one frame is 0.002 - making the
-    default *dt = 4*0.002 = 0.008*. This reward would be positive if the hopper
-    hops forward (right) desired.
+    as *`forward_reward_weight` * (x-coordinate before action - x-coordinate after action)/dt*. *dt* is
+    the time between actions and is dependent on the frame_skip parameter
+    (fixed to 4), where the frametime is 0.002 - making the
+    default *dt = 4 * 0.002 = 0.008*. This reward would be positive if the hopper
+    hops forward (positive x direction).
     - *reward_control*: A negative reward for penalising the hopper if it takes
-    actions that are too large. It is measured as *-coefficient **x**
-    sum(action<sup>2</sup>)* where *coefficient* is a parameter set for the
+    actions that are too large. It is measured as *-`ctrl_cost_weight` *
+    sum(action<sup>2</sup>)* where *`ctrl_cost_weight`* is a parameter set for the
     control and has a default value of 0.001
 
-    The total reward returned is ***reward*** *=* *alive bonus + reward_forward + reward_control*
+    The total reward returned is ***reward*** *=* *healthy_reward + reward_forward + reward_control*
 
     ### Starting State
     All observations start in state
     (0.0, 1.25, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0) with a uniform noise
-     in the range of [-0.005, 0.005] added to the values for stochasticity.
+     in the range of [-`reset_noise_scale`, `reset_noise_scale`] added to the values for stochasticity.
 
     ### Episode Termination
-    The episode terminates when any of the following happens:
+    The hopper is said to be unhealthy if any of the following happens:
+
+    1. An element of `observation[1:]` (if  `exclude_current_positions_from_observation=True`, else `observation[2:]`) is no longer contained in the closed interval specified by the argument `healthy_state_range`
+    2. The height of the hopper (`observation[0]` if  `exclude_current_positions_from_observation=True`, else `observation[1]`) is no longer contained in the closed interval specified by the argument `healthy_z_range` (usually meaning that it has fallen)
+    3. The angle (`observation[1]` if  `exclude_current_positions_from_observation=True`, else `observation[2]`) is no longer contained in the closed interval specified by the argument `healthy_angle_range`
+
+    If `terminate_when_unhealthy=True` is passed during construction (which is the default),
+    the episode terminates when any of the following happens:
 
     1. The episode duration reaches a 1000 timesteps
-    2. Any of the state space values is no longer finite
-    3. The absolute value of any of the state variable indexed (angle and beyond) is greater than 100
-    4. The height of the hopper becomes greater than 0.7 metres (hopper has hopped too high).
-    5. The absolute value of the angle (index 2) is less than 0.2 radians (hopper has fallen down).
+    2. The hopper is unhealthy
+
+    If `terminate_when_unhealthy=False` is passed, the episode is terminated only when 1000 timesteps are exceeded.
 
     ### Arguments
 
-    No additional arguments are currently supported (in v2 and lower), but
-    modifications can be made to the XML file in the assets folder
-    (or by changing the path to a modified XML file in another folder).
+    No additional arguments are currently supported in v2 and lower.
 
     ```
     env = gym.make('Hopper-v2')
@@ -130,6 +113,20 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     ```
     env = gym.make('Hopper-v3', ctrl_cost_weight=0.1, ....)
     ```
+
+    | Parameter               | Type       | Default        |Description                    |
+    |-------------------------|------------|----------------|-------------------------------|
+    | `xml_file`              | **str**    | `"hopper.xml"` | Path to a MuJoCo model |
+    | `forward_reward_weight` | **float**  | `1.0`          | Weight for forward reward (see section on reward) |
+    | `ctrl_cost_weight`      | **float**  | `0.001`        | Weight for control cost in reward (see section on reward) |
+    | `healthy_reward`        | **float**  | `1`            | Constant reward given if the ant is "healthy" after timestep |
+    | `terminate_when_unhealthy` | **bool**| `True`         | If true, issue a done signal if the hopper is no longer healthy |
+    | `healthy_state_range`   | **tuple**  | `(-100, 100)`  | The elements of `observation[1:]` (if  `exclude_current_positions_from_observation=True`, else `observation[2:]`) must be in this range for the hopper to be considered healthy |
+    | `healthy_z_range`       | **tuple**  | `(0.7, float("inf"))`    | The z-coordinate must be in this range for the hopper to be considered healthy |
+    | `healthy_angle_range`   | **tuple**  | `(-0.2, 0.2)`   | The angle given by `observation[1]` (if  `exclude_current_positions_from_observation=True`, else `observation[2]`) must be in this range for the hopper to be considered healthy |
+    | `reset_noise_scale`     | **float**  | `5e-3`         | Scale of random perturbations of initial position and velocity (see section on Starting State) |
+    | `exclude_current_positions_from_observation`| **bool** | `True`| Whether or not to omit the x-coordinate from observations. Excluding the position can serve as an inductive bias to induce position-agnostic behavior in policies |
+
 
     ### Version History
 

--- a/gym/envs/mujoco/humanoid_v3.py
+++ b/gym/envs/mujoco/humanoid_v3.py
@@ -28,9 +28,7 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     elbows respectively). The goal of the environment is to walk forward as fast as possible without falling over.
 
     ### Action Space
-    The agent take a 17-element vector for actions.
-    The action space is a continuous `(action, ...)` all in `[-1, 1]`, where `action`
-    represents the numerical torques applied at the hinge joints.
+    The action space is a `Box(-1, 1, (17,), float32)`. An action represents the torques applied at the hinge joints.
 
     | Num | Action                    | Control Min | Control Max | Name (in corresponding XML file) | Joint | Unit |
     |-----|----------------------|---------------|----------------|---------------------------------------|-------|------|
@@ -54,64 +52,67 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Observation Space
 
-    The state space consists of positional values of different body parts of the Humanoid,
+    Observations consist of positional values of different body parts of the Humanoid,
      followed by the velocities of those individual parts (their derivatives) with all the
      positions ordered before all the velocities.
 
-    The observation is a `ndarray` with shape `(376,)` where the elements correspond to the following:
+    By default, observations do not include the x- and y-coordinates of the torso. These may
+    be included by passing `exclude_current_positions_from_observation=False` during construction.
+    In that case, the observation space will have 378 dimensions where the first two dimensions
+    represent the x- and y-coordinates of the torso.
+
+    However, by default, the observation is a `ndarray` with shape `(376,)` where the elements correspond to the following:
 
     | Num | Observation                                                        | Min                | Max                | Name (in corresponding XML file) | Joint | Unit |
     |-----|---------------------------------------------------------|----------------|-----------------|----------------------------------------|-------|------|
-    | 0   | x-coordinate of the torso (centre)                                                                              | -Inf                 | Inf                | root      | free | position (m) |
-    | 1   | y-coordinate of the torso (centre)                                                                              | -Inf                 | Inf                | root      | free | position (m) |
-    | 2   | z-coordinate of the torso (centre)                                                                              | -Inf                 | Inf                | root      | free | position (m) |
-    | 3   | x-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root      | free | angle (rad) |
-    | 4   | y-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root      | free | angle (rad) |
-    | 5   | z-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root      | free | angle (rad) |
-    | 6   | w-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root       | free | angle (rad) |
-    | 7   | z-angle of the abdomen (in lower_waist)                                                                         | -Inf                 | Inf               | abdomen_z | hinge | angle (rad) |
-    | 8   | y-angle of the abdomen (in lower_waist)                                                                         | -Inf                 | Inf               | abdomen_y | hinge | angle (rad) |
-    | 9   | x-angle of the abdomen (in pelvis)                                                                              | -Inf                 | Inf               | abdomen_x | hinge | angle (rad) |
-    | 10  | x-coordinate of angle between pelvis and right hip (in right_thigh)                                             | -Inf                 | Inf               | right_hip_x | hinge | angle (rad) |
-    | 11  | z-coordinate of angle between pelvis and right hip (in right_thigh)                                             | -Inf                 | Inf               | right_hip_z | hinge | angle (rad) |
-    | 12  | y-coordinate of angle between pelvis and right hip (in right_thigh)                                             | -Inf                 | Inf               | right_hip_y | hinge | angle (rad) |
-    | 13  | angle between right hip and the right shin (in right_knee)                                                      | -Inf                 | Inf               | right_knee | hinge | angle (rad) |
-    | 14  | x-coordinate of angle between pelvis and left hip (in left_thigh)                                               | -Inf                 | Inf               | left_hip_x | hinge | angle (rad) |
-    | 15  | z-coordinate of angle between pelvis and left hip (in left_thigh)                                               | -Inf                 | Inf               | left_hip_z | hinge | angle (rad) |
-    | 16  | y-coordinate of angle between pelvis and left hip (in left_thigh)                                               | -Inf                 | Inf               | left_hip_y | hinge | angle (rad) |
-    | 17  | angle between left hip and the left shin (in left_knee)                                                         | -Inf                 | Inf               | left_knee | hinge | angle (rad) |
-    | 18  | coordinate-1 (multi-axis) angle between torso and right arm (in right_upper_arm)                                | -Inf                 | Inf               | right_shoulder1 | hinge | angle (rad) |
-    | 19  | coordinate-2 (multi-axis) angle between torso and right arm (in right_upper_arm)                                | -Inf                 | Inf               | right_shoulder2 | hinge | angle (rad) |
-    | 20  | angle between right upper arm and right_lower_arm                                                               | -Inf                 | Inf               | right_elbow | hinge | angle (rad) |
-    | 21  | coordinate-1 (multi-axis) angle between torso and left arm (in left_upper_arm)                                  | -Inf                 | Inf               | left_shoulder1 | hinge | angle (rad) |
-    | 22  | coordinate-2 (multi-axis) angle between torso and left arm (in left_upper_arm)                                  | -Inf                 | Inf               | left_shoulder2 | hinge | angle (rad) |
-    | 23  | angle between left upper arm and left_lower_arm                                                                 | -Inf                 | Inf               | left_elbow | hinge | angle (rad) |
-    | 24  | x-coordinate velocity of the torso (centre)                                                                     | -Inf                 | Inf                | root      | free | velocity (m/s) |
-    | 25  | y-coordinate velocity of the torso (centre)                                                                     | -Inf                 | Inf                | root      | free | velocity (m/s) |
-    | 26  | z-coordinate velocity of the torso (centre)                                                                     | -Inf                 | Inf                | root      | free | velocity (m/s) |
-    | 27  | x-coordinate angular velocity of the torso (centre)                                                             | -Inf                 | Inf                | root      | free | anglular velocity (rad/s) |
-    | 28  | y-coordinate angular velocity of the torso (centre)                                                             | -Inf                 | Inf                | root      | free | anglular velocity (rad/s) |
-    | 29  | z-coordinate angular velocity of the torso (centre)                                                             | -Inf                 | Inf                | root      | free | anglular velocity (rad/s) |
-    | 30  | z-coordinate of angular velocity of the abdomen (in lower_waist)                                                | -Inf                 | Inf               | abdomen_z | hinge | anglular velocity (rad/s) |
-    | 31  | y-coordinate of angular velocity of the abdomen (in lower_waist)                                                | -Inf                 | Inf               | abdomen_y | hinge | anglular velocity (rad/s) |
-    | 32  | x-coordinate of angular velocity of the abdomen (in pelvis)                                                     | -Inf                 | Inf               | abdomen_x | hinge | aanglular velocity (rad/s) |
-    | 33  | x-coordinate of the angular velocity of the angle between pelvis and right hip (in right_thigh)                 | -Inf                 | Inf               | right_hip_x | hinge | anglular velocity (rad/s) |
-    | 34  | z-coordinate of the angular velocity of the angle between pelvis and right hip (in right_thigh)                 | -Inf                 | Inf               | right_hip_z | hinge | anglular velocity (rad/s) |
-    | 35  | y-coordinate of the angular velocity of the angle between pelvis and right hip (in right_thigh)                 | -Inf                 | Inf               | right_hip_y | hinge | anglular velocity (rad/s) |
-    | 36  | angular velocity of the angle between right hip and the right shin (in right_knee)                              | -Inf                 | Inf               | right_knee | hinge | anglular velocity (rad/s) |
-    | 37  | x-coordinate of the angular velocity of the angle between pelvis and left hip (in left_thigh)                   | -Inf                 | Inf               | left_hip_x | hinge | anglular velocity (rad/s) |
-    | 38  | z-coordinate of the angular velocity of the angle between pelvis and left hip (in left_thigh)                   | -Inf                 | Inf               | left_hip_z | hinge | anglular velocity (rad/s) |
-    | 39  | y-coordinate of the angular velocity of the angle between pelvis and left hip (in left_thigh)                   | -Inf                 | Inf               | left_hip_y | hinge | anglular velocity (rad/s) |
-    | 40  | angular velocity of the angle between left hip and the left shin (in left_knee)                                 | -Inf                 | Inf               | left_knee | hinge | anglular velocity (rad/s) |
-    | 41  | coordinate-1 (multi-axis) of the angular velocity of the angle between torso and right arm (in right_upper_arm) | -Inf                 | Inf               | right_shoulder1 | hinge | anglular velocity (rad/s) |
-    | 42  | coordinate-2 (multi-axis) of the angular velocity of the angle between torso and right arm (in right_upper_arm) | -Inf                 | Inf               | right_shoulder2 | hinge | anglular velocity (rad/s) |
-    | 43  | angular velocity of the angle between right upper arm and right_lower_arm                                       | -Inf                 | Inf               | right_elbow | hinge | anglular velocity (rad/s) |
-    | 44  | coordinate-1 (multi-axis) of the angular velocity of the angle between torso and left arm (in left_upper_arm)   | -Inf                 | Inf               | left_shoulder1 | hinge | anglular velocity (rad/s) |
-    | 45  | coordinate-2 (multi-axis) of the angular velocity of the angle between torso and left arm (in left_upper_arm)   | -Inf                 | Inf               | left_shoulder2 | hinge | anglular velocity (rad/s) |
-    | 46  | angular velocitty of the angle between left upper arm and left_lower_arm                                        | -Inf                 | Inf               | left_elbow | hinge | anglular velocity (rad/s) |
+    | 0   | z-coordinate of the torso (centre)                                                                              | -Inf                 | Inf                | root      | free | position (m) |
+    | 1   | x-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root      | free | angle (rad) |
+    | 2   | y-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root      | free | angle (rad) |
+    | 3   | z-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root      | free | angle (rad) |
+    | 4   | w-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root       | free | angle (rad) |
+    | 5   | z-angle of the abdomen (in lower_waist)                                                                         | -Inf                 | Inf               | abdomen_z | hinge | angle (rad) |
+    | 6   | y-angle of the abdomen (in lower_waist)                                                                         | -Inf                 | Inf               | abdomen_y | hinge | angle (rad) |
+    | 7   | x-angle of the abdomen (in pelvis)                                                                              | -Inf                 | Inf               | abdomen_x | hinge | angle (rad) |
+    | 8   | x-coordinate of angle between pelvis and right hip (in right_thigh)                                             | -Inf                 | Inf               | right_hip_x | hinge | angle (rad) |
+    | 9   | z-coordinate of angle between pelvis and right hip (in right_thigh)                                             | -Inf                 | Inf               | right_hip_z | hinge | angle (rad) |
+    | 19  | y-coordinate of angle between pelvis and right hip (in right_thigh)                                             | -Inf                 | Inf               | right_hip_y | hinge | angle (rad) |
+    | 11  | angle between right hip and the right shin (in right_knee)                                                      | -Inf                 | Inf               | right_knee | hinge | angle (rad) |
+    | 12  | x-coordinate of angle between pelvis and left hip (in left_thigh)                                               | -Inf                 | Inf               | left_hip_x | hinge | angle (rad) |
+    | 13  | z-coordinate of angle between pelvis and left hip (in left_thigh)                                               | -Inf                 | Inf               | left_hip_z | hinge | angle (rad) |
+    | 14  | y-coordinate of angle between pelvis and left hip (in left_thigh)                                               | -Inf                 | Inf               | left_hip_y | hinge | angle (rad) |
+    | 15  | angle between left hip and the left shin (in left_knee)                                                         | -Inf                 | Inf               | left_knee | hinge | angle (rad) |
+    | 16  | coordinate-1 (multi-axis) angle between torso and right arm (in right_upper_arm)                                | -Inf                 | Inf               | right_shoulder1 | hinge | angle (rad) |
+    | 17  | coordinate-2 (multi-axis) angle between torso and right arm (in right_upper_arm)                                | -Inf                 | Inf               | right_shoulder2 | hinge | angle (rad) |
+    | 18  | angle between right upper arm and right_lower_arm                                                               | -Inf                 | Inf               | right_elbow | hinge | angle (rad) |
+    | 19  | coordinate-1 (multi-axis) angle between torso and left arm (in left_upper_arm)                                  | -Inf                 | Inf               | left_shoulder1 | hinge | angle (rad) |
+    | 20  | coordinate-2 (multi-axis) angle between torso and left arm (in left_upper_arm)                                  | -Inf                 | Inf               | left_shoulder2 | hinge | angle (rad) |
+    | 21  | angle between left upper arm and left_lower_arm                                                                 | -Inf                 | Inf               | left_elbow | hinge | angle (rad) |
+    | 22  | x-coordinate velocity of the torso (centre)                                                                     | -Inf                 | Inf                | root      | free | velocity (m/s) |
+    | 23  | y-coordinate velocity of the torso (centre)                                                                     | -Inf                 | Inf                | root      | free | velocity (m/s) |
+    | 24  | z-coordinate velocity of the torso (centre)                                                                     | -Inf                 | Inf                | root      | free | velocity (m/s) |
+    | 25  | x-coordinate angular velocity of the torso (centre)                                                             | -Inf                 | Inf                | root      | free | anglular velocity (rad/s) |
+    | 26  | y-coordinate angular velocity of the torso (centre)                                                             | -Inf                 | Inf                | root      | free | anglular velocity (rad/s) |
+    | 27  | z-coordinate angular velocity of the torso (centre)                                                             | -Inf                 | Inf                | root      | free | anglular velocity (rad/s) |
+    | 28  | z-coordinate of angular velocity of the abdomen (in lower_waist)                                                | -Inf                 | Inf               | abdomen_z | hinge | anglular velocity (rad/s) |
+    | 29  | y-coordinate of angular velocity of the abdomen (in lower_waist)                                                | -Inf                 | Inf               | abdomen_y | hinge | anglular velocity (rad/s) |
+    | 30  | x-coordinate of angular velocity of the abdomen (in pelvis)                                                     | -Inf                 | Inf               | abdomen_x | hinge | aanglular velocity (rad/s) |
+    | 31  | x-coordinate of the angular velocity of the angle between pelvis and right hip (in right_thigh)                 | -Inf                 | Inf               | right_hip_x | hinge | anglular velocity (rad/s) |
+    | 32  | z-coordinate of the angular velocity of the angle between pelvis and right hip (in right_thigh)                 | -Inf                 | Inf               | right_hip_z | hinge | anglular velocity (rad/s) |
+    | 33  | y-coordinate of the angular velocity of the angle between pelvis and right hip (in right_thigh)                 | -Inf                 | Inf               | right_hip_y | hinge | anglular velocity (rad/s) |
+    | 34  | angular velocity of the angle between right hip and the right shin (in right_knee)                              | -Inf                 | Inf               | right_knee | hinge | anglular velocity (rad/s) |
+    | 35  | x-coordinate of the angular velocity of the angle between pelvis and left hip (in left_thigh)                   | -Inf                 | Inf               | left_hip_x | hinge | anglular velocity (rad/s) |
+    | 36  | z-coordinate of the angular velocity of the angle between pelvis and left hip (in left_thigh)                   | -Inf                 | Inf               | left_hip_z | hinge | anglular velocity (rad/s) |
+    | 37  | y-coordinate of the angular velocity of the angle between pelvis and left hip (in left_thigh)                   | -Inf                 | Inf               | left_hip_y | hinge | anglular velocity (rad/s) |
+    | 38  | angular velocity of the angle between left hip and the left shin (in left_knee)                                 | -Inf                 | Inf               | left_knee | hinge | anglular velocity (rad/s) |
+    | 39  | coordinate-1 (multi-axis) of the angular velocity of the angle between torso and right arm (in right_upper_arm) | -Inf                 | Inf               | right_shoulder1 | hinge | anglular velocity (rad/s) |
+    | 40  | coordinate-2 (multi-axis) of the angular velocity of the angle between torso and right arm (in right_upper_arm) | -Inf                 | Inf               | right_shoulder2 | hinge | anglular velocity (rad/s) |
+    | 41  | angular velocity of the angle between right upper arm and right_lower_arm                                       | -Inf                 | Inf               | right_elbow | hinge | anglular velocity (rad/s) |
+    | 42  | coordinate-1 (multi-axis) of the angular velocity of the angle between torso and left arm (in left_upper_arm)   | -Inf                 | Inf               | left_shoulder1 | hinge | anglular velocity (rad/s) |
+    | 43  | coordinate-2 (multi-axis) of the angular velocity of the angle between torso and left arm (in left_upper_arm)   | -Inf                 | Inf               | left_shoulder2 | hinge | anglular velocity (rad/s) |
+    | 44  | angular velocitty of the angle between left upper arm and left_lower_arm                                        | -Inf                 | Inf               | left_elbow | hinge | anglular velocity (rad/s) |
 
     Additionally, after all the positional and velocity based values in the table,
-    the state_space consists of (in order):
+    the observation contains (in order):
     - *cinert:* Mass and inertia of a single rigid body relative to the center of mass
     (this is an intermediate result of transition). It has shape 14*10 (*nbody * 10*)
     and hence adds to another 140 elements in the state space.
@@ -128,14 +129,6 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     DOFs expressed as quaternions. One can read more about free joints on the
     [Mujoco Documentation](https://mujoco.readthedocs.io/en/latest/XMLreference.html).
 
-    **Note:** There are 47 elements in the table above - giving rise to `(378,)`
-    elements in the state space. In practice (and Gym implementation), the first two
-    positional elements are omitted from the state space since the reward function is
-    calculated based on the x-coordinate value. This value is hidden from the algorithm,
-    which in turn has to develop an abstract understanding of it from the observed rewards.
-    Therefore, observation space has shape `(376,)` instead of `(378,)` and the table should
-    not have the first two rows.
-
     **Note:** There have been reported issues that using a Mujoco-Py version > 2.0
     results in the contact forces always being 0. As such we recommend to use a Mujoco-Py
     version < 2.0 when using the Humanoid environment if you would like to report results
@@ -144,52 +137,68 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Rewards
     The reward consists of three parts:
-    - *alive_bonus*: Every timestep that the humanoid is alive, it gets a reward of 5.
-    - *lin_vel_cost*: A reward of walking forward which is measured as *1.25 *
+    - *alive_bonus*: Every timestep that the humanoid is alive (see section Episode Termination for definition), it gets a reward of fixed value `healthy_reward`
+    - *forward_reward*: A reward of walking forward which is measured as *`forward_reward_weight` *
     (average center of mass before action - average center of mass after action)/dt*.
     *dt* is the time between actions and is dependent on the frame_skip parameter
-    (default is 5), where the *dt* for one frame is 0.003 - making the default *dt = 5 * 0.003 = 0.015*.
-    This reward would be positive if the humanoid walks forward (right) desired. The calculation
+    (default is 5), where the frametime is 0.003 - making the default *dt = 5 * 0.003 = 0.015*.
+    This reward would be positive if the humanoid walks forward (in positive x-direction). The calculation
     for the center of mass is defined in the `.py` file for the Humanoid.
-    - *quad_ctrl_cost*: A negative reward for penalising the humanoid if it has too
+    - *ctrl_cost*: A negative reward for penalising the humanoid if it has too
     large of a control force. If there are *nu* actuators/controls, then the control has
-    shape  `nu x 1`. It is measured as *0.1 **x** sum(control<sup>2</sup>)*.
-    - *quad_impact_cost*: A negative reward for penalising the humanoid if the external
-    contact force is too large. It is calculated as
-    *min(0.5 * 0.000001 * sum(external contact force<sup>2</sup>), 10)*.
+    shape  `nu x 1`. It is measured as *`ctrl_cost_weight` * sum(control<sup>2</sup>)*.
+    - *contact_cost*: A negative reward for penalising the humanoid if the external
+    contact force is too large. It is calculated by clipping
+    *`contact_cost_weight` * sum(external contact force<sup>2</sup>)* to the interval specified by `contact_cost_range`.
 
-    The total reward returned is ***reward*** *=* *alive_bonus + lin_vel_cost - quad_ctrl_cost - quad_impact_cost*
+    The total reward returned is ***reward*** *=* *healthy_reward + forward_reward - ctrl_cost - contact_cost*
 
     ### Starting State
     All observations start in state
     (0.0, 0.0,  1.4, 1.0, 0.0  ... 0.0) with a uniform noise in the range
-    of [-0.01, 0.01] added to the positional and velocity values (values in the table)
+    of [-`reset_noise_scale`, `reset_noise_scale`] added to the positional and velocity values (values in the table)
     for stochasticity. Note that the initial z coordinate is intentionally
     selected to be high, thereby indicating a standing up humanoid. The initial
     orientation is designed to make it face forward as well.
 
     ### Episode Termination
-    The episode terminates when any of the following happens:
+    The humanoid is said to be unhealthy if the z-position of the torso is no longer contained in the
+    closed interval specified by the argument `healthy_z_range`.
+
+    If `terminate_when_unhealthy=True` is passed during construction (which is the default),
+    the episode terminates when any of the following happens:
 
     1. The episode duration reaches a 1000 timesteps
-    2. Any of the state space values is no longer finite
-    3. The z-coordinate of the torso (index 0 in state space OR index 2 in the table) is **not** in the range `[1.0, 2.0]` (the humanoid has fallen or is about to fall beyond recovery).
+    3. The humanoid is unhealthy
+
+    If `terminate_when_unhealthy=False` is passed, the episode is terminated only when 1000 timesteps are exceeded.
+
 
     ### Arguments
 
-    No additional arguments are currently supported (in v2 and lower), but
-    modifications can be made to the XML file in the assets folder (or by changing
-    the path to a modified XML file in another folder)..
+    No additional arguments are currently supported in v2 and lower.
 
     ```
-    env = gym.make('Ant-v2')
+    env = gym.make('Humanoid-v2')
     ```
 
     v3 and beyond take gym.make kwargs such as xml_file, ctrl_cost_weight, reset_noise_scale etc.
 
     ```
-    env = gym.make('Ant-v3', ctrl_cost_weight=0.1, ....)
+    env = gym.make('Humanoid-v3', ctrl_cost_weight=0.1, ....)
     ```
+
+    | Parameter               | Type       | Default           |Description                    |
+    |-------------------------|------------|-------------------|-------------------------------|
+    | `xml_file`              | **str**    | `"humanoid.xml"`  | Path to a MuJoCo model |
+    | `forward_reward_weight` | **float**  | `1.25`            | Weight for *forward_reward* term (see section on reward) |
+    | `ctrl_cost_weight`      | **float**  | `0.1`             | Weight for *ctrl_cost* term (see section on reward) |
+    | `contact_cost_weight`   | **float**  | `5e-7`            | Weight for *contact_cost* term (see section on reward) |
+    | `healthy_reward`        | **float**  | `5.0`             | Constant reward given if the humanoid is "healthy" after timestep |
+    | `terminate_when_unhealthy` | **bool**| `True`            | If true, issue a done signal if the z-coordinate of the torso is no longer in the `healthy_z_range` |
+    | `healthy_z_range`       | **tuple**  | `(1.0, 2.0)`      | The humanoid is considered healthy if the z-coordinate of the torso is in this range |
+    | `reset_noise_scale`     | **float**  | `1e-2`            | Scale of random perturbations of initial position and velocity (see section on Starting State) |
+    | `exclude_current_positions_from_observation`| **bool**   | `True`| Whether or not to omit the x- and y-coordinates from observations. Excluding the position can serve as an inductive bias to induce position-agnostic behavior in policies |
 
     ### Version History
 
@@ -197,7 +206,6 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     * v2: All continuous control environments now use mujoco_py >= 1.50
     * v1: max_time_steps raised to 1000 for robot based tasks. Added reward_threshold to environments.
     * v0: Initial versions release (1.0.0)
-
     """
 
     def __init__(

--- a/gym/envs/mujoco/humanoid_v3.py
+++ b/gym/envs/mujoco/humanoid_v3.py
@@ -60,6 +60,8 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     be included by passing `exclude_current_positions_from_observation=False` during construction.
     In that case, the observation space will have 378 dimensions where the first two dimensions
     represent the x- and y-coordinates of the torso.
+    Regardless of whether `exclude_current_positions_from_observation` was set to true or false, the x- and y-coordinates
+    will be returned in `info` with keys `"x_position"` and `"y_position"`, respectively.
 
     However, by default, the observation is a `ndarray` with shape `(376,)` where the elements correspond to the following:
 
@@ -137,7 +139,7 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Rewards
     The reward consists of three parts:
-    - *alive_bonus*: Every timestep that the humanoid is alive (see section Episode Termination for definition), it gets a reward of fixed value `healthy_reward`
+    - *healthy_reward*: Every timestep that the humanoid is alive (see section Episode Termination for definition), it gets a reward of fixed value `healthy_reward`
     - *forward_reward*: A reward of walking forward which is measured as *`forward_reward_weight` *
     (average center of mass before action - average center of mass after action)/dt*.
     *dt* is the time between actions and is dependent on the frame_skip parameter
@@ -151,7 +153,7 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     contact force is too large. It is calculated by clipping
     *`contact_cost_weight` * sum(external contact force<sup>2</sup>)* to the interval specified by `contact_cost_range`.
 
-    The total reward returned is ***reward*** *=* *healthy_reward + forward_reward - ctrl_cost - contact_cost*
+    The total reward returned is ***reward*** *=* *healthy_reward + forward_reward - ctrl_cost - contact_cost* and `info` will also contain the individual reward terms
 
     ### Starting State
     All observations start in state

--- a/gym/envs/mujoco/humanoidstandup.py
+++ b/gym/envs/mujoco/humanoidstandup.py
@@ -46,57 +46,57 @@ class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     The state space consists of positional values of different body parts of the Humanoid,
     followed by the velocities of those individual parts (their derivatives) with all the positions ordered before all the velocities.
 
+    **Note:** The x- and y-coordinates of the torso are being omitted to produce position-agnostic behavior in policies
+
     The observation is a `ndarray` with shape `(376,)` where the elements correspond to the following:
 
     | Num | Observation                                                        | Min                | Max                | Name (in corresponding XML file) | Joint | Unit |
     |-----|---------------------------------------------------------|----------------|-----------------|----------------------------------------|-------|------|
-    | 0   | x-coordinate of the torso (centre)                                                                              | -Inf                 | Inf                | root      | free | position (m) |
-    | 1   | y-coordinate of the torso (centre)                                                                              | -Inf                 | Inf                | root      | free | position (m) |
-    | 2   | z-coordinate of the torso (centre)                                                                              | -Inf                 | Inf                | root      | free | position (m) |
-    | 3   | x-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root      | free | angle (rad) |
-    | 4   | y-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root      | free | angle (rad) |
-    | 5   | z-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root      | free | angle (rad) |
-    | 6   | w-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root       | free | angle (rad) |
-    | 7   | z-angle of the abdomen (in lower_waist)                                                                         | -Inf                 | Inf               | abdomen_z | hinge | angle (rad) |
-    | 8   | y-angle of the abdomen (in lower_waist)                                                                         | -Inf                 | Inf               | abdomen_y | hinge | angle (rad) |
-    | 9   | x-angle of the abdomen (in pelvis)                                                                              | -Inf                 | Inf               | abdomen_x | hinge | angle (rad) |
-    | 10  | x-coordinate of angle between pelvis and right hip (in right_thigh)                                             | -Inf                 | Inf               | right_hip_x | hinge | angle (rad) |
-    | 11  | z-coordinate of angle between pelvis and right hip (in right_thigh)                                             | -Inf                 | Inf               | right_hip_z | hinge | angle (rad) |
-    | 12  | y-coordinate of angle between pelvis and right hip (in right_thigh)                                             | -Inf                 | Inf               | right_hip_y | hinge | angle (rad) |
-    | 13  | angle between right hip and the right shin (in right_knee)                                                      | -Inf                 | Inf               | right_knee | hinge | angle (rad) |
-    | 14  | x-coordinate of angle between pelvis and left hip (in left_thigh)                                               | -Inf                 | Inf               | left_hip_x | hinge | angle (rad) |
-    | 15  | z-coordinate of angle between pelvis and left hip (in left_thigh)                                               | -Inf                 | Inf               | left_hip_z | hinge | angle (rad) |
-    | 16  | y-coordinate of angle between pelvis and left hip (in left_thigh)                                               | -Inf                 | Inf               | left_hip_y | hinge | angle (rad) |
-    | 17  | angle between left hip and the left shin (in left_knee)                                                         | -Inf                 | Inf               | left_knee | hinge | angle (rad) |
-    | 18  | coordinate-1 (multi-axis) angle between torso and right arm (in right_upper_arm)                                | -Inf                 | Inf               | right_shoulder1 | hinge | angle (rad) |
-    | 19  | coordinate-2 (multi-axis) angle between torso and right arm (in right_upper_arm)                                | -Inf                 | Inf               | right_shoulder2 | hinge | angle (rad) |
-    | 20  | angle between right upper arm and right_lower_arm                                                               | -Inf                 | Inf               | right_elbow | hinge | angle (rad) |
-    | 21  | coordinate-1 (multi-axis) angle between torso and left arm (in left_upper_arm)                                  | -Inf                 | Inf               | left_shoulder1 | hinge | angle (rad) |
-    | 22  | coordinate-2 (multi-axis) angle between torso and left arm (in left_upper_arm)                                  | -Inf                 | Inf               | left_shoulder2 | hinge | angle (rad) |
-    | 23  | angle between left upper arm and left_lower_arm                                                                 | -Inf                 | Inf               | left_elbow | hinge | angle (rad) |
-    | 24  | x-coordinate velocity of the torso (centre)                                                                     | -Inf                 | Inf                | root      | free | velocity (m/s) |
-    | 25  | y-coordinate velocity of the torso (centre)                                                                     | -Inf                 | Inf                | root      | free | velocity (m/s) |
-    | 26  | z-coordinate velocity of the torso (centre)                                                                     | -Inf                 | Inf                | root      | free | velocity (m/s) |
-    | 27  | x-coordinate angular velocity of the torso (centre)                                                             | -Inf                 | Inf                | root      | free | anglular velocity (rad/s) |
-    | 28  | y-coordinate angular velocity of the torso (centre)                                                             | -Inf                 | Inf                | root      | free | anglular velocity (rad/s) |
-    | 29  | z-coordinate angular velocity of the torso (centre)                                                             | -Inf                 | Inf                | root      | free | anglular velocity (rad/s) |
-    | 30  | z-coordinate of angular velocity of the abdomen (in lower_waist)                                                | -Inf                 | Inf               | abdomen_z | hinge | anglular velocity (rad/s) |
-    | 31  | y-coordinate of angular velocity of the abdomen (in lower_waist)                                                | -Inf                 | Inf               | abdomen_y | hinge | anglular velocity (rad/s) |
-    | 32  | x-coordinate of angular velocity of the abdomen (in pelvis)                                                     | -Inf                 | Inf               | abdomen_x | hinge | aanglular velocity (rad/s) |
-    | 33  | x-coordinate of the angular velocity of the angle between pelvis and right hip (in right_thigh)                 | -Inf                 | Inf               | right_hip_x | hinge | anglular velocity (rad/s) |
-    | 34  | z-coordinate of the angular velocity of the angle between pelvis and right hip (in right_thigh)                 | -Inf                 | Inf               | right_hip_z | hinge | anglular velocity (rad/s) |
-    | 35  | y-coordinate of the angular velocity of the angle between pelvis and right hip (in right_thigh)                 | -Inf                 | Inf               | right_hip_y | hinge | anglular velocity (rad/s) |
-    | 36  | angular velocity of the angle between right hip and the right shin (in right_knee)                              | -Inf                 | Inf               | right_knee | hinge | anglular velocity (rad/s) |
-    | 37  | x-coordinate of the angular velocity of the angle between pelvis and left hip (in left_thigh)                   | -Inf                 | Inf               | left_hip_x | hinge | anglular velocity (rad/s) |
-    | 38  | z-coordinate of the angular velocity of the angle between pelvis and left hip (in left_thigh)                   | -Inf                 | Inf               | left_hip_z | hinge | anglular velocity (rad/s) |
-    | 39  | y-coordinate of the angular velocity of the angle between pelvis and left hip (in left_thigh)                   | -Inf                 | Inf               | left_hip_y | hinge | anglular velocity (rad/s) |
-    | 40  | angular velocity of the angle between left hip and the left shin (in left_knee)                                 | -Inf                 | Inf               | left_knee | hinge | anglular velocity (rad/s) |
-    | 41  | coordinate-1 (multi-axis) of the angular velocity of the angle between torso and right arm (in right_upper_arm) | -Inf                 | Inf               | right_shoulder1 | hinge | anglular velocity (rad/s) |
-    | 42  | coordinate-2 (multi-axis) of the angular velocity of the angle between torso and right arm (in right_upper_arm) | -Inf                 | Inf               | right_shoulder2 | hinge | anglular velocity (rad/s) |
-    | 43  | angular velocity of the angle between right upper arm and right_lower_arm                                       | -Inf                 | Inf               | right_elbow | hinge | anglular velocity (rad/s) |
-    | 44  | coordinate-1 (multi-axis) of the angular velocity of the angle between torso and left arm (in left_upper_arm)   | -Inf                 | Inf               | left_shoulder1 | hinge | anglular velocity (rad/s) |
-    | 45  | coordinate-2 (multi-axis) of the angular velocity of the angle between torso and left arm (in left_upper_arm)   | -Inf                 | Inf               | left_shoulder2 | hinge | anglular velocity (rad/s) |
-    | 46  | angular velocitty of the angle between left upper arm and left_lower_arm                                        | -Inf                 | Inf               | left_elbow | hinge | anglular velocity (rad/s) |
+    | 0   | z-coordinate of the torso (centre)                                                                              | -Inf                 | Inf                | root      | free | position (m) |
+    | 1   | x-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root      | free | angle (rad) |
+    | 2   | y-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root      | free | angle (rad) |
+    | 3   | z-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root      | free | angle (rad) |
+    | 4   | w-orientation of the torso (centre)                                                                             | -Inf                 | Inf                | root       | free | angle (rad) |
+    | 5   | z-angle of the abdomen (in lower_waist)                                                                         | -Inf                 | Inf               | abdomen_z | hinge | angle (rad) |
+    | 6   | y-angle of the abdomen (in lower_waist)                                                                         | -Inf                 | Inf               | abdomen_y | hinge | angle (rad) |
+    | 7   | x-angle of the abdomen (in pelvis)                                                                              | -Inf                 | Inf               | abdomen_x | hinge | angle (rad) |
+    | 8   | x-coordinate of angle between pelvis and right hip (in right_thigh)                                             | -Inf                 | Inf               | right_hip_x | hinge | angle (rad) |
+    | 9   | z-coordinate of angle between pelvis and right hip (in right_thigh)                                             | -Inf                 | Inf               | right_hip_z | hinge | angle (rad) |
+    | 10  | y-coordinate of angle between pelvis and right hip (in right_thigh)                                             | -Inf                 | Inf               | right_hip_y | hinge | angle (rad) |
+    | 11  | angle between right hip and the right shin (in right_knee)                                                      | -Inf                 | Inf               | right_knee | hinge | angle (rad) |
+    | 12  | x-coordinate of angle between pelvis and left hip (in left_thigh)                                               | -Inf                 | Inf               | left_hip_x | hinge | angle (rad) |
+    | 13  | z-coordinate of angle between pelvis and left hip (in left_thigh)                                               | -Inf                 | Inf               | left_hip_z | hinge | angle (rad) |
+    | 14  | y-coordinate of angle between pelvis and left hip (in left_thigh)                                               | -Inf                 | Inf               | left_hip_y | hinge | angle (rad) |
+    | 15  | angle between left hip and the left shin (in left_knee)                                                         | -Inf                 | Inf               | left_knee | hinge | angle (rad) |
+    | 16  | coordinate-1 (multi-axis) angle between torso and right arm (in right_upper_arm)                                | -Inf                 | Inf               | right_shoulder1 | hinge | angle (rad) |
+    | 17  | coordinate-2 (multi-axis) angle between torso and right arm (in right_upper_arm)                                | -Inf                 | Inf               | right_shoulder2 | hinge | angle (rad) |
+    | 18  | angle between right upper arm and right_lower_arm                                                               | -Inf                 | Inf               | right_elbow | hinge | angle (rad) |
+    | 19  | coordinate-1 (multi-axis) angle between torso and left arm (in left_upper_arm)                                  | -Inf                 | Inf               | left_shoulder1 | hinge | angle (rad) |
+    | 20  | coordinate-2 (multi-axis) angle between torso and left arm (in left_upper_arm)                                  | -Inf                 | Inf               | left_shoulder2 | hinge | angle (rad) |
+    | 21  | angle between left upper arm and left_lower_arm                                                                 | -Inf                 | Inf               | left_elbow | hinge | angle (rad) |
+    | 22  | x-coordinate velocity of the torso (centre)                                                                     | -Inf                 | Inf                | root      | free | velocity (m/s) |
+    | 23  | y-coordinate velocity of the torso (centre)                                                                     | -Inf                 | Inf                | root      | free | velocity (m/s) |
+    | 24  | z-coordinate velocity of the torso (centre)                                                                     | -Inf                 | Inf                | root      | free | velocity (m/s) |
+    | 25  | x-coordinate angular velocity of the torso (centre)                                                             | -Inf                 | Inf                | root      | free | anglular velocity (rad/s) |
+    | 26  | y-coordinate angular velocity of the torso (centre)                                                             | -Inf                 | Inf                | root      | free | anglular velocity (rad/s) |
+    | 27  | z-coordinate angular velocity of the torso (centre)                                                             | -Inf                 | Inf                | root      | free | anglular velocity (rad/s) |
+    | 28  | z-coordinate of angular velocity of the abdomen (in lower_waist)                                                | -Inf                 | Inf               | abdomen_z | hinge | anglular velocity (rad/s) |
+    | 29  | y-coordinate of angular velocity of the abdomen (in lower_waist)                                                | -Inf                 | Inf               | abdomen_y | hinge | anglular velocity (rad/s) |
+    | 30  | x-coordinate of angular velocity of the abdomen (in pelvis)                                                     | -Inf                 | Inf               | abdomen_x | hinge | aanglular velocity (rad/s) |
+    | 31  | x-coordinate of the angular velocity of the angle between pelvis and right hip (in right_thigh)                 | -Inf                 | Inf               | right_hip_x | hinge | anglular velocity (rad/s) |
+    | 32  | z-coordinate of the angular velocity of the angle between pelvis and right hip (in right_thigh)                 | -Inf                 | Inf               | right_hip_z | hinge | anglular velocity (rad/s) |
+    | 33  | y-coordinate of the angular velocity of the angle between pelvis and right hip (in right_thigh)                 | -Inf                 | Inf               | right_hip_y | hinge | anglular velocity (rad/s) |
+    | 35  | angular velocity of the angle between right hip and the right shin (in right_knee)                              | -Inf                 | Inf               | right_knee | hinge | anglular velocity (rad/s) |
+    | 36  | x-coordinate of the angular velocity of the angle between pelvis and left hip (in left_thigh)                   | -Inf                 | Inf               | left_hip_x | hinge | anglular velocity (rad/s) |
+    | 37  | z-coordinate of the angular velocity of the angle between pelvis and left hip (in left_thigh)                   | -Inf                 | Inf               | left_hip_z | hinge | anglular velocity (rad/s) |
+    | 38  | y-coordinate of the angular velocity of the angle between pelvis and left hip (in left_thigh)                   | -Inf                 | Inf               | left_hip_y | hinge | anglular velocity (rad/s) |
+    | 39  | angular velocity of the angle between left hip and the left shin (in left_knee)                                 | -Inf                 | Inf               | left_knee | hinge | anglular velocity (rad/s) |
+    | 40  | coordinate-1 (multi-axis) of the angular velocity of the angle between torso and right arm (in right_upper_arm) | -Inf                 | Inf               | right_shoulder1 | hinge | anglular velocity (rad/s) |
+    | 41  | coordinate-2 (multi-axis) of the angular velocity of the angle between torso and right arm (in right_upper_arm) | -Inf                 | Inf               | right_shoulder2 | hinge | anglular velocity (rad/s) |
+    | 42  | angular velocity of the angle between right upper arm and right_lower_arm                                       | -Inf                 | Inf               | right_elbow | hinge | anglular velocity (rad/s) |
+    | 43  | coordinate-1 (multi-axis) of the angular velocity of the angle between torso and left arm (in left_upper_arm)   | -Inf                 | Inf               | left_shoulder1 | hinge | anglular velocity (rad/s) |
+    | 44  | coordinate-2 (multi-axis) of the angular velocity of the angle between torso and left arm (in left_upper_arm)   | -Inf                 | Inf               | left_shoulder2 | hinge | anglular velocity (rad/s) |
+    | 45  | angular velocitty of the angle between left upper arm and left_lower_arm                                        | -Inf                 | Inf               | left_elbow | hinge | anglular velocity (rad/s) |
 
 
     Additionally, after all the positional and velocity based values in the table,
@@ -116,13 +116,6 @@ class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     The (x,y,z) coordinates are translational DOFs while the orientations are rotational
     DOFs expressed as quaternions. One can read more about free joints on the
     [Mujoco Documentation](https://mujoco.readthedocs.io/en/latest/XMLreference.html).
-
-    **Note:** There are 47 elements in the table above - giving rise to `(378,)`
-    elements in the state space. In practice (and Gym implementation), the first two
-    positional elements are omitted from the state space since the reward function is
-    calculated based on the x-coordinate value. This value is hidden from the algorithm,
-    which in turn has to develop an abstract understanding of it from the observed rewards.
-    Therefore, observation space has shape `(376,)` instead of `(378,)` and the table should not have the first two rows.
 
     **Note:** There have been reported issues that using a Mujoco-Py version > 2.0 results
     in the contact forces always being 0. As such we recommend to use a Mujoco-Py version < 2.0
@@ -163,9 +156,7 @@ class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Arguments
 
-    No additional arguments are currently supported (in v2 and lower), but
-    modifications can be made to the XML file in the assets folder
-    (or by changing the path to a modified XML file in another folder)..
+    No additional arguments are currently supported.
 
     ```
     env = gym.make('HumanoidStandup-v2')
@@ -177,7 +168,6 @@ class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Version History
 
-    * v3: support for gym.make kwargs such as xml_file, ctrl_cost_weight, reset_noise_scale etc. rgb rendering comes from tracking camera (so agent does not run away from screen)
     * v2: All continuous control environments now use mujoco_py >= 1.50
     * v1: max_time_steps raised to 1000 for robot based tasks. Added reward_threshold to environments.
     * v0: Initial versions release (1.0.0)

--- a/gym/envs/mujoco/inverted_double_pendulum.py
+++ b/gym/envs/mujoco/inverted_double_pendulum.py
@@ -92,9 +92,7 @@ class InvertedDoublePendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Arguments
 
-    No additional arguments are currently supported (in v2 and lower), but modifications can
-    be made to the XML file in the assets folder (or by changing the path to a modified XML
-    file in another folder)..
+    No additional arguments are currently supported.
 
     ```
     env = gym.make('InvertedDoublePendulum-v2')
@@ -105,7 +103,6 @@ class InvertedDoublePendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Version History
 
-    * v3: support for gym.make kwargs such as xml_file, ctrl_cost_weight, reset_noise_scale etc. rgb rendering comes from tracking camera (so agent does not run away from screen)
     * v2: All continuous control environments now use mujoco_py >= 1.50
     * v1: max_time_steps raised to 1000 for robot based tasks (including inverted pendulum)
     * v0: Initial versions release (1.0.0)

--- a/gym/envs/mujoco/inverted_pendulum.py
+++ b/gym/envs/mujoco/inverted_pendulum.py
@@ -63,9 +63,7 @@ class InvertedPendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Arguments
 
-    No additional arguments are currently supported (in v2 and lower),
-    but modifications can be made to the XML file in the assets folder
-    (or by changing the path to a modified XML file in another folder).
+    No additional arguments are currently supported.
 
     ```
     env = gym.make('InvertedPendulum-v2')
@@ -76,7 +74,6 @@ class InvertedPendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Version History
 
-    * v3: support for gym.make kwargs such as xml_file, ctrl_cost_weight, reset_noise_scale etc. rgb rendering comes from tracking camera (so agent does not run away from screen)
     * v2: All continuous control environments now use mujoco_py >= 1.50
     * v1: max_time_steps raised to 1000 for robot based tasks (including inverted pendulum)
     * v0: Initial versions release (1.0.0)

--- a/gym/envs/mujoco/swimmer_v3.py
+++ b/gym/envs/mujoco/swimmer_v3.py
@@ -33,13 +33,11 @@ class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     * *k*: viscous-friction coefficient
 
     While the default environment has *n* = 3, *l<sub>i</sub>* = 0.1,
-    and *k* = 0.1. It is possible to tweak the MuJoCo XML files to increase the
+    and *k* = 0.1. It is possible to pass a custom MuJoCo XML file during construction to increase the
     number of links, or to tweak any of the parameters.
 
     ### Action Space
-    The agent take a 2-element vector for actions.
-    The action space is a continuous `(action, action)` in `[-1, 1]`, where
-    `action` represents the numerical torques applied between *links*
+    The action space is a `Box(-1, 1, (2,), float32)`. An action represents the torques applied between *links*
 
     | Num | Action                             | Control Min | Control Max | Name (in corresponding XML file) | Joint | Unit         |
     |-----|------------------------------------|-------------|-------------|----------------------------------|-------|--------------|
@@ -48,30 +46,18 @@ class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Observation Space
 
-    The state space consists of:
-    * A<sub>0</sub>: position of first point
+    By default, observations consists of:
     * θ<sub>i</sub>: angle of part *i* with respect to the *x* axis
-    * A<sub>0</sub>, θ<sub>i</sub>: their derivatives with respect to time (velocity and angular velocity)
+    * θ<sub>i</sub>': its derivative with respect to time (angular velocity)
 
-    The observation is a `ndarray` with shape `(8,)` where the elements correspond to the following:
+    In the default case, observations do not include the x- and y-coordinates of the front tip. These may
+    be included by passing `exclude_current_positions_from_observation=False` during construction.
+    Then, the observation space will have 10 dimensions where the first two dimensions
+    represent the x- and y-coordinates of the front tip.
+    Regardless of whether `exclude_current_positions_from_observation` was set to true or false, the x- and y-coordinates
+    will be returned in `info` with keys `"x_position"` and `"y_position"`, respectively.
 
-    | Num | Observation           | Min                  | Max                | Name (in corresponding XML file) | Joint| Unit |
-    |-----|-----------------------|----------------------|--------------------|----------------------|--------------------|--------------------|
-    | 0   | x-coordinate of the front tip              | -Inf                 | Inf                | slider1 | slide | position (m) |
-    | 1   | y-coordinate of the front tip              | -Inf                 | Inf                | slider2 | slide | position (m) |
-    | 2   | angle of the front tip                     | -Inf                 | Inf                | rot | hinge | angle (rad) |
-    | 3   | angle of the second rotor                  | -Inf                 | Inf                | rot2 | hinge | angle (rad) |
-    | 4   | angle of the second rotor                  | -Inf                 | Inf                | rot3 | hinge | angle (rad) |
-    | 5   | velocity of the tip along the x-axis       | -Inf                 | Inf                | slider1 | slide | velocity (m/s) |
-    | 6   | velocity of the tip along the y-axis       | -Inf                 | Inf                | slider2 | slide | velocity (m/s) |
-    | 7   | angular velocity of front tip              | -Inf                 | Inf                | rot | hinge | angular velocity (rad/s) |
-    | 8   | angular velocity of second rotor           | -Inf                 | Inf                | rot2 | hinge | angular velocity (rad/s) |
-    | 9   | angular velocity of third rotor            | -Inf                 | Inf                | rot3 | hinge | angular velocity (rad/s) |
-
-    **Note:**
-    In practice (and Gym implementation), the first two positional elements are
-    omitted from the state space since the reward function is calculated based
-    on those values. Therefore, observation space has shape `(8,)` and looks like:
+    By default, the observation is a `ndarray` with shape `(8,)` where the elements correspond to the following:
 
     | Num | Observation           | Min                  | Max                | Name (in corresponding XML file) | Joint| Unit |
     |-----|-----------------------|----------------------|--------------------|----------------------|--------------------|--------------------|
@@ -86,30 +72,28 @@ class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Rewards
     The reward consists of two parts:
-    - *reward_front*: A reward of moving forward which is measured
-    as *(x-coordinate before action - x-coordinate after action)/dt*. *dt* is
-    the time between actions and is dependeent on the frame_skip parameter
-    (default is 4), where the *dt* for one frame is 0.01 - making the
+    - *forward_reward*: A reward of moving forward which is measured
+    as *`forward_reward_weight` * (x-coordinate before action - x-coordinate after action)/dt*. *dt* is
+    the time between actions and is dependent on the frame_skip parameter
+    (default is 4), where the frametime is 0.01 - making the
     default *dt = 4 * 0.01 = 0.04*. This reward would be positive if the swimmer
     swims right as desired.
-    - *reward_control*: A negative reward for penalising the swimmer if it takes
-    actions that are too large. It is measured as *-coefficient x
-    sum(action<sup>2</sup>)* where *coefficient* is a parameter set for the
-    control and has a default value of 0.0001
+    - *ctrl_cost*: A cost for penalising the swimmer if it takes
+    actions that are too large. It is measured as *`ctrl_cost_weight` *
+    sum(action<sup>2</sup>)* where *`ctrl_cost_weight`* is a parameter set for the
+    control and has a default value of 1e-4
 
-    The total reward returned is ***reward*** *=* *reward_front + reward_control*
+    The total reward returned is ***reward*** *=* *forward_reward - ctrl_cost* and `info` will also contain the individual reward terms
 
     ### Starting State
-    All observations start in state (0,0,0,0,0,0,0,0) with a Uniform noise in the range of [-0.1, 0.1] is added to the initial state for stochasticity.
+    All observations start in state (0,0,0,0,0,0,0,0) with a Uniform noise in the range of [-`reset_noise_scale`, `reset_noise_scale`] is added to the initial state for stochasticity.
 
     ### Episode Termination
     The episode terminates when the episode length is greater than 1000.
 
     ### Arguments
 
-    No additional arguments are currently supported (in v2 and lower), but
-    modifications can be made to the XML file in the assets folder
-    (or by changing the path to a modified XML file in another folder).
+    No additional arguments are currently supported in v2 and lower.
 
     ```
     gym.make('Swimmer-v2')
@@ -120,6 +104,15 @@ class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     ```
     env = gym.make('Swimmer-v3', ctrl_cost_weight=0.1, ....)
     ```
+
+    | Parameter               | Type       | Default      |Description                    |
+    |-------------------------|------------|--------------|-------------------------------|
+    | `xml_file`              | **str**    | `"swimmer.xml"`| Path to a MuJoCo model |
+    | `forward_reward_weight` | **float**  | `1.0`        | Weight for *forward_reward* term (see section on reward) |
+    | `ctrl_cost_weight`      | **float**  | `1e-4`       | Weight for *ctrl_cost* term (see section on reward) |
+    | `reset_noise_scale`     | **float**  | `0.1`        | Scale of random perturbations of initial position and velocity (see section on Starting State) |
+    | `exclude_current_positions_from_observation`| **bool** | `True`| Whether or not to omit the x- and y-coordinates from observations. Excluding the position can serve as an inductive bias to induce position-agnostic behavior in policies |
+
 
     ### Version History
 

--- a/gym/envs/mujoco/walker2d_v3.py
+++ b/gym/envs/mujoco/walker2d_v3.py
@@ -17,7 +17,7 @@ class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     This environment builds on the hopper environment based on the work done by Erez, Tassa, and Todorov
     in ["Infinite Horizon Model Predictive Control for Nonlinear Periodic Tasks"](http://www.roboticsproceedings.org/rss07/p10.pdf)
-    by adding another set of legs making it possiible for the robot to walker forward instead of
+    by adding another set of legs making it possible for the robot to walker forward instead of
     hop. Like other Mujoco environments, this environment aims to increase the number of independent state
     and control variables as compared to the classic control environments. The walker is a
     two-dimensional two-legged figure that consist of four main body parts - a single torso at the top
@@ -27,9 +27,7 @@ class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     direction by applying torques on the six hinges connecting the six body parts.
 
     ### Action Space
-    The agent take a 6-element vector for actions.
-    The action space is a continuous `(action, action, action, action, action, action)`
-    all in `[-1, 1]`, where `action` represents the numerical torques applied at the hinge joints.
+    The action space is a `Box(-1, 1, (6,), float32)`. An action represents the torques applied at the hinge joints.
 
     | Num | Action                                 | Control Min | Control Max | Name (in corresponding XML file) | Joint | Unit         |
     |-----|----------------------------------------|-------------|-------------|----------------------------------|-------|--------------|
@@ -42,40 +40,17 @@ class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Observation Space
 
-    The state space consists of positional values of different body parts of the walker,
+    Observations consist of positional values of different body parts of the walker,
     followed by the velocities of those individual parts (their derivatives) with all the positions ordered before all the velocities.
 
-    The observation is a `ndarray` with shape `(17,)` where the elements correspond to the following:
+    By default, observations do not include the x-coordinate of the top. It may
+    be included by passing `exclude_current_positions_from_observation=False` during construction.
+    In that case, the observation space will have 18 dimensions where the first dimension
+    represent the x-coordinates of the top of the walker.
+    Regardless of whether `exclude_current_positions_from_observation` was set to true or false, the x-coordinate
+    of the top will be returned in `info` with key `"x_position"`.
 
-    | Num | Observation                                                       | Min                | Max                | Name (in corresponding XML file) | Joint | Unit |
-    |-----|--------------------------------------------------------|----------------|-----------------|----------------------------------------|-------|------|
-    | 0   | x-coordinate of the top                            | -Inf                 | Inf                | rootx (torso)      | slide | position (m) |
-    | 1   | z-coordinate of the top (height of hopper)         | -Inf                 | Inf                | rootz (torso)      | slide | position (m) |
-    | 2   | angle of the top                                   | -Inf                 | Inf                | rooty (torso)      | hinge | angle (rad) |
-    | 3   | angle of the thigh joint                           | -Inf                 | Inf                | thigh_joint        | hinge | angle (rad) |
-    | 4   | angle of the leg joint                             | -Inf                 | Inf                | leg_joint            | hinge | angle (rad) |
-    | 5   | angle of the foot joint                            | -Inf                 | Inf                | foot_joint          | hinge | angle (rad) |
-    | 6   | angle of the left thigh joint                      | -Inf                 | Inf                | thigh_left_joint  | hinge | angle (rad) |
-    | 7   | angle of the left leg joint                        | -Inf                 | Inf                | leg_left_joint    | hinge | angle (rad) |
-    | 8   | angle of the left foot joint                       | -Inf                 | Inf                | foot_left_joint  | hinge | angle (rad) |
-    | 9   | velocity of the x-coordinate of the top            | -Inf                 | Inf                | rootx               | slide | velocity (m/s) |
-    | 10  | velocity of the z-coordinate (height) of the top   | -Inf                 | Inf                | rootz                | slide | velocity (m/s)  |
-    | 11  | angular velocity of the angle of the top           | -Inf                 | Inf                | rooty                | hinge | angular velocity (rad/s) |
-    | 12  | angular velocity of the thigh hinge                | -Inf                 | Inf                | thigh_joint        | hinge | angular velocity (rad/s) |
-    | 13  | angular velocity of the leg hinge                  | -Inf                 | Inf                | leg_joint            |  hinge | angular velocity (rad/s) |
-    | 14  | angular velocity of the foot hinge                 | -Inf                 | Inf                | foot_joint           | hinge | angular velocity (rad/s) |
-    | 15  | angular velocity of the thigh hinge                | -Inf                 | Inf                | thigh_left_joint   | hinge | angular velocity (rad/s) |
-    | 16  | angular velocity of the leg hinge                  | -Inf                 | Inf                | leg_left_joint     | hinge | angular velocity (rad/s) |
-    | 17  | angular velocity of the foot hinge                 | -Inf                 | Inf                | foot_left_joint    | hinge | angular velocity (rad/s) |
-
-
-
-    **Note:**
-    In practice (and Gym implementation), the first positional element is omitted from the
-    state space since the reward function is calculated based on that value. This value is
-    hidden from the algorithm, which in turn has to develop an abstract understanding of it
-    from the observed rewards. Therefore, observation space has shape `(17,)`
-    instead of `(18,)` and looks like:
+    By default, observation is a `ndarray` with shape `(17,)` where the elements correspond to the following:
 
     | Num | Observation                                                       | Min                | Max                | Name (in corresponding XML file) | Joint | Unit |
     |-----|--------------------------------------------------------|----------------|-----------------|----------------------------------------|-------|------|
@@ -99,37 +74,42 @@ class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     ### Rewards
     The reward consists of three parts:
-    - *alive bonus*: Every timestep that the walker is alive, it gets a reward of 1,
-    - *reward_forward*: A reward of walking forward which is measured as
-    *(x-coordinate before action - x-coordinate after action)/dt*.
+    - *healthy_reward*: Every timestep that the walker is alive, it receives a fixed reward of value `healthy_reward`,
+    - *forward_reward*: A reward of walking forward which is measured as
+    *`forward_reward_weight` * (x-coordinate before action - x-coordinate after action)/dt*.
     *dt* is the time between actions and is dependeent on the frame_skip parameter
-    (default is 4), where the *dt* for one frame is 0.002 - making the default
+    (default is 4), where the frametime is 0.002 - making the default
     *dt = 4 * 0.002 = 0.008*. This reward would be positive if the walker walks forward (right) desired.
-    - *reward_control*: A negative reward for penalising the walker if it
+    - *ctrl_cost*: A cost for penalising the walker if it
     takes actions that are too large. It is measured as
-    *-coefficient **x** sum(action<sup>2</sup>)* where *coefficient* is
+    *`ctrl_cost_weight` * sum(action<sup>2</sup>)* where *`ctrl_cost_weight`* is
     a parameter set for the control and has a default value of 0.001
 
-    The total reward returned is ***reward*** *=* *alive bonus + reward_forward + reward_control*
+    The total reward returned is ***reward*** *=* *healthy_reward bonus + forward_reward - ctrl_cost* and `info` will also contain the individual reward terms
 
     ### Starting State
     All observations start in state
     (0.0, 1.25, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-    with a uniform noise in the range of [-0.005, 0.005] added to the values for stochasticity.
+    with a uniform noise in the range of [-`reset_noise_scale`, `reset_noise_scale`] added to the values for stochasticity.
 
     ### Episode Termination
-    The episode terminates when any of the following happens:
+    The walker is said to be unhealthy if any of the following happens:
+
+    1. Any of the state space values is no longer finite
+    2. The height of the walker is ***not*** in the closed interval specified by `healthy_z_range`
+    3. The absolute value of the angle (`observation[1]` if `exclude_current_positions_from_observation=False`, else `observation[2]`) is ***not*** in the closed interval specified by `healthy_angle_range`
+
+    If `terminate_when_unhealthy=True` is passed during construction (which is the default),
+    the episode terminates when any of the following happens:
 
     1. The episode duration reaches a 1000 timesteps
-    2. Any of the state space values is no longer finite
-    3. The height of the walker (index 1) is ***not*** in the range `[0.8, 2]`
-    4. The absolute value of the angle (index 2) is ***not*** in the range `[-1, 1]`
+    2. The walker is unhealthy
+
+    If `terminate_when_unhealthy=False` is passed, the episode is terminated only when 1000 timesteps are exceeded.
 
     ### Arguments
 
-    No additional arguments are currently supported (in v2 and lower),
-    but modifications can be made to the XML file in the assets folder
-    (or by changing the path to a modified XML file in another folder)..
+    No additional arguments are currently supported in v2 and lower.
 
     ```
     env = gym.make('Walker2d-v2')
@@ -140,6 +120,19 @@ class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     ```
     env = gym.make('Walker2d-v3', ctrl_cost_weight=0.1, ....)
     ```
+
+    | Parameter               | Type       | Default      |Description                    |
+    |-------------------------|------------|--------------|-------------------------------|
+    | `xml_file`              | **str**    | `"walker2d.xml"` | Path to a MuJoCo model |
+    | `forward_reward_weight` | **float**  | `1.0`        | Weight for *forward_reward* term (see section on reward) |
+    | `ctrl_cost_weight`      | **float**  | `1e-3`       | Weight for *ctr_cost* term (see section on reward) |
+    | `healthy_reward`        | **float**  | `1.0`        | Constant reward given if the ant is "healthy" after timestep |
+    | `terminate_when_unhealthy` | **bool**| `True`       | If true, issue a done signal if the z-coordinate of the walker is no longer healthy |
+    | `healthy_z_range`       | **tuple**  | `(0.8, 2)`   | The z-coordinate of the top of the walker must be in this range to be considered healthy |
+    | `healthy_angle_range`   | **tuple**  | `(-1, 1)`    | The angle must be in this range to be considered healthy|
+    | `reset_noise_scale`     | **float**  | `5e-3`       | Scale of random perturbations of initial position and velocity (see section on Starting State) |
+    | `exclude_current_positions_from_observation`| **bool** | `True`| Whether or not to omit the x-coordinate from observations. Excluding the position can serve as an inductive bias to induce position-agnostic behavior in policies |
+
 
     ### Version History
 


### PR DESCRIPTION
This is a WIP

Imo a big issue is that it's not clear how v2 and v3 relate and which version is actually being documented. Am I right in assuming that 
1. We concentrate on v3?
2. The only difference between v3 and v2 is configurability? I.e. the default configuration of v3 is equivalent to v2? (That's what the current version info seems to imply)

Changes so far:

### General Changes
- Rephrase action space
- In "Observation Space": "state space" -> "observations": This seems to be a recurring phrasing in the MuJoCo docs. My reason for changing this is two-fold: If we are being pedantic, the state space does not consist of positional values of different body parts, but of states. Secondly, there is a slight distinction between states and observations in the setting of POMDPs and we are mostly concerned about observations.
- Change the tables for observation space to illustrate `exclude_current_positions_from_observation=True` and discuss `exclude_current_positions_from_observation=False` as special case
- Talk about weights for reward terms
- Update names of reward terms to match code
- Note that individual reward terms are returned in `info`
- Talk about `terminate_when_unhealthy`
- Currently, the documentation is encouraging users to modify the XML assets that come with Gym. I don't think that's a good idea, especially since v3 allows to specify the path to a custom MuJoCo model.
- Give a list of kwargs for `make`

### Ant
- Change y-coordinate to z-coordinate in termination criterion

### Half Cheetah
- Changed y-coordinate to z-coordinate. **TODO**: Is this correct?

### Humanoid
- Question: Is there any difference between "control" and "action". Why use the term "control"?
- I cannot claim to understand cinert, cvel etc.

### HumanoidStandup, InvertedDoublePendulum, InvertedPendulum
- Remove v3 from version info


There are probably a bunch of changes that I forgot to mention in the list above