### PR TITLE
Fix RandomNumberGenerator pickling

### DIFF
--- a/gym/utils/seeding.py
+++ b/gym/utils/seeding.py
@@ -100,15 +100,17 @@ class RandomNumberGenerator(np.random.Generator):
         return (RandomNumberGenerator._generator_ctor, init_args, *args)
 
     @staticmethod
-    def _generator_ctor(bit_generator_name='MT19937'):
+    def _generator_ctor(bit_generator_name="MT19937"):
         # Workaround method for RandomNumberGenerator pickling, see __reduce__ above.
         # Ported from numpy.random._pickle.__generator_ctor function.
         from numpy.random._pickle import BitGenerators
+
         if bit_generator_name in BitGenerators:
             bit_generator = BitGenerators[bit_generator_name]
         else:
-            raise ValueError(str(bit_generator_name) + ' is not a known '
-                                                    'BitGenerator module.')
+            raise ValueError(
+                f"{bit_generator_name} is not a known BitGenerator module."
+            )
         return RandomNumberGenerator(bit_generator())
 
 

--- a/gym/utils/seeding.py
+++ b/gym/utils/seeding.py
@@ -97,7 +97,7 @@ class RandomNumberGenerator(np.random.Generator):
         # See: https://github.com/numpy/numpy/blob/41d37b714caa1eef72f984d529f1d40ed48ce535/numpy/random/_generator.pyx#L221-L223
         # And: https://github.com/numpy/numpy/blob/41d37b714caa1eef72f984d529f1d40ed48ce535/numpy/random/_pickle.py#L17-L37
         _, init_args, *args = np.random.Generator.__reduce__(self)
-        return RandomNumberGenerator._generator_ctor, init_args, *args
+        return (RandomNumberGenerator._generator_ctor, init_args, *args)
 
     @staticmethod
     def _generator_ctor(bit_generator_name='MT19937'):

--- a/tests/utils/test_seeding.py
+++ b/tests/utils/test_seeding.py
@@ -1,3 +1,5 @@
+import pickle
+
 from gym import error
 from gym.utils import seeding
 
@@ -16,3 +18,11 @@ def test_valid_seeds():
     for seed in [0, 1]:
         random, seed1 = seeding.np_random(seed)
         assert seed == seed1
+
+
+def test_rng_pickle():
+    rng, _ = seeding.np_random(seed=0)
+    pickled = pickle.dumps(rng)
+    rng2 = pickle.loads(pickled)
+    assert isinstance(rng2, seeding.RandomNumberGenerator), "Unpickled object is not a RandomNumberGenerator"
+    assert rng.random() == rng2.random()

--- a/tests/utils/test_seeding.py
+++ b/tests/utils/test_seeding.py
@@ -24,5 +24,7 @@ def test_rng_pickle():
     rng, _ = seeding.np_random(seed=0)
     pickled = pickle.dumps(rng)
     rng2 = pickle.loads(pickled)
-    assert isinstance(rng2, seeding.RandomNumberGenerator), "Unpickled object is not a RandomNumberGenerator"
+    assert isinstance(
+        rng2, seeding.RandomNumberGenerator
+    ), "Unpickled object is not a RandomNumberGenerator"
     assert rng.random() == rng2.random()


### PR DESCRIPTION
## Reason
gym 0.22.0 defines a `RandomNumberGenerator` class inheriting `np.random.Generator`.
`np.random.Generator` defines `__reduce__`, but it's hard-coded to return a `Generator` instead of its subclass `RandomNumberGenerator`. Thus, sampling from a Space will be broken after pickling and unpickling, due to using the deprecated methods defined in `RandomNumberGenerator`. (Which further breaks some RL frameworks like RLlib relying on pickling for distributed training)

## Example
Before
```python
>>> import gym, pickle
>>> space = gym.spaces.Discrete(500)
>>> rng = pickle.loads(pickle.dumps(space.np_random))
>>> rng
Generator(PCG64) at _
>>> rng.randint(2)
AttributeError: 'numpy.random._generator.Generator' object has no attribute 'randint'
```
After
```python
>>> import gym, pickle
>>> space = gym.spaces.Discrete(500)
>>> rng = pickle.loads(pickle.dumps(space.np_random))
>>> rng
RandomNumberGenerator(PCG64) at _
>>> rng.randint(2)
1
```