### PR TITLE
Fix space utils for Discrete with non-zero start

### DIFF
--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -78,7 +78,7 @@ def _flatten_box_multibinary(space, x) -> np.ndarray:
 @flatten.register(Discrete)
 def _flatten_discrete(space, x) -> np.ndarray:
     onehot = np.zeros(space.n, dtype=space.dtype)
-    onehot[x] = 1
+    onehot[x - space.start] = 1
     return onehot
 
 
@@ -124,7 +124,7 @@ def _unflatten_box_multibinary(space: Box | MultiBinary, x: np.ndarray) -> np.nd
 
 @unflatten.register(Discrete)
 def _unflatten_discrete(space: Discrete, x: np.ndarray) -> int:
-    return int(np.nonzero(x)[0][0])
+    return int(space.start + np.nonzero(x)[0][0])
 
 
 @unflatten.register(MultiDiscrete)

--- a/gym/vector/utils/spaces.py
+++ b/gym/vector/utils/spaces.py
@@ -56,7 +56,7 @@ def _batch_space_discrete(space, n=1):
     else:
         return Box(
             low=space.start,
-            high=space.start + space.n,
+            high=space.start + space.n - 1,
             shape=(n,),
             dtype=space.dtype,
         )

--- a/gym/vector/utils/spaces.py
+++ b/gym/vector/utils/spaces.py
@@ -53,7 +53,15 @@ def batch_space_base(space, n=1):
         return Box(low=low, high=high, dtype=space.dtype)
 
     elif isinstance(space, Discrete):
-        return MultiDiscrete(np.full((n,), space.n, dtype=space.dtype))
+        if space.start == 0:
+            return MultiDiscrete(np.full((n,), space.n, dtype=space.dtype))
+        else:
+            return Box(
+                low=space.start,
+                high=space.start + space.n,
+                shape=(n,),
+                dtype=space.dtype,
+            )
 
     elif isinstance(space, MultiDiscrete):
         repeats = tuple([n] + [1] * space.nvec.ndim)

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -28,9 +28,11 @@ spaces = [
             ),
         }
     ),
+    Discrete(3, start=2),
+    Discrete(8, start=-5),
 ]
 
-flatdims = [3, 4, 4, 15, 7, 9, 14, 10, 7]
+flatdims = [3, 4, 4, 15, 7, 9, 14, 10, 7, 3, 8]
 
 
 @pytest.mark.parametrize(["space", "flatdim"], zip(spaces, flatdims))
@@ -123,6 +125,8 @@ expected_flattened_dtypes = [
     np.int64,
     np.int8,
     np.float64,
+    np.int64,
+    np.int64,
 ]
 
 
@@ -187,6 +191,8 @@ samples = [
     OrderedDict(
         [("position", 3), ("velocity", np.array([0.5, 3.5], dtype=np.float32))]
     ),
+    3,
+    -2,
 ]
 
 
@@ -200,6 +206,8 @@ expected_flattened_samples = [
     np.array([1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0], dtype=np.int64),
     np.array([0, 1, 1, 0, 0, 0, 1, 1, 1, 1], dtype=np.int8),
     np.array([0, 0, 0, 1, 0, 0.5, 3.5], dtype=np.float64),
+    np.array([0, 1, 0], dtype=np.int64),
+    np.array([0, 0, 0, 1, 0, 0, 0, 0], dtype=np.int64),
 ]
 
 
@@ -243,6 +251,8 @@ expected_flattened_spaces = [
         high=np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 5.0], dtype=np.float64),
         dtype=np.float64,
     ),
+    Box(low=0, high=1, shape=(3,), dtype=np.int64),
+    Box(low=0, high=1, shape=(8,), dtype=np.int64),
 ]
 
 

--- a/tests/vector/test_shared_memory.py
+++ b/tests/vector/test_shared_memory.py
@@ -26,6 +26,7 @@ expected_types = [
     Array("B", 1),
     Array("B", 32 * 32 * 3),
     Array("i", 1),
+    Array("i", 1),
     (Array("i", 1), Array("i", 1)),
     (Array("i", 1), Array("f", 2)),
     Array("B", 3),

--- a/tests/vector/test_spaces.py
+++ b/tests/vector/test_spaces.py
@@ -33,7 +33,7 @@ expected_batch_spaces_4 = [
     Box(low=0, high=255, shape=(4,), dtype=np.uint8),
     Box(low=0, high=255, shape=(4, 32, 32, 3), dtype=np.uint8),
     MultiDiscrete([2, 2, 2, 2]),
-    Box(low=-2, high=3, shape=(4,), dtype=np.int64),
+    Box(low=-2, high=2, shape=(4,), dtype=np.int64),
     Tuple((MultiDiscrete([3, 3, 3, 3]), MultiDiscrete([5, 5, 5, 5]))),
     Tuple(
         (

--- a/tests/vector/test_spaces.py
+++ b/tests/vector/test_spaces.py
@@ -33,6 +33,7 @@ expected_batch_spaces_4 = [
     Box(low=0, high=255, shape=(4,), dtype=np.uint8),
     Box(low=0, high=255, shape=(4, 32, 32, 3), dtype=np.uint8),
     MultiDiscrete([2, 2, 2, 2]),
+    Box(low=-2, high=3, shape=(4,), dtype=np.int64),
     Tuple((MultiDiscrete([3, 3, 3, 3]), MultiDiscrete([5, 5, 5, 5]))),
     Tuple(
         (

--- a/tests/vector/utils.py
+++ b/tests/vector/utils.py
@@ -18,6 +18,7 @@ spaces = [
     Box(low=0, high=255, shape=(), dtype=np.uint8),
     Box(low=0, high=255, shape=(32, 32, 3), dtype=np.uint8),
     Discrete(2),
+    Discrete(5, start=-2),
     Tuple((Discrete(3), Discrete(5))),
     Tuple(
         (


### PR DESCRIPTION
 - Fix `flatten` and `unflatten` functions for a `Discrete` space by adding an offset.
 - Fix `batch_space` to return a `Box` space when batching a `Discrete` space with non-zero `start` (and still return a `MultiDiscrete` otherwise).
 - Break down the `singledispatch` for the function `batch_space`, and use the conventions from `gym.spaces.utils`.

Fixes #2644