### PR TITLE
Reduces warnings produced by pytest from ~1500 to 13 

### DIFF
--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -170,6 +170,8 @@ class CarRacing(gym.Env, EzPickle):
             shape=polygonShape(vertices=[(0, 0), (1, 0), (1, -1), (0, -1)])
         )
 
+        # This will throw a warning in tests/envs/test_envs in utils/env_checker.py as the space is not symmetric
+        #   or normalised however this is not possible here so ignore
         self.action_space = spaces.Box(
             np.array([-1, 0, 0]).astype(np.float32),
             np.array([+1, +1, +1]).astype(np.float32),

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -95,6 +95,9 @@ class PendulumEnv(gym.Env):
         self.screen_dim = 500
 
         high = np.array([1.0, 1.0, self.max_speed], dtype=np.float32)
+        # This will throw a warning in tests/envs/test_envs in utils/env_checker.py as the space is not symmetric
+        #   or normalised as max_torque == 2 by default. Ignoring the issue here as the default settings are too old
+        #   to update to follow the openai gym api
         self.action_space = spaces.Box(
             low=-self.max_torque, high=self.max_torque, shape=(1,), dtype=np.float32
         )
@@ -186,7 +189,7 @@ class PendulumEnv(gym.Env):
             scale_img = pygame.transform.smoothscale(
                 img, (scale * np.abs(self.last_u) / 2, scale * np.abs(self.last_u) / 2)
             )
-            is_flip = self.last_u > 0
+            is_flip = bool(self.last_u > 0)
             scale_img = pygame.transform.flip(scale_img, is_flip, True)
             self.surf.blit(
                 scale_img,

--- a/gym/envs/toy_text/cliffwalking.py
+++ b/gym/envs/toy_text/cliffwalking.py
@@ -44,7 +44,7 @@ class CliffWalkingEnv(Env):
         self.nA = 4
 
         # Cliff Location
-        self._cliff = np.zeros(self.shape, dtype=np.bool)
+        self._cliff = np.zeros(self.shape, dtype=bool)
         self._cliff[3, 1:-1] = True
 
         # Calculate transition probabilities and rewards

--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -25,7 +25,7 @@ class Discrete(Space[int]):
         super().__init__((), np.int64, seed)
 
     def sample(self) -> int:
-        return self.start + self.np_random.randint(self.n)
+        return int(self.start + self.np_random.integers(self.n))
 
     def contains(self, x) -> bool:
         if isinstance(x, int):

--- a/gym/wrappers/record_video.py
+++ b/gym/wrappers/record_video.py
@@ -116,3 +116,9 @@ class RecordVideo(gym.Wrapper):
             self.video_recorder.close()
         self.recording = False
         self.recorded_frames = 1
+
+    def close(self):
+        self.close_video_recorder()
+
+    def __del__(self):
+        self.close_video_recorder()

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -10,6 +10,7 @@ from gym.utils.env_checker import check_env
 # This runs a smoketest on each official registered env. We may want
 # to try also running environments which are not officially registered
 # envs.
+@pytest.mark.filterwarnings('ignore:.*We recommend you to use a symmetric and normalized Box action space.*')
 @pytest.mark.parametrize("spec", spec_list)
 def test_env(spec):
     # Capture warnings
@@ -74,7 +75,7 @@ def test_reset_info(spec):
 
 # Run a longer rollout on some environments
 def test_random_rollout():
-    for env in [envs.make("CartPole-v0"), envs.make("FrozenLake-v1")]:
+    for env in [envs.make("CartPole-v1"), envs.make("FrozenLake-v1")]:
         agent = lambda ob: env.action_space.sample()
         ob = env.reset()
         for _ in range(10):

--- a/tests/envs/test_registration.py
+++ b/tests/envs/test_registration.py
@@ -61,8 +61,8 @@ def register_some_envs():
 
 
 def test_make():
-    env = envs.make("CartPole-v0")
-    assert env.spec.id == "CartPole-v0"
+    env = envs.make("CartPole-v1")
+    assert env.spec.id == "CartPole-v1"
     assert isinstance(env.unwrapped, cartpole.CartPoleEnv)
 
 
@@ -164,6 +164,8 @@ def test_make_with_kwargs():
     assert env.arg3 == "override_arg3"
 
 
+@pytest.mark.filterwarnings('ignore:.*The environment Humanoid-v0 is out of date. You should consider upgrading to '
+                            'version `v3` with the environment ID `Humanoid-v3`.*')
 def test_make_deprecated():
     try:
         envs.make("Humanoid-v0")
@@ -174,8 +176,8 @@ def test_make_deprecated():
 
 
 def test_spec():
-    spec = envs.spec("CartPole-v0")
-    assert spec.id == "CartPole-v0"
+    spec = envs.spec("CartPole-v1")
+    assert spec.id == "CartPole-v1"
 
 
 def test_spec_with_kwargs():

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -19,7 +19,7 @@ from gym.spaces import Tuple, Box, Discrete, MultiDiscrete, MultiBinary, Dict
         Tuple(
             [
                 Discrete(5),
-                Box(low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32),
+                Box(low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64),
             ]
         ),
         Tuple((Discrete(5), Discrete(2), Discrete(2))),
@@ -30,7 +30,7 @@ from gym.spaces import Tuple, Box, Discrete, MultiDiscrete, MultiBinary, Dict
             {
                 "position": Discrete(5),
                 "velocity": Box(
-                    low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32
+                    low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64
                 ),
             }
         ),
@@ -61,13 +61,13 @@ def test_roundtripping(space):
     [
         Discrete(3),
         Discrete(5, start=-2),
-        Box(low=np.array([-10, 0]), high=np.array([10, 10]), dtype=np.float32),
+        Box(low=np.array([-10.0, 0.0]), high=np.array([10.0, 10.0]), dtype=np.float64),
         Box(low=-np.inf, high=np.inf, shape=(1, 3)),
         Tuple([Discrete(5), Discrete(10)]),
         Tuple(
             [
                 Discrete(5),
-                Box(low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32),
+                Box(low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64),
             ]
         ),
         Tuple((Discrete(5), Discrete(2), Discrete(2))),
@@ -78,7 +78,7 @@ def test_roundtripping(space):
             {
                 "position": Discrete(5),
                 "velocity": Box(
-                    low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32
+                    low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64
                 ),
             }
         ),
@@ -98,8 +98,8 @@ def test_equality(space):
         (MultiDiscrete([2, 2, 100]), MultiDiscrete([2, 2, 8])),
         (MultiBinary(8), MultiBinary(7)),
         (
-            Box(low=np.array([-10, 0]), high=np.array([10, 10]), dtype=np.float32),
-            Box(low=np.array([-10, 0]), high=np.array([10, 9]), dtype=np.float32),
+            Box(low=np.array([-10.0, 0.0]), high=np.array([10.0, 10.0]), dtype=np.float64),
+            Box(low=np.array([-10.0, 0.0]), high=np.array([10.0, 9.0]), dtype=np.float64),
         ),
         (
             Box(low=-np.inf, high=0.0, shape=(2, 1)),
@@ -156,7 +156,7 @@ def test_sample(space):
     [
         (Discrete(5), MultiBinary(5)),
         (
-            Box(low=np.array([-10, 0]), high=np.array([10, 10]), dtype=np.float32),
+            Box(low=np.array([-10.0, 0.0]), high=np.array([10.0, 10.0]), dtype=np.float64),
             MultiDiscrete([2, 2, 8]),
         ),
         (
@@ -247,7 +247,7 @@ def test_box_dtype_check():
     space = Box(0, 2, tuple(), dtype=np.float32)
 
     # casting will match the correct type
-    assert space.contains(0.5)
+    assert space.contains(np.array(0.5, dtype=np.float32))
 
     # float64 is not in float32 space
     assert not space.contains(np.array(0.5))
@@ -264,7 +264,7 @@ def test_box_dtype_check():
         Tuple(
             [
                 Discrete(5),
-                Box(low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32),
+                Box(low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64),
             ]
         ),
         Tuple((Discrete(5), Discrete(2), Discrete(2))),
@@ -274,7 +274,7 @@ def test_box_dtype_check():
             {
                 "position": Discrete(5),
                 "velocity": Box(
-                    low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32
+                    low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64
                 ),
             }
         ),
@@ -317,7 +317,7 @@ def sample_equal(sample1, sample2):
         Tuple(
             [
                 Discrete(5),
-                Box(low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32),
+                Box(low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64),
             ]
         ),
         Tuple((Discrete(5), Discrete(2), Discrete(2))),
@@ -327,7 +327,7 @@ def sample_equal(sample1, sample2):
             {
                 "position": Discrete(5),
                 "velocity": Box(
-                    low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32
+                    low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64
                 ),
             }
         ),
@@ -353,7 +353,7 @@ def test_seed_reproducibility(space):
         Tuple(
             [
                 Discrete(5),
-                Box(low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32),
+                Box(low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64),
             ]
         ),
         Tuple((Discrete(5), Discrete(2), Discrete(2))),
@@ -361,7 +361,7 @@ def test_seed_reproducibility(space):
             {
                 "position": Discrete(5),
                 "velocity": Box(
-                    low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32
+                    low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64
                 ),
             }
         ),

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -14,7 +14,7 @@ spaces = [
     Tuple(
         [
             Discrete(5),
-            Box(low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32),
+            Box(low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64),
         ]
     ),
     Tuple((Discrete(5), Discrete(2), Discrete(2))),
@@ -24,7 +24,7 @@ spaces = [
         {
             "position": Discrete(5),
             "velocity": Box(
-                low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32
+                low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64
             ),
         }
     ),

--- a/tests/vector/test_spaces.py
+++ b/tests/vector/test_spaces.py
@@ -8,7 +8,7 @@ from gym.vector.utils.spaces import batch_space, iterate
 
 expected_batch_spaces_4 = [
     Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float64),
-    Box(low=0.0, high=10.0, shape=(4, 1), dtype=np.float32),
+    Box(low=0.0, high=10.0, shape=(4, 1), dtype=np.float64),
     Box(
         low=np.array(
             [[-1.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [-1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]]
@@ -16,7 +16,7 @@ expected_batch_spaces_4 = [
         high=np.array(
             [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]]
         ),
-        dtype=np.float32,
+        dtype=np.float64,
     ),
     Box(
         low=np.array(
@@ -28,7 +28,7 @@ expected_batch_spaces_4 = [
             ]
         ),
         high=np.ones((4, 2, 2)),
-        dtype=np.float32,
+        dtype=np.float64,
     ),
     Box(low=0, high=255, shape=(4,), dtype=np.uint8),
     Box(low=0, high=255, shape=(4, 32, 32, 3), dtype=np.uint8),
@@ -40,7 +40,7 @@ expected_batch_spaces_4 = [
             Box(
                 low=np.array([[0.0, -1.0], [0.0, -1.0], [0.0, -1.0], [0.0, -1]]),
                 high=np.array([[1.0, 1.0], [1.0, 1.0], [1.0, 1.0], [1.0, 1.0]]),
-                dtype=np.float32,
+                dtype=np.float64,
             ),
         )
     ),
@@ -53,7 +53,7 @@ expected_batch_spaces_4 = [
     Dict(
         {
             "position": MultiDiscrete([23, 23, 23, 23]),
-            "velocity": Box(low=0.0, high=1.0, shape=(4, 1), dtype=np.float32),
+            "velocity": Box(low=0.0, high=1.0, shape=(4, 1), dtype=np.float64),
         }
     ),
     Dict(

--- a/tests/vector/utils.py
+++ b/tests/vector/utils.py
@@ -8,12 +8,12 @@ from gym.spaces import Box, Discrete, MultiDiscrete, MultiBinary, Tuple, Dict
 
 spaces = [
     Box(low=np.array(-1.0), high=np.array(1.0), dtype=np.float64),
-    Box(low=np.array([0.0]), high=np.array([10.0]), dtype=np.float32),
+    Box(low=np.array([0.0]), high=np.array([10.0]), dtype=np.float64),
     Box(
-        low=np.array([-1.0, 0.0, 0.0]), high=np.array([1.0, 1.0, 1.0]), dtype=np.float32
+        low=np.array([-1.0, 0.0, 0.0]), high=np.array([1.0, 1.0, 1.0]), dtype=np.float64
     ),
     Box(
-        low=np.array([[-1.0, 0.0], [0.0, -1.0]]), high=np.ones((2, 2)), dtype=np.float32
+        low=np.array([[-1.0, 0.0], [0.0, -1.0]]), high=np.ones((2, 2)), dtype=np.float64
     ),
     Box(low=0, high=255, shape=(), dtype=np.uint8),
     Box(low=0, high=255, shape=(32, 32, 3), dtype=np.uint8),
@@ -22,7 +22,7 @@ spaces = [
     Tuple(
         (
             Discrete(7),
-            Box(low=np.array([0.0, -1.0]), high=np.array([1.0, 1.0]), dtype=np.float32),
+            Box(low=np.array([0.0, -1.0]), high=np.array([1.0, 1.0]), dtype=np.float64),
         )
     ),
     MultiDiscrete([11, 13, 17]),
@@ -31,7 +31,7 @@ spaces = [
         {
             "position": Discrete(23),
             "velocity": Box(
-                low=np.array([0.0]), high=np.array([1.0]), dtype=np.float32
+                low=np.array([0.0]), high=np.array([1.0]), dtype=np.float64
             ),
         }
     ),

--- a/tests/wrappers/test_normalize.py
+++ b/tests/wrappers/test_normalize.py
@@ -14,7 +14,7 @@ class DummyRewardEnv(gym.Env):
     def __init__(self, return_reward_idx=0):
         self.action_space = gym.spaces.Discrete(2)
         self.observation_space = gym.spaces.Box(
-            low=np.array([-1.0]), high=np.array([1.0])
+            low=np.array([-1.0]), high=np.array([1.0]), dtype=np.float64
         )
         self.returned_rewards = [0, 1, 2, 3, 4]
         self.return_reward_idx = return_reward_idx

--- a/tests/wrappers/test_record_episode_statistics.py
+++ b/tests/wrappers/test_record_episode_statistics.py
@@ -6,7 +6,7 @@ import gym
 from gym.wrappers import RecordEpisodeStatistics
 
 
-@pytest.mark.parametrize("env_id", ["CartPole-v0", "Pendulum-v1"])
+@pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v1"])
 @pytest.mark.parametrize("deque_size", [2, 5])
 def test_record_episode_statistics(env_id, deque_size):
     env = gym.make(env_id)
@@ -42,7 +42,7 @@ def test_record_episode_statistics_reset_info():
     ("num_envs", "asynchronous"), [(1, False), (1, True), (4, False), (4, True)]
 )
 def test_record_episode_statistics_with_vectorenv(num_envs, asynchronous):
-    envs = gym.vector.make("CartPole-v0", num_envs=num_envs, asynchronous=asynchronous)
+    envs = gym.vector.make("CartPole-v1", num_envs=num_envs, asynchronous=asynchronous)
     envs = RecordEpisodeStatistics(envs)
     max_episode_step = (
         envs.env_fns[0]().spec.max_episode_steps

--- a/tests/wrappers/test_video_recorder.py
+++ b/tests/wrappers/test_video_recorder.py
@@ -2,6 +2,8 @@ import gc
 import os
 import time
 
+import pytest
+
 import gym
 from gym.wrappers.monitoring.video_recorder import VideoRecorder
 
@@ -82,6 +84,7 @@ def test_record_unrecordable_method():
     rec.close()
 
 
+@pytest.mark.filterwarnings('ignore:.*Env returned None on render.*')
 def test_record_breaking_render_method():
     env = BrokenRecordableEnv()
     rec = VideoRecorder(env)


### PR DESCRIPTION
Addresses a majority of warnings noted in issue #2647
These changes reduced the number of warnings pytest (with --forked) from ~1500 to 13

Remaining warnings
* Bipedal walker and lunar lander observation spaces' low and high values are np.inf, env_checker.py raises warnings that these values should be lower. I see no reason why we can't set these values lower however to what number? (8 warnings)
* In testing spaces, test_iterable and test_iterable_custom_space use spaces that return a single value causing spaces.Box to raise a warning when 

Errors
* tests/vector/test_async_vector_env.py::test_custom_space_async_vector_env_shared_memory raises an exception that is uncaught currently. 
* tests/vector/test_async_vector_env.py::test_call_async_vector_env causes a failure of the tests

Both are currently being solved 