### PR TITLE
Fix misleading warning message.

### DIFF
--- a/gym/wrappers/atari_preprocessing.py
+++ b/gym/wrappers/atari_preprocessing.py
@@ -54,7 +54,7 @@ class AtariPreprocessing(gym.Wrapper):
         super().__init__(env)
         assert (
             cv2 is not None
-        ), "opencv-python package not installed! Try running pip install gym[atari] to get dependencies  for atari"
+        ), "opencv-python package not installed! Try running pip install gym[other] to get dependencies  for atari"
         assert frame_skip > 0
         assert screen_size > 0
         assert noop_max >= 0


### PR DESCRIPTION
`pip install gym[atari]` will not install opencv. Correct way to install opencv is `pip install gym[other]` .