### PR TITLE
call close method of parent when overriding it in RecordVideo

### DIFF
--- a/gym/wrappers/record_video.py
+++ b/gym/wrappers/record_video.py
@@ -118,6 +118,7 @@ class RecordVideo(gym.Wrapper):
         self.recorded_frames = 1
 
     def close(self):
+        super().close()
         self.close_video_recorder()
 
     def __del__(self):


### PR DESCRIPTION
`gym.Wrapper`'s `close` method calls the environment that it wraps.  However `RecordVideo`, which subclass `Wrapper`, overrode `close` method but didn't call parent `close` method, this can cause resource leak in a environment that relies on `close` method to clean up.

Previously (before https://github.com/openai/gym/commit/850247f888cc4642561488b7c17f8b29873b31bd), `close` method wasn't overridden in `RecordVideo`, so the environment can close properly. This PR add a function call to `close` method of parent class (Wrapper).