### PR TITLE
autoreset wrapper

### DIFF
--- a/gym/wrappers/__init__.py
+++ b/gym/wrappers/__init__.py
@@ -16,3 +16,4 @@ from gym.wrappers.record_episode_statistics import RecordEpisodeStatistics
 from gym.wrappers.normalize import NormalizeObservation, NormalizeReward
 from gym.wrappers.record_video import RecordVideo, capped_cubic_video_schedule
 from gym.wrappers.order_enforcing import OrderEnforcing
+from gym.wrappers.autoreset import AutoResetWrapper

--- a/gym/wrappers/autoreset.py
+++ b/gym/wrappers/autoreset.py
@@ -39,9 +39,6 @@ import gym
 
 
 class AutoResetWrapper(gym.Wrapper):
-    def reset(self, **kwargs):
-        return self.env.reset(**kwargs)
-
     def step(self, action):
         obs, reward, done, info = self.env.step(action)
         if done:

--- a/gym/wrappers/autoreset.py
+++ b/gym/wrappers/autoreset.py
@@ -17,7 +17,8 @@ final_done is always True
 
 info is a dict of the form {info:{<self.env info>}, "final_obs":<the
 observation after calling self.env.step(), prior to calling
-self.env.reset()>}
+self.env.reset()>,"final_info":<the info after calling 
+self.env.step(), prior to calling self.env.reset()>}
 
 If done is not true when self.env.step() is called, self.step() returns
 obs, reward, and done as normal, and wraps the info returned
@@ -45,6 +46,11 @@ class AutoResetWrapper(gym.Wrapper):
         obs, reward, done, info = self.env.step(action)
         if done:
             new_obs, new_info = self.env.reset(return_info=True)
-            return new_obs, done, reward, {"info": new_info, "final_obs": obs}
+            return (
+                new_obs,
+                done,
+                reward,
+                {"info": new_info, "final_obs": obs, "final_info": info},
+            )
         else:
             return obs, reward, done, {"info": info}

--- a/gym/wrappers/autoreset.py
+++ b/gym/wrappers/autoreset.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+import numpy as np
+import gym
+
+
+class AutoResetWrapper(gym.Wrapper):
+    def __init__(self, env):
+        super().__init__(env)
+        self._env_done = False
+
+    def reset(self, **kwargs):
+        self._env_done = False
+        return self.env.reset(**kwargs)
+
+    def step(self, action):
+        if self._env_done:
+            obs, info = self.reset(
+                return_info=True
+            )  # we are assuming the return_info behavior is implemented in environments using this wrapper
+            return obs, None, None, info
+
+        obs, reward, done, info = self.env.step(action)
+        self._env_done = done
+
+        return obs, reward, done, info

--- a/gym/wrappers/autoreset.py
+++ b/gym/wrappers/autoreset.py
@@ -1,3 +1,22 @@
+"""
+A class for providing an automatic reset functionality for gym environments when calling step.
+
+If done was not true for the previous call to step, step returns
+
+obs, reward, done, info
+
+as normal.
+
+If done was true for the previous call to step, the action is ignored, and self.env.reset is called, and step returns
+
+obs, None, None, info
+
+Warning: When using this wrapper to collect rollouts, note that the action given to .step() which causes the reset (first call to 
+.step() after done = True) will have no effect on any observation, and should likely be excluded from logging.
+
+"""
+
+
 from typing import Optional
 
 import numpy as np

--- a/gym/wrappers/autoreset.py
+++ b/gym/wrappers/autoreset.py
@@ -1,54 +1,56 @@
-"""
-A class for providing an automatic reset functionality
-for gym environments when calling self.step().
-
-When calling step causes self.env.step() to return done,
-self.env.reset() is called,
-and the return format of self.step() is as follows:
-
-new_obs, final_reward, final_done, info
-
-new_obs is the first observation after calling self.env.reset(),
-
-final_reward is the reward after calling self.env.step(),
-prior to calling self.env.reset()
-
-final_done is always True
-
-info is a dict of the form {info:{<self.env info>}, "final_obs":<the
-observation after calling self.env.step(), prior to calling
-self.env.reset()>,"final_info":<the info after calling
-self.env.step(), prior to calling self.env.reset()>}
-
-If done is not true when self.env.step() is called, self.step() returns
-obs, reward, and done as normal, and wraps the info returned
-by from self.env.step() in another layer of dictionary with the key
-"info", to preserve the structure of the info return across cases.
-
-Warning: When using this wrapper to collect rollouts, note
-that the when self.env.step() returns done, a
-new observation from after calling self.env.reset() is returned
-by self.step() alongside the final reward and done state from the
-previous episode . If you need the final state from the previous
-episode, you need to retrieve it via the the "final_obs" key
-in the info dict. Make sure you know what you're doing if you
-use this wrapper!
-"""
-
-
 import gym
 
 
 class AutoResetWrapper(gym.Wrapper):
