### PR TITLE
Hide PyGame window when rendering with mode="rgb_array"

### DIFF
--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -536,7 +536,7 @@ class BipedalWalker(gym.Env, EzPickle):
         return np.array(state, dtype=np.float32), reward, done, {}
 
     def render(self, mode="human"):
-        if self.screen is None:
+        if self.screen is None and mode == "human":
             pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((VIEWPORT_W, VIEWPORT_H))
@@ -653,15 +653,17 @@ class BipedalWalker(gym.Env, EzPickle):
         )
 
         self.surf = pygame.transform.flip(self.surf, False, True)
-        self.screen.blit(self.surf, (-self.scroll * SCALE, 0))
         if mode == "human":
+            self.screen.blit(self.surf, (-self.scroll * SCALE, 0))
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])
             pygame.display.flip()
 
         if mode == "rgb_array":
+            final_surf = pygame.Surface((VIEWPORT_W, VIEWPORT_H))
+            final_surf.blit(self.surf, (-self.scroll * SCALE, 0))
             return np.transpose(
-                np.array(pygame.surfarray.pixels3d(self.screen)), axes=(1, 0, 2)
+                np.array(pygame.surfarray.pixels3d(final_surf)), axes=(1, 0, 2)
             )
         else:
             return self.isopen

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -147,6 +147,7 @@ class LunarLander(gym.Env, EzPickle):
     def __init__(self, continuous: bool = False):
         EzPickle.__init__(self)
         self.screen = None
+        self.last_render_mode = None
         self.clock = None
         self.isopen = True
         self.world = Box2D.b2World()
@@ -445,10 +446,14 @@ class LunarLander(gym.Env, EzPickle):
         return np.array(state, dtype=np.float32), reward, done, {}
 
     def render(self, mode="human"):
-        if self.screen is None:
+        if self.screen is None or self.last_render_mode != mode:
             pygame.init()
             pygame.display.init()
-            self.screen = pygame.display.set_mode((VIEWPORT_W, VIEWPORT_H))
+            self.screen = pygame.display.set_mode(
+                (VIEWPORT_W, VIEWPORT_H),
+                flags=pygame.HIDDEN if mode == "rgb_array" else pygame.SHOWN,
+            )
+            self.last_render_mode = mode
         if self.clock is None:
             self.clock = pygame.time.Clock()
 

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -147,7 +147,6 @@ class LunarLander(gym.Env, EzPickle):
     def __init__(self, continuous: bool = False):
         EzPickle.__init__(self)
         self.screen = None
-        self.last_render_mode = None
         self.clock = None
         self.isopen = True
         self.world = Box2D.b2World()
@@ -446,18 +445,14 @@ class LunarLander(gym.Env, EzPickle):
         return np.array(state, dtype=np.float32), reward, done, {}
 
     def render(self, mode="human"):
-        if self.screen is None or self.last_render_mode != mode:
+        if self.screen is None and mode == "human":
             pygame.init()
             pygame.display.init()
-            self.screen = pygame.display.set_mode(
-                (VIEWPORT_W, VIEWPORT_H),
-                flags=pygame.HIDDEN if mode == "rgb_array" else pygame.SHOWN,
-            )
-            self.last_render_mode = mode
+            self.screen = pygame.display.set_mode((VIEWPORT_W, VIEWPORT_H))
         if self.clock is None:
             self.clock = pygame.time.Clock()
 
-        self.surf = pygame.Surface(self.screen.get_size())
+        self.surf = pygame.Surface((VIEWPORT_W, VIEWPORT_H))
 
         pygame.transform.scale(self.surf, (SCALE, SCALE))
         pygame.draw.rect(self.surf, (255, 255, 255), self.surf.get_rect())
@@ -536,9 +531,9 @@ class LunarLander(gym.Env, EzPickle):
                     )
 
         self.surf = pygame.transform.flip(self.surf, False, True)
-        self.screen.blit(self.surf, (0, 0))
 
         if mode == "human":
+            self.screen.blit(self.surf, (0, 0))
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])
             pygame.display.flip()

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -326,6 +326,7 @@ class AcrobotEnv(core.Env):
 
         self.surf = pygame.transform.flip(self.surf, False, True)
         if mode == "human":
+            assert self.screen is not None
             self.screen.blit(self.surf, (0, 0))
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -267,7 +267,7 @@ class AcrobotEnv(core.Env):
         return (dtheta1, dtheta2, ddtheta1, ddtheta2, 0.0)
 
     def render(self, mode="human"):
-        if self.screen is None:
+        if self.screen is None and mode == "human":
             pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((self.SCREEN_DIM, self.SCREEN_DIM))
@@ -325,15 +325,15 @@ class AcrobotEnv(core.Env):
             )
 
         self.surf = pygame.transform.flip(self.surf, False, True)
-        self.screen.blit(self.surf, (0, 0))
         if mode == "human":
+            self.screen.blit(self.surf, (0, 0))
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])
             pygame.display.flip()
 
         if mode == "rgb_array":
             return np.transpose(
-                np.array(pygame.surfarray.pixels3d(self.screen)), axes=(1, 0, 2)
+                np.array(pygame.surfarray.pixels3d(self.surf)), axes=(1, 0, 2)
             )
         else:
             return self.isopen

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -255,6 +255,7 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
 
         self.surf = pygame.transform.flip(self.surf, False, True)
         if mode == "human":
