### PR TITLE
Change reward_threshold from int to float

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -96,7 +96,7 @@ class EnvSpec:
 
     id_requested: InitVar[str]
     entry_point: Optional[Union[Callable, str]] = field(default=None)
-    reward_threshold: Optional[int] = field(default=None)
+    reward_threshold: Optional[float] = field(default=None)
     nondeterministic: bool = field(default=False)
     max_episode_steps: Optional[int] = field(default=None)
     order_enforce: bool = field(default=True)


### PR DESCRIPTION
# Description

@RedTachyon: We are unsure why `reward_threshold` is supposed to be an integer. Is there any good reason to require this? If so, this PR can be closed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