+    """
+    A class for providing an automatic reset functionality
+    for gym environments when calling self.step().
+
+    When calling step causes self.env.step() to return done,
+    self.env.reset() is called,
+    and the return format of self.step() is as follows:
+
+    new_obs, final_reward, final_done, info
+
+    new_obs is the first observation after calling self.env.reset(),
+
+    final_reward is the reward after calling self.env.step(),
+    prior to calling self.env.reset()
+
+    final_done is always True
+
+    info is a dict containing all the keys from the info dict returned by
+    the call to self.env.reset(), with an additional key 'final_obs"
+    containing the observation returned by the last call to self.env.step()
+    and "final_info" containing the info dict returned by the last call
+    to self.env.step().
+
+    If done is not true when self.env.step() is called, self.step() returns
+    obs, reward, done, and info as normal.
+
+    Warning: When using this wrapper to collect rollouts, note
+    that the when self.env.step() returns done, a
+    new observation from after calling self.env.reset() is returned
+    by self.step() alongside the final reward and done state from the
+    previous episode . If you need the final state from the previous
+    episode, you need to retrieve it via the the "final_obs" key
+    in the info dict. Make sure you know what you're doing if you
+    use this wrapper!
+    """
+
     def step(self, action):
         obs, reward, done, info = self.env.step(action)
+
         if done:
+
             new_obs, new_info = self.env.reset(return_info=True)
-            return (
-                new_obs,
-                reward,
-                done,
-                {"info": new_info, "final_obs": obs, "final_info": info},
-            )
-        else:
-            return obs, reward, done, {"info": info}
+            assert "final_obs" not in new_info
+            assert "final_info" not in new_info
+
+            new_info["final_obs"] = obs
+            new_info["final_info"] = info
+
+            obs = new_obs
+            info = new_info
+
+        return obs, reward, done, info

--- a/gym/wrappers/autoreset.py
+++ b/gym/wrappers/autoreset.py
@@ -27,11 +27,12 @@ by from self.env.step() in another layer of dictionary with the key
 
 Warning: When using this wrapper to collect rollouts, note
 that the when self.env.step() returns done, a
-new observation from after calling reset is returned
-alongside the final reward and done state from the
-previous episode by self.step(). It's important to retrieve the final state
-from the "final_obs" key in the info dict. Make sure you know what you're
-doing if you use this wrapper!
+new observation from after calling self.env.reset() is returned
+by self.step() alongside the final reward and done state from the
+previous episode . If you need the final state from the previous
+episode, you need to retrieve it via the the "final_obs" key
+in the info dict. Make sure you know what you're doing if you
+use this wrapper!
 """
 
 

--- a/gym/wrappers/autoreset.py
+++ b/gym/wrappers/autoreset.py
@@ -1,25 +1,27 @@
 """
-A class for providing an automatic reset functionality for gym environments when calling step.
+A class for providing an automatic reset functionality
+for gym environments when calling step.
 
-If done was not true for the previous call to step, step returns
+If done was not true for the previous call to step, step returns:
 
 obs, reward, done, info
 
 as normal.
 
-If done was true for the previous call to step, the action is ignored, and self.env.reset is called, and step returns
+If done was true for the previous call to step, the action is ignored,
+and self.env.reset is called, and step returns:
 
 obs, None, None, info
 
-Warning: When using this wrapper to collect rollouts, note that the action given to .step() which causes the reset (first call to 
-.step() after done = True) will have no effect on any observation, and should likely be excluded from logging.
+Warning: When using this wrapper to collect rollouts, note
+that the actiongiven to .step() which causes the reset
+(first call to .step() after done == True) will
+have no effect on any observation, and should likely
+be excluded from logging.
 
 """
 
 
-from typing import Optional
-
-import numpy as np
 import gym
 
 
@@ -36,7 +38,8 @@ class AutoResetWrapper(gym.Wrapper):
         if self._env_done:
             obs, info = self.reset(
                 return_info=True
-            )  # we are assuming the return_info behavior is implemented in environments using this wrapper
+            )  # in environments using this wrapper we are assuming the
+            #    return_info behavior is implemented
             return obs, None, None, info
 
         obs, reward, done, info = self.env.step(action)

--- a/gym/wrappers/autoreset.py
+++ b/gym/wrappers/autoreset.py
@@ -1,24 +1,36 @@
 """
 A class for providing an automatic reset functionality
