### PR TITLE
AutoResetWrapper integration with gym.make()

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -90,7 +90,7 @@ class EnvSpec:
         nondeterministic: Whether this environment is non-deterministic even after seeding
         max_episode_steps: The maximum number of steps that an episode can consist of
         order_enforce: Whether to wrap the environment in an orderEnforcing wrapper
-        auto_reset: Whether the environment should automatically reset when it reaches the done state
+        autoreset: Whether the environment should automatically reset when it reaches the done state
         kwargs: The kwargs to pass to the environment class
 
     """
@@ -101,7 +101,7 @@ class EnvSpec:
     nondeterministic: bool = field(default=False)
     max_episode_steps: Optional[int] = field(default=None)
     order_enforce: bool = field(default=True)
-    auto_reset: bool = field(default=False)
+    autoreset: bool = field(default=False)
     kwargs: dict = field(default_factory=dict)
     namespace: Optional[str] = field(init=False)
     name: str = field(init=False)
@@ -134,9 +134,9 @@ class EnvSpec:
         _kwargs = self.kwargs.copy()
         _kwargs.update(kwargs)
 
-        if "auto_reset" in _kwargs:
-            self.auto_reset = _kwargs["auto_reset"]
-            del [_kwargs["auto_reset"]]
+        if "autoreset" in _kwargs:
+            self.autoreset = _kwargs["autoreset"]
+            del [_kwargs["autoreset"]]
 
         if callable(self.entry_point):
             env = self.entry_point(**_kwargs)
@@ -160,7 +160,7 @@ class EnvSpec:
 
             env = TimeLimit(env, max_episode_steps=env.spec.max_episode_steps)
 
-        if self.auto_reset == True:
+        if self.autoreset == True:
             from gym.wrappers.autoreset import AutoResetWrapper
 
             env = AutoResetWrapper(env)

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -1,4 +1,6 @@
 from typing import Optional
+import types
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -60,6 +62,46 @@ def test_autoreset_reset_info():
     obs, info = env.reset(return_info=True)
     assert ob_space.contains(obs)
     assert isinstance(info, dict)
+
+
+def test_make_autoreset():
+
+    env = gym.make("CartPole-v1", auto_reset=True)
+    ob_space = env.observation_space
+    obs = env.reset(seed=0)
+    env.action_space.seed(0)
+
+    env.env.reset = MagicMock(side_effect=env.env.reset)
+
+    done = False
+    while not done:
+        obs, reward, done, info = env.step(env.action_space.sample())
+    
+    assert env.env.reset.called
+
+    env = gym.make("CartPole-v1", auto_reset=False)
+    ob_space = env.observation_space
+    obs = env.reset(seed=0)
+    env.action_space.seed(0)
+
+    env.env.reset = MagicMock(side_effect=env.env.reset)
+
+    done = False
+    while not done:
+        obs, reward, done, info = env.step(env.action_space.sample())
+    assert not env.env.reset.called
+
+    env = gym.make("CartPole-v1")
+    ob_space = env.observation_space
+    obs = env.reset(seed=0)
+    env.action_space.seed(0)
+
+    env.env.reset = MagicMock(side_effect=env.env.reset)
+
+    done = False
+    while not done:
+        obs, reward, done, info = env.step(env.action_space.sample())
+    assert not env.env.reset.called
 
 
 def test_autoreset_autoreset():

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -66,7 +66,7 @@ def test_autoreset_reset_info():
 
 def test_make_autoreset():
 
-    env = gym.make("CartPole-v1", auto_reset=True)
+    env = gym.make("CartPole-v1", autoreset=True)
     ob_space = env.observation_space
     obs = env.reset(seed=0)
     env.action_space.seed(0)
@@ -79,7 +79,7 @@ def test_make_autoreset():
     
     assert env.env.reset.called
 
-    env = gym.make("CartPole-v1", auto_reset=False)
+    env = gym.make("CartPole-v1", autoreset=False)
     ob_space = env.observation_space
     obs = env.reset(seed=0)
     env.action_space.seed(0)


### PR DESCRIPTION
# Description

This is a pull request to integrate the autoreset wrapper into gym.make() with it being disabled by default. The keyword argument is autoreset. If autoreset is set to False or a value is not provided for auto_reset in gym.make, then the env will not be wrapped with the autoreset wrapper. 

Some things to note that might be relevant for the code review are current the only test is for cartpole is because it is guaranteed to terminate in a relative short number of time-steps. I'm open to suggestions for how to improve test coverage.

Fixes https://github.com/openai/gym/issues/2564

## Type of change

Please delete options that are not relevant.

- [ ] This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

