### PR TITLE
Make `NormalizeObservation` compatible with pybullet

### DIFF
--- a/gym/wrappers/normalize.py
+++ b/gym/wrappers/normalize.py
@@ -65,14 +65,16 @@ class NormalizeObservation(gym.core.Wrapper):
 
     def reset(self, **kwargs):
         output = self.env.reset(**kwargs)
-        if len(output) == 2:
-            obs, _ = output
+        if kwargs.get("return_info", False):
+            obs = output[0]
         else:
             obs = output
+
         if self.is_vector_env:
             obs = self.normalize(obs)
         else:
             obs = self.normalize(np.array([obs]))[0]
+
         return output
 
     def normalize(self, obs):

--- a/gym/wrappers/normalize.py
+++ b/gym/wrappers/normalize.py
@@ -82,6 +82,7 @@ class NormalizeObservation(gym.core.Wrapper):
         self.obs_rms.update(obs)
         return (obs - self.obs_rms.mean) / np.sqrt(self.obs_rms.var + self.epsilon)
 
+
 class NormalizeReward(gym.core.Wrapper):
     def __init__(
         self,

--- a/gym/wrappers/normalize.py
+++ b/gym/wrappers/normalize.py
@@ -64,23 +64,23 @@ class NormalizeObservation(gym.core.Wrapper):
         return obs, rews, dones, infos
 
     def reset(self, **kwargs):
-        output = self.env.reset(**kwargs)
-        if kwargs.get("return_info", False):
-            obs = output[0]
+        return_info = kwargs.get("return_info", False)
+        if return_info:
+            obs, info = self.env.reset(**kwargs)
         else:
-            obs = output
-
+            obs = self.env.reset(**kwargs)
         if self.is_vector_env:
             obs = self.normalize(obs)
         else:
             obs = self.normalize(np.array([obs]))[0]
-
-        return output
+        if not return_info:
+            return obs
+        else:
+            return obs, info
 
     def normalize(self, obs):
         self.obs_rms.update(obs)
         return (obs - self.obs_rms.mean) / np.sqrt(self.obs_rms.var + self.epsilon)
-
 
 class NormalizeReward(gym.core.Wrapper):
     def __init__(

--- a/gym/wrappers/normalize.py
+++ b/gym/wrappers/normalize.py
@@ -63,26 +63,17 @@ class NormalizeObservation(gym.core.Wrapper):
             obs = self.normalize(np.array([obs]))[0]
         return obs, rews, dones, infos
 
-    def reset(
-        self,
-        seed: Optional[int] = None,
-        return_info: bool = False,
-        options: Optional[dict] = None,
-    ):
-        obs = None
-        info = None
-        if not return_info:
-            obs = self.env.reset(seed=seed, options=options)
+    def reset(self, **kwargs):
+        output = self.env.reset(**kwargs)
+        if len(output) == 2:
+            obs, _ = output
         else:
-            obs, info = self.env.reset(seed=seed, return_info=True, options=options)
+            obs = output
         if self.is_vector_env:
             obs = self.normalize(obs)
         else:
             obs = self.normalize(np.array([obs]))[0]
-        if not return_info:
-            return obs
-        else:
-            return obs, info
+        return output
 
     def normalize(self, obs):
         self.obs_rms.update(obs)

--- a/tests/wrappers/test_normalize.py
+++ b/tests/wrappers/test_normalize.py
@@ -3,6 +3,7 @@ from typing import Optional
 import gym
 import numpy as np
 from numpy.testing import assert_almost_equal
+import pytest
 
 from gym.wrappers.normalize import NormalizeObservation, NormalizeReward
 
@@ -46,10 +47,11 @@ def make_env(return_reward_idx):
     return thunk
 
 
-def test_normalize_observation():
+@pytest.mark.parametrize("return_info", [False, True])
+def test_normalize_observation(return_info: bool):
     env = DummyRewardEnv(return_reward_idx=0)
     env = NormalizeObservation(env)
-    env.reset()
+    env.reset(return_info=return_info)
     env.step(env.action_space.sample())
     assert_almost_equal(env.obs_rms.mean, 0.5, decimal=4)
     env.step(env.action_space.sample())


### PR DESCRIPTION
This PR follows up with https://github.com/openai/gym/issues/2531#issuecomment-1046122844. Basically the following script errors out:

```python
# pip install pybullet==3.1.8
import gym
import numpy as np
import pybullet_envs

env = gym.make("HopperBulletEnv-v0")
env = gym.wrappers.ClipAction(env)
env = gym.wrappers.NormalizeObservation(env)
env.reset()
```

```
pybullet build time: Sep  3 2021 23:59:09
/home/costa/.cache/pypoetry/virtualenvs/cleanrl-ghSZGHE3-py3.9/lib/python3.9/site-packages/gym/spaces/box.py:78: UserWarning: WARN: Box bound precision lowered by casting to float32
  logger.warn(f"Box bound precision lowered by casting to {self.dtype}")
argv[0]=
argv[0]=
Traceback (most recent call last):
  File "/home/costa/Documents/go/src/github.com/cleanrl/cleanrl/test.py", line 14, in <module>
    env.reset()
  File "/home/costa/.cache/pypoetry/virtualenvs/cleanrl-ghSZGHE3-py3.9/lib/python3.9/site-packages/gym/core.py", line 324, in reset
    return self.env.reset(**kwargs)
  File "/home/costa/.cache/pypoetry/virtualenvs/cleanrl-ghSZGHE3-py3.9/lib/python3.9/site-packages/gym/core.py", line 283, in reset
    return self.env.reset(**kwargs)
  File "/home/costa/.cache/pypoetry/virtualenvs/cleanrl-ghSZGHE3-py3.9/lib/python3.9/site-packages/gym/core.py", line 311, in reset
    return self.observation(self.env.reset(**kwargs))
  File "/home/costa/.cache/pypoetry/virtualenvs/cleanrl-ghSZGHE3-py3.9/lib/python3.9/site-packages/gym/wrappers/normalize.py", line 75, in reset
    obs = self.env.reset(seed=seed, options=options)
  File "/home/costa/.cache/pypoetry/virtualenvs/cleanrl-ghSZGHE3-py3.9/lib/python3.9/site-packages/gym/core.py", line 337, in reset
    return self.env.reset(**kwargs)
  File "/home/costa/.cache/pypoetry/virtualenvs/cleanrl-ghSZGHE3-py3.9/lib/python3.9/site-packages/gym/wrappers/time_limit.py", line 26, in reset
    return self.env.reset(**kwargs)
  File "/home/costa/.cache/pypoetry/virtualenvs/cleanrl-ghSZGHE3-py3.9/lib/python3.9/site-packages/gym/wrappers/order_enforcing.py", line 18, in reset
    return self.env.reset(**kwargs)
TypeError: reset() got an unexpected keyword argument 'seed'
```

And the reason is that https://github.com/openai/gym/blob/bdde1ede6c52ea5fa95f54404fa3e4f4420d7afc/gym/wrappers/normalize.py#L77  forces to use the `seed ` during reset.

This PR fixes this breaking change and makes gym compatible with past gym environments that don't implement `env.reset(seed=seed)`