-for gym environments when calling step.
+for gym environments when calling self.step().
 
-If done was not true for the previous call to step, step returns:
+When calling step causes self.env.step() to return done,
+self.env.reset() is called,
+and the return format of self.step() is as follows:
 
-obs, reward, done, info
+new_obs, final_reward, final_done, info
 
-as normal.
+new_obs is the first observation after calling self.env.reset(),
 
-If done was true for the previous call to step, the action is ignored,
-and self.env.reset is called, and step returns:
+final_reward is the reward after calling self.env.step(),
+prior to calling self.env.reset()
 
-obs, None, None, info
+final_done is always True
+
+info is a dict of the form {info:{<self.env info>}, "final_obs":<the
+observation after calling self.env.step(), prior to calling
+self.env.reset()>}
+
+If done is not true when self.env.step() is called, self.step() returns
+obs, reward, and done as normal, and wraps the info returned
+by from self.env.step() in another layer of dictionary with the key
+"info", to preserve the structure of the info return across cases.
 
 Warning: When using this wrapper to collect rollouts, note
-that the actiongiven to .step() which causes the reset
-(first call to .step() after done == True) will
-have no effect on any observation, and should likely
-be excluded from logging.
-
+that the when self.env.step() returns done, a
+new observation from after calling reset is returned
+alongside the final reward and done state from the
+previous episode by self.step(). It's important to retrieve the final state
+from the "final_obs" key in the info dict. Make sure you know what you're
+doing if you use this wrapper!
 """
 
 
@@ -26,23 +38,13 @@ import gym
 
 
 class AutoResetWrapper(gym.Wrapper):
-    def __init__(self, env):
-        super().__init__(env)
-        self._env_done = False
-
     def reset(self, **kwargs):
-        self._env_done = False
         return self.env.reset(**kwargs)
 
     def step(self, action):
-        if self._env_done:
-            obs, info = self.reset(
-                return_info=True
-            )  # in environments using this wrapper we are assuming the
-            #    return_info behavior is implemented
-            return obs, None, None, info
-
         obs, reward, done, info = self.env.step(action)
-        self._env_done = done
-
-        return obs, reward, done, info
+        if done:
+            new_obs, new_info = self.env.reset(return_info=True)
+            return new_obs, done, reward, {"info": new_info, "final_obs": obs}
+        else:
+            return obs, reward, done, {"info": info}

--- a/gym/wrappers/autoreset.py
+++ b/gym/wrappers/autoreset.py
@@ -45,8 +45,8 @@ class AutoResetWrapper(gym.Wrapper):
             new_obs, new_info = self.env.reset(return_info=True)
             return (
                 new_obs,
-                done,
                 reward,
+                done,
                 {"info": new_info, "final_obs": obs, "final_info": info},
             )
         else:

--- a/gym/wrappers/autoreset.py
+++ b/gym/wrappers/autoreset.py
@@ -17,7 +17,7 @@ final_done is always True
 
 info is a dict of the form {info:{<self.env info>}, "final_obs":<the
 observation after calling self.env.step(), prior to calling
-self.env.reset()>,"final_info":<the info after calling 
+self.env.reset()>,"final_info":<the info after calling
 self.env.step(), prior to calling self.env.reset()>}
 
 If done is not true when self.env.step() is called, self.step() returns

--- a/gym/wrappers/autoreset.py
+++ b/gym/wrappers/autoreset.py
@@ -10,19 +10,19 @@ class AutoResetWrapper(gym.Wrapper):
     self.env.reset() is called,
     and the return format of self.step() is as follows:
 
-    new_obs, final_reward, final_done, info
+    new_obs, terminal_reward, terminal_done, info
 
     new_obs is the first observation after calling self.env.reset(),
 
-    final_reward is the reward after calling self.env.step(),
+    terminal_reward is the reward after calling self.env.step(),
     prior to calling self.env.reset()
 
-    final_done is always True
+    terminal_done is always True
 
     info is a dict containing all the keys from the info dict returned by
-    the call to self.env.reset(), with an additional key 'final_obs"
+    the call to self.env.reset(), with an additional key "terminal_observation"
     containing the observation returned by the last call to self.env.step()
-    and "final_info" containing the info dict returned by the last call
+    and "terminal_info" containing the info dict returned by the last call
     to self.env.step().
 
     If done is not true when self.env.step() is called, self.step() returns
@@ -31,9 +31,9 @@ class AutoResetWrapper(gym.Wrapper):
     Warning: When using this wrapper to collect rollouts, note
     that the when self.env.step() returns done, a
     new observation from after calling self.env.reset() is returned
-    by self.step() alongside the final reward and done state from the
-    previous episode . If you need the final state from the previous
-    episode, you need to retrieve it via the the "final_obs" key
+    by self.step() alongside the terminal reward and done state from the
+    previous episode . If you need the terminal state from the previous
+    episode, you need to retrieve it via the the "terminal_observation" key
     in the info dict. Make sure you know what you're doing if you
     use this wrapper!
     """
