### PR TITLE
Added kwarg Documentation for BlackJack and LunarLander

### DIFF
--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -125,6 +125,16 @@ class LunarLander(gym.Env, EzPickle):
     import gym
     env = gym.make("LunarLander-v2", continuous=True)
     ```
+    If `continuous=True` is passed, continuous actions (corresponding to the throttle of the engines) will be used and the
+    action space will be `Box(-1, +1, (2,), dtype=np.float32)`.
+    The first coordinate of an action determines the throttle of the main engine, while the second
+    coordinate specifies the throttle of the lateral boosters.
+    Given an action `np.array([main, lateral])`, the main engine will be turned off completely if
+    `main < 0` and the throttle scales affinely from 50% to 100% for `0 <= main <= 1` (in particular, the
+    main engine doesn't work  with less than 50% power).
+    Similarly, if `-0.5 < lateral < 0.5`, the lateral boosters will not fire at all. If `lateral < -0.5`, the left
+    booster will fire, and if `lateral > 0.5`, the right booster will fire. Again, the throttle scales affinely
+    from 50% to 100% between -1 and -0.5 (and 0.5 and 1, respectively).
 
     ### Version History
     - v2: Count energy spent

--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -94,11 +94,17 @@ class BlackjackEnv(gym.Env):
     ### Arguments
 
     ```
-    gym.make('Blackjack-v1', natural=False)
+    gym.make('Blackjack-v1', natural=False, sab=False)
     ```
 
-    <a id="nat">`natural`</a>: Whether to give an additional reward for
+    <a id="nat">`natural=False`</a>: Whether to give an additional reward for
     starting with a natural blackjack, i.e. starting with an ace and ten (sum is 21).
+
+    <a id="sab">`sab=False`</a>: Whether to follow the exact rules outlined in the book by
+    Sutton and Barto. If `sab` is `True`, the keyword argument `natural` will be ignored.
+    If the player achieves a natural blackjack and the dealer does not, the player
+    will win (i.e. get a reward of +1). The reverse rule does not apply.
+    If both the player and the dealer get a natural, it will be a draw (i.e. reward 0).
 
     ### Version History
     * v0: Initial versions release (1.0.0)


### PR DESCRIPTION
I added documentation for the `continuous` kwarg of LunarLander and the `sab` argument of BlackJack. We might want to consider removing the HTML in the BlackJack docstring, but I left it in for now. The other ToyText environments either don't have any kwargs for `__init__`, or they are sufficiently documented.

I feel like hardcore vs normal mode for bipedal walker is already included in the documentation (at the beginning).

- [x] This change requires a documentation update