### PR TITLE
gym.spaces.Tuple inherits from collections.abc.Sequence

### DIFF
--- a/gym/spaces/tuple.py
+++ b/gym/spaces/tuple.py
@@ -1,9 +1,10 @@
+from collections.abc import Sequence
 from typing import Iterable, List, Optional, Union
 import numpy as np
 from .space import Space
 
 
-class Tuple(Space[tuple]):
+class Tuple(Space[tuple], Sequence):
     """
     A tuple (i.e., product) of simpler spaces
 

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -391,7 +391,7 @@ def test_tuple():
         assert space == spaces[len(spaces)-1-i]
     assert space_tuple.index(Discrete(5)) == 0
     assert space_tuple.index(Discrete(5), 1) == 2
-    with pytest.raises(ValueError, match=r".* not in tuple"):
+    with pytest.raises(ValueError):
         space_tuple.index(Discrete(10), 0, 1)
 
 

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -378,7 +378,6 @@ def test_seed_subspace_incorrelated(space):
 
 
 def test_tuple():
-    # 1D multi-discrete
     spaces = [Discrete(5), Discrete(10), Discrete(5)]
     space_tuple = Tuple(spaces)
 

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -377,6 +377,23 @@ def test_seed_subspace_incorrelated(space):
     assert len(states) == len(set(states))
 
 
+def test_tuple():
+    # 1D multi-discrete
+    spaces = [Discrete(5), Discrete(10)]
+    space_tuple = Tuple(spaces)
+
+    assert len(space_tuple) == len(spaces)
+    assert space_tuple.count() == len(spaces)
+    for i, space in enumerate(space_tuple):
+        assert space == spaces[i]
+    for i, space in enumerate(reversed(space_tuple)):
+        assert space == spaces[len(spaces)-1-i]
+    for i, space in enumerate(spaces):
+        assert space_tuple.index(space) == i
+    with pytest.raises(ValueError, match=r".* not in tuple"):
+        space_tuple.index(spaces[1], 0, 1)
+
+
 def test_multidiscrete_as_tuple():
     # 1D multi-discrete
     space = MultiDiscrete([3, 4, 5])

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -387,7 +387,7 @@ def test_tuple():
     for i, space in enumerate(space_tuple):
         assert space == spaces[i]
     for i, space in enumerate(reversed(space_tuple)):
-        assert space == spaces[len(spaces)-1-i]
+        assert space == spaces[len(spaces) - 1 - i]
     assert space_tuple.index(Discrete(5)) == 0
     assert space_tuple.index(Discrete(5), 1) == 2
     with pytest.raises(ValueError):

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -84,7 +84,7 @@ def test_roundtripping(space):
 )
 def test_equality(space):
     space1 = space
-    space2 = copy.copy(space)
+    space2 = copy.deepcopy(space)
     assert space1 == space2, f"Expected {space1} to equal {space2}"
 
 
@@ -379,19 +379,20 @@ def test_seed_subspace_incorrelated(space):
 
 def test_tuple():
     # 1D multi-discrete
-    spaces = [Discrete(5), Discrete(10)]
+    spaces = [Discrete(5), Discrete(10), Discrete(5)]
     space_tuple = Tuple(spaces)
 
     assert len(space_tuple) == len(spaces)
-    assert space_tuple.count() == len(spaces)
+    assert space_tuple.count(Discrete(5)) == 2
+    assert space_tuple.count(MultiBinary(2)) == 0
     for i, space in enumerate(space_tuple):
         assert space == spaces[i]
     for i, space in enumerate(reversed(space_tuple)):
         assert space == spaces[len(spaces)-1-i]
-    for i, space in enumerate(spaces):
-        assert space_tuple.index(space) == i
+    assert space_tuple.index(Discrete(5)) == 0
+    assert space_tuple.index(Discrete(5), 1) == 2
     with pytest.raises(ValueError, match=r".* not in tuple"):
-        space_tuple.index(spaces[1], 0, 1)
+        space_tuple.index(Discrete(10), 0, 1)
 
 
 def test_multidiscrete_as_tuple():


### PR DESCRIPTION
Following the PR I did a few months back (https://github.com/openai/gym/pull/2446), the tuple wrapper of gym should inherits from the abstract interface of Python. It is important for type check via `isinstance` and enable using such objects transparently with libraries such as [dmtree](https://github.com/deepmind/tree). 

It will bring a way helper methods along the way but it cannot be avoided to interoperability: : `__iter__`, `__reversed__`, `index`, and `count`
Personally I don't think it is an issue since it is new features and it is not conflicting.

As the previous PR, this patch is NOT removing any existing feature and should not break backward compatibility.