### PR TITLE
Fixed warnings produced by test_record_video.py and test_video_recorder.py

### DIFF
--- a/gym/wrappers/monitoring/video_recorder.py
+++ b/gym/wrappers/monitoring/video_recorder.py
@@ -109,7 +109,7 @@ class VideoRecorder:
             "video.frames_per_second", self.frames_per_sec
         )
         self.backward_compatible_output_frames_per_sec = env.metadata.get(
-            "video.output_frames_per_second", self.frames_per_sec
+            "video.output_frames_per_second", self.output_frames_per_sec
         )
         if self.frames_per_sec != self.backward_compatible_frames_per_sec:
             logger.deprecation(

--- a/gym/wrappers/monitoring/video_recorder.py
+++ b/gym/wrappers/monitoring/video_recorder.py
@@ -106,7 +106,7 @@ class VideoRecorder:
 
         # backward-compatibility mode:
         self.backward_compatible_frames_per_sec = env.metadata.get(
-            "video.frames_per_second", 30
+            "video.frames_per_second", self.frames_per_sec
         )
         self.backward_compatible_output_frames_per_sec = env.metadata.get(
             "video.output_frames_per_second", self.frames_per_sec


### PR DESCRIPTION
With https://github.com/openai/gym/pull/2654, test_record_video.py and test_video_recorder.py were throwing new warnings
This was caused by the new render_fps value being different from the default backward compatible value. 

Updated the default backward compatible values to be the up to date parameters