### PR TITLE
Add SpaceWrapper, FilteredSpace and Space.where

### DIFF
--- a/gym/spaces/other/filter.py
+++ b/gym/spaces/other/filter.py
@@ -38,27 +38,27 @@ class FilteredSpace(SpaceWrapper[T_cov]):
 
     Other cool examples:
 
-    >>> unit_circle = Box(-1, 1, shape=(2,), dtype=np.float64, seed=123).where(lambda xy: (xy ** 2).sum() <= 1)
-    >>> np.array((0.1, 0.2)) in unit_circle
+    >>> unit_disk = Box(-1, 1, shape=(2,), dtype=np.float64, seed=123).where(lambda xy: (xy ** 2).sum() <= 1)
+    >>> np.array((0.1, 0.2)) in unit_disk
     True
-    >>> np.array((1, 1)) in unit_circle
+    >>> np.array((1, 1)) in unit_disk
     False
-    >>> unit_circle.sample()
+    >>> unit_disk.sample()
     array([ 0.36470373, -0.89235796])
 
-    >>> def hypersphere(radius: float, dimensions: int) -> FilteredSpace[np.ndarray]:
+    >>> def hyperball(radius: float, dimensions: int) -> FilteredSpace[np.ndarray]:
     ...     return Box(-radius, +radius, shape=(dimensions,)).where(
-    ...         lambda v: v.pow(2).sum() <= radius**dimensions
+    ...         lambda v: v.pow(2).sum() <= radius ** 2
     ...     )
     ...
