### PR TITLE
Added event.pump to render

### DIFF
--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -533,6 +533,7 @@ class LunarLander(gym.Env, EzPickle):
         self.screen.blit(self.surf, (0, 0))
 
         if mode == "human":
+            pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])
             pygame.display.flip()
 


### PR DESCRIPTION
Added `pygame.event.pump()` to `render()` in lunar_lander.py - to allow pygame to handle internal actions

This action solves window freeze on Windows:
- when trying to move window 
- when window is clicked 