### PR TITLE
make error message on accessing private attributes more representative

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -225,7 +225,7 @@ class Wrapper(Env[ObsType, ActType]):
 
     def __getattr__(self, name):
         if name.startswith("_"):
-            raise AttributeError(f"attempted to get missing private attribute '{name}'")
+            raise AttributeError(f"accessing private attribute '{name}' is prohibited")
         return getattr(self.env, name)
 
     @property


### PR DESCRIPTION
This error message was kinda misleading.
The code is checking if a private attributes is accessed and then raises an error.