-    >>> unit_sphere = hypersphere(radius=1, dimensions=3)
+    >>> unit_ball = hyperball(radius=1, dimensions=3)
     """
 
     def __init__(
         self,
         space: Space[T_cov],
         predicates: Sequence[Predicate[T_cov]],
-        max_sampling_attempts: int | None = None,
+        max_sampling_attempts: int | None = 1_000,
     ):
         super().__init__(space=space)
         self.space = space

--- a/gym/spaces/other/filter.py
+++ b/gym/spaces/other/filter.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any, Callable, List, Sequence, TypeVar
+
+import numpy as np
+from gym.spaces.box import Box
+from gym.spaces.dict import Dict as DictSpace
+from gym.spaces.discrete import Discrete
+from gym.spaces.multi_binary import MultiBinary
+from gym.spaces.multi_discrete import MultiDiscrete
+from gym.spaces.other.wrapper import SpaceWrapper
+from gym.spaces.space import Space
+from gym.spaces.tuple import Tuple as TupleSpace
+
+T = TypeVar("T")
+T_cot = TypeVar("T_cot", contravariant=True)
+T_cov = TypeVar("T_cov", covariant=True)
+Predicate = Callable[[T_cot], bool]
+
+
+class FilteredSpace(SpaceWrapper[T_cov]):
+    """Adds assumptions (predicates) to a space, limiting the samples that are considered valid.
+    
+    Uses rejection sampling with a maximum of `max_sampling_attempts` attempts.
+
+    >>> from gym.spaces import Discrete, Box, Space
+    >>> import numpy as np
+
+    >>> odd_digits = Discrete(10, seed=123).where(lambda n: n % 2 == 1)
+    >>> 1 in odd_digits
+    True
+    >>> 2 in odd_digits
+    False
+    >>> odd_digits.sample()
+    5
+
+    Other cool examples:
+
+    >>> unit_circle = Box(-1, 1, shape=(2,), dtype=np.float64, seed=123).where(lambda xy: (xy ** 2).sum() <= 1)
+    >>> np.array((0.1, 0.2)) in unit_circle
+    True
+    >>> np.array((1, 1)) in unit_circle
+    False
+    >>> unit_circle.sample()
+    array([ 0.36470373, -0.89235796])
+
+    >>> def hypersphere(radius: float, dimensions: int) -> FilteredSpace[np.ndarray]:
+    ...     return Box(-radius, +radius, shape=(dimensions,)).where(
+    ...         lambda v: v.pow(2).sum() <= radius**dimensions
+    ...     )
+    ...
+    >>> unit_sphere = hypersphere(radius=1, dimensions=3)
+    """
+
+    def __init__(
+        self,
+        space: Space[T_cov],
+        predicates: Sequence[Predicate[T_cov]],
+        max_sampling_attempts: int | None = None,
+    ):
+        super().__init__(space=space)
+        self.space = space
+        self.predicates = list(predicates)
+        self.max_sampling_attempts = max_sampling_attempts
+
+    def contains(self, x) -> bool:
+        """Checks if the wrapped space contains this sample and if it fits all assumptions."""
+        return self.space.contains(x) and all(
+            predicate(x) for predicate in self.predicates
+        )
+
+    def sample(self) -> T_cov:
+        sample = self.space.sample()
+        attempts = 1
+        while sample not in self:
+            sample = self.space.sample()
+            if self.max_sampling_attempts and attempts == self.max_sampling_attempts:
+                raise RuntimeError(
+                    f"Unable to find a valid sample with {self.max_sampling_attempts} attempts."
+                )
+            attempts += 1
+        return sample
+
+    def where(self, *predicates: Predicate[T_cov]) -> FilteredSpace[T_cov]:
+        cls = type(self)
+        return cls(self.space, predicates=self.predicates + list(predicates))
+
+    def __repr__(self):
+        return repr(self.space) + ".where(" + repr(self.predicates) + ")"
+
+
+from gym.vector.utils.numpy_utils import concatenate, create_empty_array
+from gym.vector.utils.shared_memory import (
+    create_shared_memory,
+    mp,
+    read_from_shared_memory,
+    write_to_shared_memory,
+)
+from gym.vector.utils.spaces import batch_space, iterate
+
+
+def _batched_predicate(
+    batched_sample: T, batched_space: Space[T], predicate: Predicate
+) -> bool:
+    """Predicate that applies `predicate` to all the items in `batched_sample`. Returns all(results)
+    """
+    return all(map(predicate, iterate(batched_space, batched_sample)))
+
+
+@batch_space.register(FilteredSpace)
+def _batch_filtered(space: FilteredSpace, n: int) -> Space | FilteredSpace:
+    # NOTE: Depending on the type of the wrapped space, this could do something a bit different
+    # (e.g. batch the predicate function too).
+
+    if isinstance(
+        space.space, (Box, Discrete, MultiDiscrete, MultiBinary, DictSpace, TupleSpace)
+    ):
+        # Create a predicate that will be applied on all the samples in the batch.
+        batched_space = batch_space(space.space, n=n)
+        batched_predicates: List[Predicate] = [
+            functools.partial(
+                _batched_predicate, batched_space=batched_space, predicate=predicate
+            )
+            for predicate in space.predicates
+        ]
+        return type(space)(space=batched_space, predicates=batched_predicates)
+
+    # Just use the default behaviour in the worst case (Tuple of FilteredSpaces).
+    return batch_space.dispatch(Space)(space, n=n)
+    # NOTE: Is there a deepcopy missing from the underlying implementation?
+    # return TupleSpace(tuple(copy.deepcopy(space) for _ in range(n)))
+
+
+@iterate.register
+def _iterate_filtered(space: FilteredSpace, items: Any):
+    return iterate(space.space, items)
+
+
+@concatenate.register
+def _concatenate_filtered(space: FilteredSpace, items: Any, out: Any):
+    return concatenate(space.space, items, out)
+
+
+@create_empty_array.register
+def _create_empty_filtered(
+    space: FilteredSpace, n: int = 1, fn: Callable[..., np.ndarray] = np.zeros
+):
+    return create_empty_array(space.space, n=n, fn=fn)
+
+
+@create_shared_memory.register
+def _create_shared_memory_filtered(space: FilteredSpace, n: int = 1, ctx=mp):
+    return create_shared_memory(space.space, n=n, ctx=ctx)
+
+
+@write_to_shared_memory.register(FilteredSpace)
+def _write_to_shared_memory_filtered(
+    space: FilteredSpace[T], index: int, value: T, shared_memory: Any
+) -> None:
+    write_to_shared_memory(
+        space.space, index=index, value=value, shared_memory=shared_memory
+    )
+
+
+@read_from_shared_memory.register
+def _read_from_shared_memory_filtered(
+    space: FilteredSpace, shared_memory: Any, n: int = 1
+):
+    return read_from_shared_memory(space.space, shared_memory=shared_memory, n=n)

--- a/gym/spaces/other/wrapper.py
+++ b/gym/spaces/other/wrapper.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from gym.spaces.space import Space, T_cov
+from typing import Sequence, Type, Optional
+
+
+class SpaceWrapper(Space[T_cov]):
+    """Base class for wrapper around spaces."""
+
+    def __init__(
+        self,
+        space: Space,
+        shape: Optional[Sequence[int]] = None,
+        dtype: Optional[Type | str] = None,
+        seed: Optional[int] = None,
+    ):
+        super().__init__(
+            shape=shape if shape is not None else space.shape,
+            dtype=dtype or space.dtype,
+            seed=seed,
+        )
+        self.space = space
+
+    def __getattr__(self, attr: str):
+        if attr.startswith("_"):
+            raise AttributeError(f"Attempted to get missing private attribute '{attr}'")
+        return getattr(self.space, attr)
+
+    def seed(self, seed: Optional[int] = None):
+        """Seed the rng of the wrapped space."""
+        return self.space.seed(seed)
+
+    def sample(self) -> T_cov:
+        """Take a sample from the wrapped space."""
+        return self.space.sample()
+
+    def contains(self, x) -> bool:
+        """Checks if the wrapped space contains this sample."""
+        return self.space.contains(x)
+
+    def __str__(self):
+        return f"<{type(self).__name__}{self.space}>"
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    def to_jsonable(self, sample_n):
+        """Convert a batch of samples from this space to a JSONable data type."""
+        return self.space.to_jsonable(sample_n)
+
+    def from_jsonable(self, sample_n):
+        """Convert a JSONable data type to a batch of samples from this space."""
+        return self.space.from_jsonable(sample_n)
+

--- a/gym/spaces/space.py
+++ b/gym/spaces/space.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
-from typing import (
-    TypeVar,
-    Generic,
-    Optional,
-    Sequence,
-    Iterable,
-    Mapping,
-    Type,
-)
+import typing
+from typing import Generic, Iterable, Mapping, Optional, Sequence, Type, TypeVar
 
-import numpy as np
+if typing.TYPE_CHECKING:
+    from gym.spaces.other.filter import FilteredSpace, Predicate
 
 from gym.utils import seeding
-
 
 T_cov = TypeVar("T_cov", covariant=True)
 
@@ -110,3 +103,17 @@ class Space(Generic[T_cov]):
         """Convert a JSONable data type to a batch of samples from this space."""
         # By default, assume identity is JSONable
         return sample_n
+
+    def where(self, *predicates: Predicate[T_cov]) -> FilteredSpace[T_cov]:
+        """Returns a filtered sub-region of `self`, where the elements match the given predicates.
+
+        ```python
+        space: Space[Discrete] = Discretes().where(lambda n: n % 2 == 0)
+
+        assert Discrete(2) in space
+        assert Discrete(3) not in space
+        ```
+        """
+        from gym.spaces.other.filter import FilteredSpace
+
+        return FilteredSpace(self, predicates=list(predicates))

--- a/tests/spaces/other/test_filter.py
+++ b/tests/spaces/other/test_filter.py
@@ -1,0 +1,156 @@
+from typing import Callable
+from gym.spaces.other.filter import FilteredSpace, Predicate
+
+from gym.spaces import (
+    Space,
+    Box,
+    Discrete,
+    MultiBinary,
+    MultiDiscrete,
+    Dict as DictSpace,
+    Tuple as TupleSpace,
+)
+from gym.spaces.space import T_cov
+
+import pytest
+import numpy as np
+
+
+@pytest.mark.parametrize(
+    "base_space, pred",
+    [
+        (Discrete(10), lambda v: v % 2 == 0,),
+        (Box(0, 1, shape=(3,), dtype=np.float32), lambda v: (v > 0.5).all(),),
+        (Box(0, 1, dtype=np.float32), lambda v: (v > 0.5).all(),),
+        (
+            TupleSpace([Discrete(5), Discrete(5, start=10)]),
+            # note: Could be nice to auto-unpack the tuples if pred has >1 args.
+            (lambda ab: ab[0] < 2 and ab[1] > 3),
+        ),
+        (
+            TupleSpace(
+                [
+                    Discrete(5),
+                    Box(low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32),
+                ]
+            ),
+            lambda a_array: a_array[0] > 2 and a_array[1].sum() > 2,
+        ),
+        (
+            TupleSpace((Discrete(5), Discrete(2), Discrete(2))),
+            (lambda a_b_c: sum(a_b_c) == 4),
+        ),
+        (
+            DictSpace(
+                {
+                    "position": Discrete(5),
+                    "velocity": Box(
+                        low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32
+                    ),
+                }
+            ),
+            (lambda d: d["position"] > 2 and d["velocity"].sum() > 1.0),
+        ),
+    ],
+)
+@pytest.mark.parametrize("use_where", [False, True])
+def test_samples_are_in_space(
+    base_space: Space[T_cov], pred: Predicate[T_cov], use_where: bool
+):
+    space = (
+        base_space.where(pred)
+        if use_where
+        else FilteredSpace(base_space, predicates=[pred])
+    )
+    n_samples = 20
+    for _ in range(n_samples):
+        sample = space.sample()
+        assert sample in space
+        assert pred(sample)
+
+
+@pytest.mark.parametrize(
+    "base_space, pred",
+    [
+        (Discrete(10), lambda v: v > 100),
+        (Box(0, 1, shape=(10,), dtype=np.float32), lambda v: v.shape == (123,)),
+        (Box(0, 1, dtype=np.float32), lambda v: (v < 0.0).all()),
+    ],
+)
+@pytest.mark.parametrize("use_where", [False, True])
+def test_sample_with_impossible_predicate_raises_error(
+    base_space: Space[T_cov], pred: Predicate[T_cov], use_where: bool
+):
+    space = (
+        base_space.where(pred)
+        if use_where
+        else FilteredSpace(base_space, predicates=[pred])
+    )
+    space.max_sampling_attempts = 100
+
+    with pytest.raises(RuntimeError):
+        space.sample()
+
+
+@pytest.mark.parametrize(
+    "base_space, pred",
+    [
+        (Discrete(10), lambda v: v % 2 == 0,),
+        (Box(0, 1, shape=(3,), dtype=np.float32), lambda v: (0.1 <= v).all(),),
+        (Box(0, 1, dtype=np.float32), lambda v: (v > 0.5).all(),),
+        (
+            TupleSpace([Discrete(5), Discrete(5, start=10)]),
+            # note: Could be nice to auto-unpack the tuples if pred has >1 args.
+            (lambda ab: ab[0] < 3 and ab[1] > 2),
+        ),
+        (
+            TupleSpace(
+                [
+                    Discrete(5),
+                    Box(low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32),
+                ]
+            ),
+            lambda a_array: a_array[0] > 2 and a_array[1].sum() > 1,
+        ),
+        (
+            TupleSpace((Discrete(5), Discrete(2), Discrete(2))),
+            (lambda a_b_c: sum(a_b_c) == 4),
+        ),
+        (
+            DictSpace(
+                {
+                    "position": Discrete(5),
+                    "velocity": Box(
+                        low=np.array([0, 0]), high=np.array([1, 5]), dtype=np.float32
+                    ),
+                }
+            ),
+            (lambda d: d["position"] > 2 and d["velocity"].sum() > 1.0),
+        ),
+    ],
+)
+@pytest.mark.parametrize("use_where", [False, True])
+@pytest.mark.parametrize("n", [1, 3])
+def test_batch_space_samples_are_in_space(
+    base_space: Space[T_cov], pred: Predicate[T_cov], use_where: bool, n: int
+):
+    filtered_space = (
+        base_space.where(pred)
+        if use_where
+        else FilteredSpace(base_space, predicates=[pred])
+    )
+    from gym.vector.utils.spaces import batch_space
+
+    batched_base_space = batch_space(base_space, n=n)
+    batched_filtered_space = batch_space(filtered_space, n=n)
+    assert isinstance(batched_filtered_space, FilteredSpace)
+    batched_filtered_space.max_sampling_attempts = 1000
+    assert batched_filtered_space.space == batch_space(base_space, n=n)
+
+    n_samples = 10
+    for _ in range(n_samples):
+        sample = batched_filtered_space.sample()
+        assert sample in batched_base_space
+        assert sample in batched_filtered_space
+
+        assert all(predicate(sample) for predicate in batched_filtered_space.predicates)


### PR DESCRIPTION
This PR adds a new feature that makes the gym spaces a lot more expressive: **Filtered** spaces!

There are 3 components in this PR:
- `SpaceWrapper` (in `gym/spaces/other/wrapper.py`):
    - Same idea as `gym.Wrapper`, but for spaces! This can serve as the basis for a bunch of cool adapters for gym spaces in the future! For example, something like a `TensorSpaceWrapper`, that converts the samples to/from Tensors in the `sample` and `contains`, respectively.
- `FilteredSpace`  (in `gym/spaces/other/filter.py`):
    - Adds assumptions (predicates) to a space, limiting the samples that are considered valid.
    - Uses rejection sampling with a maximum of `max_sampling_attempts` attempts.
- `Space.where(predicate)`:
    - Adds filters to the space, returning a `SpaceWrapper`.


```python
>>> from gym.spaces import Discrete, Box, Space
>>> import numpy as np

>>> odd_digits = Discrete(10, seed=123).where(lambda n: n % 2 == 1)
>>> 1 in odd_digits
True
>>> 2 in odd_digits
False
>>> odd_digits.sample()
5
```
Other cool examples:
```python
>>> unit_circle = Box(-1, 1, shape=(2,), dtype=np.float64, seed=123).where(lambda xy: (xy ** 2).sum() <= 1)
>>> np.array((0.1, 0.2)) in unit_circle
True
>>> np.array((1, 1)) in unit_circle
False
>>> unit_circle.sample()
array([ 0.36470373, -0.89235796])

>>> def hypersphere(radius: float, dimensions: int) -> FilteredSpace[np.ndarray]:
...     return Box(-radius, +radius, shape=(dimensions,)).where(
...         lambda v: v.pow(2).sum() <= radius**dimensions
...     )
...
>>> unit_sphere = hypersphere(radius=1, dimensions=3)
```