### PR TITLE
Actually display deprecation warnings

### DIFF
--- a/gym/logger.py
+++ b/gym/logger.py
@@ -13,6 +13,9 @@ DISABLED = 50
 min_level = 30
 
 
+warnings.simplefilter("once", DeprecationWarning)
+
+
 def set_level(level: int) -> None:
     """
     Set logging threshold on current logger.


### PR DESCRIPTION
Hey folks, it turns out our deprecation warnings are not shown to the users most of the time. See https://github.com/openai/gym/issues/2674. You can try this out with the following command, which clearly shows the `env.seed()` warning is not being displayed at all. Pretty wild stuff, right? XD It turns out the deprecations are only shown in you run `python -Wall`, which 99% of the users would not do.

```python
(gym-vSAllIMi-py3.9) ➜  gym git:(deprecationwarning) ✗ python
Python 3.9.5 (default, Jul 19 2021, 13:27:26) 
[GCC 10.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import gym
>>> e = gym.make("CartPole-v1")
>>> e.seed(1)
[1]
>>> exit()
```

This PR actually displays the deprecation warnings (only once so the users are not spammed):

```python
(gym-vSAllIMi-py3.9) ➜  gym git:(deprecationwarning) ✗ python
Python 3.9.5 (default, Jul 19 2021, 13:27:26) 
[GCC 10.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import gym
>>> e = gym.make("CartPole-v1")
>>> e.seed(1)
/home/costa/Documents/go/src/github.com/vwxyzjn/gym/gym/core.py:172: DeprecationWarning: WARN: Function `env.seed(seed)` is marked as deprecated and will be removed in the future. Please use `env.reset(seed=seed) instead.
  deprecation(
[1]
>>> e.seed(1)
[1]
>>> e.seed(1)
[1]
```
