### PR TITLE
Adds ids to parametrize of environments

### DIFF
--- a/tests/envs/test_determinism.py
+++ b/tests/envs/test_determinism.py
@@ -4,7 +4,7 @@ import pytest
 from tests.envs.spec_list import spec_list
 
 
-@pytest.mark.parametrize("spec", spec_list)
+@pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_env(spec):
     # Note that this precludes running this test in multiple
     # threads. However, we probably already can't do multithreading

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -13,7 +13,7 @@ from tests.envs.spec_list import spec_list
 @pytest.mark.filterwarnings(
     "ignore:.*We recommend you to use a symmetric and normalized Box action space.*"
 )
-@pytest.mark.parametrize("spec", spec_list)
+@pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_env(spec):
     # Capture warnings
     with pytest.warns(None) as warnings:
@@ -58,7 +58,7 @@ def test_env(spec):
     env.close()
 
 
-@pytest.mark.parametrize("spec", spec_list)
+@pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_reset_info(spec):
 
     with pytest.warns(None) as warnings:

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -65,7 +65,7 @@ def test_autoreset_reset_info():
     assert isinstance(info, dict)
 
 
-@pytest.mark.parametrize("spec", spec_list)
+@pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_make_autoreset_true(spec):
     """
     Note: This test assumes that the outermost wrapper is AutoResetWrapper
@@ -92,7 +92,7 @@ def test_make_autoreset_true(spec):
     assert env.unwrapped.reset.called
 
 
-@pytest.mark.parametrize("spec", spec_list)
+@pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_make_autoreset_false(spec):
     env = None
     with pytest.warns(None) as warnings:
@@ -100,7 +100,7 @@ def test_make_autoreset_false(spec):
     assert not isinstance(env, AutoResetWrapper)
 
 
-@pytest.mark.parametrize("spec", spec_list)
+@pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_make_autoreset_default_false(spec):
     env = None
     with pytest.warns(None) as warnings:


### PR DESCRIPTION
When testing environments currently, each of the parametrized tests says "spec0", "spec1", ...
This PR adds ids to all of the cases where the spec_list is used in the tests making it easier to debug when one of the environments crashes
I use .id rather than .name as this includes the version name of the environment used