+            assert self.screen is not None
             self.screen.blit(self.surf, (0, 0))
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -202,7 +202,7 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
 
         x = self.state
 
-        if self.screen is None:
+        if self.screen is None and mode == "human":
             pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((screen_width, screen_height))
@@ -254,15 +254,15 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         gfxdraw.hline(self.surf, 0, screen_width, carty, (0, 0, 0))
 
         self.surf = pygame.transform.flip(self.surf, False, True)
-        self.screen.blit(self.surf, (0, 0))
         if mode == "human":
+            self.screen.blit(self.surf, (0, 0))
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])
             pygame.display.flip()
 
         if mode == "rgb_array":
             return np.transpose(
-                np.array(pygame.surfarray.pixels3d(self.screen)), axes=(1, 0, 2)
+                np.array(pygame.surfarray.pixels3d(self.surf)), axes=(1, 0, 2)
             )
         else:
             return self.isopen

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -248,6 +248,7 @@ class Continuous_MountainCarEnv(gym.Env):
 
         self.surf = pygame.transform.flip(self.surf, False, True)
         if mode == "human":
+            assert self.screen is not None
             self.screen.blit(self.surf, (0, 0))
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -182,7 +182,7 @@ class Continuous_MountainCarEnv(gym.Env):
         scale = screen_width / world_width
         carwidth = 40
         carheight = 20
-        if self.screen is None:
+        if self.screen is None and mode == "human":
             pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((screen_width, screen_height))
@@ -247,15 +247,15 @@ class Continuous_MountainCarEnv(gym.Env):
         )
 
         self.surf = pygame.transform.flip(self.surf, False, True)
-        self.screen.blit(self.surf, (0, 0))
         if mode == "human":
+            self.screen.blit(self.surf, (0, 0))
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])
             pygame.display.flip()
 
         if mode == "rgb_array":
             return np.transpose(
-                np.array(pygame.surfarray.pixels3d(self.screen)), axes=(1, 0, 2)
+                np.array(pygame.surfarray.pixels3d(self.surf)), axes=(1, 0, 2)
             )
         else:
             return self.isopen

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -224,6 +224,7 @@ class MountainCarEnv(gym.Env):
 
         self.surf = pygame.transform.flip(self.surf, False, True)
         if mode == "human":
+            assert self.screen is not None
             self.screen.blit(self.surf, (0, 0))
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -158,7 +158,7 @@ class MountainCarEnv(gym.Env):
         scale = screen_width / world_width
         carwidth = 40
         carheight = 20
-        if self.screen is None:
+        if self.screen is None and mode == "human":
             pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((screen_width, screen_height))
@@ -223,15 +223,15 @@ class MountainCarEnv(gym.Env):
         )
 
         self.surf = pygame.transform.flip(self.surf, False, True)
-        self.screen.blit(self.surf, (0, 0))
         if mode == "human":
+            self.screen.blit(self.surf, (0, 0))
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])
             pygame.display.flip()
 
         if mode == "rgb_array":
             return np.transpose(
-                np.array(pygame.surfarray.pixels3d(self.screen)), axes=(1, 0, 2)
+                np.array(pygame.surfarray.pixels3d(self.surf)), axes=(1, 0, 2)
             )
         else:
             return self.isopen

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -143,7 +143,7 @@ class PendulumEnv(gym.Env):
         return np.array([np.cos(theta), np.sin(theta), thetadot], dtype=np.float32)
 
     def render(self, mode="human"):
-        if self.screen is None:
+        if self.screen is None and mode == "human":
             pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((self.screen_dim, self.screen_dim))
@@ -205,15 +205,15 @@ class PendulumEnv(gym.Env):
         gfxdraw.filled_circle(self.surf, offset, offset, int(0.05 * scale), (0, 0, 0))
 
         self.surf = pygame.transform.flip(self.surf, False, True)
-        self.screen.blit(self.surf, (0, 0))
         if mode == "human":
+            self.screen.blit(self.surf, (0, 0))
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])
             pygame.display.flip()
 
         if mode == "rgb_array":
             return np.transpose(
-                np.array(pygame.surfarray.pixels3d(self.screen)), axes=(1, 0, 2)
+                np.array(pygame.surfarray.pixels3d(self.surf)), axes=(1, 0, 2)
             )
         else:
             return self.isopen

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -206,6 +206,7 @@ class PendulumEnv(gym.Env):
 
         self.surf = pygame.transform.flip(self.surf, False, True)
         if mode == "human":
+            assert self.screen is not None
             self.screen.blit(self.surf, (0, 0))
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])


### PR DESCRIPTION
PyGame will currently open a blank window if we are using mode="rgb_array". ~I propose a fix where we keep track of the last mode that was used in the call to `render` and initialize a new display if the mode changes. We can use `flags=pygame.HIDDEN` to hide the display if `mode=="rgb_array"`.~

I have implemented this for LunarLander. I'm not really familiar with PyGame so someone should confirm that this approach actually makes sense. Then I will implement it for the other environments. 