### PR TITLE
Add py.typed to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
             "envs/classic_control/assets/*.png",
             "envs/toy_text/font/*.ttf",
             "envs/toy_text/img/*.png",
+            "py.typed",
         ]
     },
     tests_require=["pytest", "mock"],


### PR DESCRIPTION
As is described in https://peps.python.org/pep-0561/#packaging-type-information

I think this will close #2682 but haven't released anything using this feature before myself