@@ -44,11 +44,15 @@ class AutoResetWrapper(gym.Wrapper):
         if done:
 
             new_obs, new_info = self.env.reset(return_info=True)
-            assert "final_obs" not in new_info
-            assert "final_info" not in new_info
+            assert (
+                "terminal_observation" not in new_info
+            ), 'info dict cannot contain key "terminal_observation" '
+            assert (
+                "terminal_info" not in new_info
+            ), 'info dict cannot contain key "terminal_info" '
 
-            new_info["final_obs"] = obs
-            new_info["final_info"] = info
+            new_info["terminal_observation"] = obs
+            new_info["terminal_info"] = info
 
             obs = new_obs
             info = new_info

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -74,8 +74,8 @@ def test_autoreset_autoreset():
     assert info == {"info": {}, "final_obs": np.array([3])}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([1])
-    assert reward is 0
-    assert done is False
+    assert reward == 0
+    assert done == False
     assert info == {"info": {}}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([2])

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -8,6 +8,15 @@ from gym.wrappers import AutoResetWrapper
 
 
 class DummyResetEnv(gym.Env):
+    """
+    A dummy environment which returns ascending numbers starting
+    at 0 when self.step() is called. After the third call to self.step()
+    done is true. Info dicts are also returned containing the same number
+    returned as an observation, accessible via the key "count".
+    This environment is provided for the purpose of testing the
+    autoreset wrapper.
+    """
+
     metadata = {}
 
     def __init__(self):
@@ -46,10 +55,8 @@ def test_autoreset_reset_info():
     ob_space = env.observation_space
     obs = env.reset()
     assert ob_space.contains(obs)
-    del obs
     obs = env.reset(return_info=False)
     assert ob_space.contains(obs)
-    del obs
     obs, info = env.reset(return_info=True)
     assert ob_space.contains(obs)
     assert isinstance(info, dict)
@@ -66,18 +73,18 @@ def test_autoreset_autoreset():
     assert obs == np.array([1])
     assert reward == 0
     assert done == False
-    assert info == {"info": {"count": 1}}
+    assert info == {"count": 1}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([2])
     assert done == False
     assert reward == 0
-    assert info == {"info": {"count": 2}}
+    assert info == {"count": 2}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([0])
     assert done == True
     assert reward == 1
     assert info == {
-        "info": {"count": 0},
+        "count": 0,
         "final_obs": np.array([3]),
         "final_info": {"count": 3},
     }
@@ -85,9 +92,9 @@ def test_autoreset_autoreset():
     assert obs == np.array([1])
     assert reward == 0
     assert done == False
-    assert info == {"info": {"count": 1}}
+    assert info == {"count": 1}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([2])
     assert reward == 0
     assert done == False
-    assert info == {"info": {"count": 2}}
+    assert info == {"count": 2}

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -1,0 +1,84 @@
+import pytest
+from typing import Optional
+
+import numpy as np
+
+import gym
+from gym.wrappers import AutoResetWrapper
+
+
+class DummyResetEnv(gym.Env):
+    metadata = {}
+
+    def __init__(self):
+        self.action_space = gym.spaces.Box(low=np.array([-1.0]), high=np.array([1.0]))
+        self.observation_space = gym.spaces.Box(
+            low=np.array([-1.0]), high=np.array([1.0])
+        )
+        self.count = 0
+
+    def step(self, action):
+        self.count += 1
+        return np.array([self.count]), 1 if self.count > 2 else 0, self.count > 2, {}
+
+    def reset(
+        self,
+        *,
+        seed: Optional[int] = None,
+        return_info: Optional[bool] = False,
+        options: Optional[dict] = None
+    ):
+        self.count = 0
+        if not return_info:
+            return np.array([self.count])
+        else:
+            return np.array([self.count]), {}
+
+
+def test_autoreset_reset_info():
+    env = gym.make("CartPole-v1")
+    env = AutoResetWrapper(env)
+    ob_space = env.observation_space
+    obs = env.reset()
+    assert ob_space.contains(obs)
+    del obs
+    obs = env.reset(return_info=False)
+    assert ob_space.contains(obs)
+    del obs
+    obs, info = env.reset(return_info=True)
+    assert ob_space.contains(obs)
+    assert isinstance(info, dict)
+
+
+def test_autoreset_autoreset():
+    env = DummyResetEnv()
+    env = AutoResetWrapper(env)
+    obs, info = env.reset(return_info=True)
+    assert obs == np.array([0])
+    assert info == {}
+    action = 1
+    obs, reward, done, info = env.step(action)
+    assert obs == np.array([1])
+    assert reward == 0
+    assert done == False
+    assert info == {}
+    obs, reward, done, info = env.step(action)
+    assert obs == np.array([2])
+    assert done == False
+    assert reward == 0
+    assert info == {}
+    obs, reward, done, info = env.step(action)
+    assert obs == np.array([3])
+    assert done == True
+    assert reward == 1
+    assert info == {}
+    obs, reward, done, info = env.step(action)
+    assert obs == np.array([0])
+    assert reward is None
+    assert done is None
+    assert info == {}
+    obs, reward, done, info = env.step(action)
+    assert obs == np.array([1])
+    assert reward == 0
+    assert done == False
+    assert info == {}

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -61,24 +61,24 @@ def test_autoreset_autoreset():
     assert obs == np.array([1])
     assert reward == 0
     assert done == False
-    assert info == {}
+    assert info == {"info": {}}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([2])
     assert done == False
     assert reward == 0
-    assert info == {}
-    obs, reward, done, info = env.step(action)
-    assert obs == np.array([3])
-    assert done == True
-    assert reward == 1
-    assert info == {}
+    assert info == {"info": {}}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([0])
-    assert reward is None
-    assert done is None
-    assert info == {}
+    assert done == True
+    assert reward == 1
+    assert info == {"info": {}, "final_obs": np.array([3])}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([1])
+    assert reward is 0
+    assert done is False
+    assert info == {"info": {}}
+    obs, reward, done, info = env.step(action)
+    assert obs == np.array([2])
     assert reward == 0
     assert done == False
-    assert info == {}
+    assert info == {"info": {}}

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -19,7 +19,12 @@ class DummyResetEnv(gym.Env):
 
     def step(self, action):
         self.count += 1
-        return np.array([self.count]), 1 if self.count > 2 else 0, self.count > 2, {}
+        return (
+            np.array([self.count]),
+            1 if self.count > 2 else 0,
+            self.count > 2,
+            {"count": self.count},
+        )
 
     def reset(
         self,
@@ -32,7 +37,7 @@ class DummyResetEnv(gym.Env):
         if not return_info:
             return np.array([self.count])
         else:
-            return np.array([self.count]), {}
+            return np.array([self.count]), {"count": self.count}
 
 
 def test_autoreset_reset_info():
@@ -55,30 +60,34 @@ def test_autoreset_autoreset():
     env = AutoResetWrapper(env)
     obs, info = env.reset(return_info=True)
     assert obs == np.array([0])
-    assert info == {}
+    assert info == {"count": 0}
     action = 1
     obs, reward, done, info = env.step(action)
     assert obs == np.array([1])
     assert reward == 0
     assert done == False
-    assert info == {"info": {}}
+    assert info == {"info": {"count": 1}}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([2])
     assert done == False
     assert reward == 0
-    assert info == {"info": {}}
+    assert info == {"info": {"count": 2}}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([0])
     assert done == True
     assert reward == 1
-    assert info == {"info": {}, "final_obs": np.array([3])}
+    assert info == {
+        "info": {"count": 0},
+        "final_obs": np.array([3]),
+        "final_info": {"count": 3},
+    }
     obs, reward, done, info = env.step(action)
     assert obs == np.array([1])
     assert reward == 0
     assert done == False
-    assert info == {"info": {}}
+    assert info == {"info": {"count": 1}}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([2])
     assert reward == 0
     assert done == False
-    assert info == {"info": {}}
+    assert info == {"info": {"count": 2}}

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -85,8 +85,8 @@ def test_autoreset_autoreset():
     assert reward == 1
     assert info == {
         "count": 0,
-        "final_obs": np.array([3]),
-        "final_info": {"count": 3},
+        "terminal_observation": np.array([3]),
+        "terminal_info": {"count": 3},
     }
     obs, reward, done, info = env.step(action)
     assert obs == np.array([1])


### PR DESCRIPTION
This pull request implements the proposal in issue #2564.  Here is a draft of a wrapper which will automatically reset its environment when an additional call to step is made after an environment has returned done = True. There is a test provided for this wrapper using a dummy environment. 

For the call to step after done=True, self.env.reset() is called, then 

````obs, None, None, info````

is returned by the wrapper.
`
I think this is ready for review.