### PR TITLE
Add test gym utils play. Fix #2729

### DIFF
--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -1,12 +1,13 @@
 import argparse
 
-import matplotlib
 import pygame
 
 import gym
 from gym import logger
 
 try:
+    import matplotlib
+
     matplotlib.use("TkAgg")
     import matplotlib.pyplot as plt
 except ImportError as e:
@@ -133,22 +134,19 @@ def play(env, transpose=True, fps=30, zoom=None, callback=None, keys_to_action=N
     env.reset()
     game = PlayableGame(env, keys_to_action)
 
-    relevant_keys = game.get_relevant_keys(keys_to_action)
     video_size = game.get_video_size(zoom)
 
-    pressed_keys = []
-    running = True
     env_done = True
 
     screen = pygame.display.set_mode(video_size)
     clock = pygame.time.Clock()
 
-    while running:
+    while game.running:
         if env_done:
             env_done = False
             obs = env.reset()
         else:
-            action = keys_to_action.get(tuple(sorted(pressed_keys)), 0)
+            action = keys_to_action.get(tuple(sorted(game.pressed_keys)), 0)
             prev_obs = obs
             obs, rew, env_done, info = env.step(action)
             if callback is not None:
@@ -159,19 +157,9 @@ def play(env, transpose=True, fps=30, zoom=None, callback=None, keys_to_action=N
 
         # process pygame events
         for event in pygame.event.get():
-            # game.process_event(event)
+            game.process_event(event)
             # test events, set key states
-            if event.type == pygame.KEYDOWN:
-                if event.key in relevant_keys:
-                    pressed_keys.append(event.key)
-                elif event.key == 27:
-                    running = False
-            elif event.type == pygame.KEYUP:
-                if event.key in relevant_keys:
-                    pressed_keys.remove(event.key)
-            elif event.type == pygame.QUIT:
-                running = False
-            elif event.type == VIDEORESIZE:
+            if event.type == VIDEORESIZE:
                 video_size = event.size
                 screen = pygame.display.set_mode(video_size)
                 print(video_size)

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -1,9 +1,11 @@
 import argparse
+from typing import Tuple
 
 import pygame
+from pygame.event import Event
 
 import gym
-from gym import logger
+from gym import Env, logger
 
 try:
     import matplotlib
@@ -20,7 +22,7 @@ from pygame.locals import VIDEORESIZE
 
 
 class PlayableGame:
-    def __init__(self, env, keys_to_action=None, zoom=None):
+    def __init__(self, env: Env, keys_to_action: dict = None, zoom: float = None):
         self.env = env
         self.relevant_keys = self._get_relevant_keys(keys_to_action)
         self.video_size = self._get_video_size(zoom)
@@ -28,7 +30,7 @@ class PlayableGame:
         self.pressed_keys = []
         self.running = True
 
-    def _get_relevant_keys(self, keys_to_action):
+    def _get_relevant_keys(self, keys_to_action: dict) -> set:
         if keys_to_action is None:
             if hasattr(self.env, "get_keys_to_action"):
                 keys_to_action = self.env.get_keys_to_action()
@@ -43,7 +45,7 @@ class PlayableGame:
         relevant_keys = set(sum(map(list, keys_to_action.keys()), []))
         return relevant_keys
 
-    def _get_video_size(self, zoom=None):
+    def _get_video_size(self, zoom: float = None) -> Tuple[int, int]:
         rendered = self.env.render(mode="rgb_array")
         video_size = [rendered.shape[1], rendered.shape[0]]
 
@@ -52,7 +54,7 @@ class PlayableGame:
 
         return video_size
 
-    def process_event(self, event):
+    def process_event(self, event: Event) -> None:
         if event.type == pygame.KEYDOWN:
             if event.key in self.relevant_keys:
                 self.pressed_keys.append(event.key)

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -59,7 +59,7 @@ class PlayableGame:
         return relevant_keys
 
     def _get_video_size(self, zoom: Optional[float] = None) -> Tuple[int, int]:
-        # TODO: this needs to be updated when the render API API change goes through
+        # TODO: this needs to be updated when the render API change goes through
         rendered = self.env.render(mode="rgb_array")
         video_size = [rendered.shape[1], rendered.shape[0]]
 
@@ -175,7 +175,7 @@ def play(
             if callback is not None:
                 callback(prev_obs, obs, action, rew, done, info)
         if obs is not None:
-            # TODO: this needs to be updated when the render API API change goes through
+            # TODO: this needs to be updated when the render API change goes through
             rendered = env.render(mode="rgb_array")
             display_arr(
                 game.screen, rendered, transpose=transpose, video_size=game.video_size

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -1,4 +1,3 @@
-import argparse
 from typing import Callable, Dict, Optional, Tuple
 
 import pygame

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -199,20 +199,3 @@ class PlayPlot:
             )
             self.ax[i].set_xlim(xmin, xmax)
         plt.pause(0.000001)
-
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--env",
-        type=str,
-        default="MontezumaRevengeNoFrameskip-v4",
-        help="Define Environment",
-    )
-    args = parser.parse_args()
-    env = gym.make(args.env)
-    play(env, zoom=4, fps=60)
-
-
-if __name__ == "__main__":
-    main()

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -56,7 +56,7 @@ class PlayableGame:
                     "%s does not have explicit key to action mapping, "
                     "please specify one manually" % self.env.spec.id
                 )
-        relevant_keys = set(sum(map(list, keys_to_action.keys()), []))
+        relevant_keys = set(sum((list(k) for k in keys_to_action.keys()), []))
         return relevant_keys
 
     def _get_video_size(self, zoom: float = None) -> Tuple[int, int]:

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -72,7 +72,7 @@ class PlayableGame:
         if event.type == pygame.KEYDOWN:
             if event.key in self.relevant_keys:
                 self.pressed_keys.append(event.key)
-            elif event.key == 27:
+            elif event.key == pygame.K_ESCAPE:
                 self.running = False
         elif event.type == pygame.KEYUP:
             if event.key in self.relevant_keys:

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -157,6 +157,8 @@ def play(
                 # ...
             }
         If None, default key_to_action mapping for that env is used, if provided.
+    seed: bool or None
+        Random seed used when resetting the environment. If None, no seed is used.
     """
     env.reset(seed=seed)
     game = PlayableGame(env, keys_to_action, zoom)

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -101,6 +101,7 @@ def play(
     zoom: Optional[float] = None,
     callback: Optional[Callable] = None,
     keys_to_action: Optional[Dict[Tuple[int], int]] = None,
+    seed: Optional[int] = None,
 ):
     """Allows one to play the game using keyboard.
 
@@ -157,7 +158,7 @@ def play(
             }
         If None, default key_to_action mapping for that env is used, if provided.
     """
-    env.reset()
+    env.reset(seed=seed)
     game = PlayableGame(env, keys_to_action, zoom)
 
     done = True
@@ -166,7 +167,7 @@ def play(
     while game.running:
         if done:
             done = False
-            obs = env.reset()
+            obs = env.reset(seed=seed)
         else:
             action = keys_to_action.get(tuple(sorted(game.pressed_keys)), 0)
             prev_obs = obs

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -60,6 +60,7 @@ class PlayableGame:
         return relevant_keys
 
     def _get_video_size(self, zoom: float = None) -> Tuple[int, int]:
+        # TODO: this needs to be updated when the render API API change goes through
         rendered = self.env.render(mode="rgb_array")
         video_size = [rendered.shape[1], rendered.shape[0]]
 
@@ -175,6 +176,7 @@ def play(
             if callback is not None:
                 callback(prev_obs, obs, action, rew, done, info)
         if obs is not None:
+            # TODO: this needs to be updated when the render API API change goes through
             rendered = env.render(mode="rgb_array")
             display_arr(
                 game.screen, rendered, transpose=transpose, video_size=game.video_size

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -58,7 +58,7 @@ class PlayableGame:
         relevant_keys = set(sum((list(k) for k in keys_to_action.keys()), []))
         return relevant_keys
 
-    def _get_video_size(self, zoom: float = None) -> Tuple[int, int]:
+    def _get_video_size(self, zoom: Optional[float] = None) -> Tuple[int, int]:
         # TODO: this needs to be updated when the render API API change goes through
         rendered = self.env.render(mode="rgb_array")
         video_size = [rendered.shape[1], rendered.shape[0]]

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+import pytest
+import numpy as np
+import gym
+
+from gym.utils.play import PlayableGame
+from gym.utils.play import play
+
+
+
+@dataclass
+class DummyEnvSpec():
+    id: str
+
+
+class DummyPlayEnv(gym.Env):
+    
+    def step(self, action):
+        ...
+        
+    def reset(self):
+        ...
+        
+    def render(self, mode):
+        return np.zeros((1,1))
+
+
+def dummy_keys_to_action():
+    return {(ord('a'),): 0, (ord('d'),): 1}
+
+
+def test_play_relvant_keys():
+    env = DummyPlayEnv()
+    keys_to_action = {
+         (ord('a'),): 0,
+         (ord('d'),): 1
+    }
+    game = PlayableGame(env)
+    relevant_keys = game.get_relevant_keys(keys_to_action)
+    assert relevant_keys == {97, 100}
+
+
+def test_play_revant_keys_no_mapping():
+    env = DummyPlayEnv()
+    env.spec = DummyEnvSpec("DummyPlayEnv")
+    game = PlayableGame(env)
+    
+    with pytest.raises(AssertionError) as info:
+        game.get_relevant_keys()
+
+
+def test_play_relevant_keys_with_env_attribute():
+    """Env has a keys_to_action attribute
+    """
+    env = DummyPlayEnv()
+    env.get_keys_to_action = dummy_keys_to_action
+    game = PlayableGame(env)
+    relevant_keys = game.get_relevant_keys()
+    assert relevant_keys == {97, 100}
+
+
+
+
+
+
+# def test_play_loop():
+#     env = DummyPlayEnv()
+#     keys_to_action = {
+#         (ord('a'),): 0,
+#         (ord('d'),): 1
+#     }
+#     play(env, keys_to_action=keys_to_action)

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -49,13 +49,13 @@ def close_pygame():
     pygame.quit()
 
 
-def test_play_relvant_keys():
+def test_play_relevant_keys():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
     assert game.relevant_keys == {97, 100}
 
 
-def test_play_revant_keys_no_mapping():
+def test_play_relevant_keys_no_mapping():
     env = DummyPlayEnv()
     env.spec = DummyEnvSpec("DummyPlayEnv")
 

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -1,66 +1,83 @@
 from dataclasses import dataclass
-import pytest
+from typing import Optional
+
 import numpy as np
+import pygame
+import pytest
+
 import gym
-
-from gym.utils.play import PlayableGame
-from gym.utils.play import play
-
+from gym.utils.play import PlayableGame, play
 
 
 @dataclass
-class DummyEnvSpec():
+class MockKeyEvent:
+    type: pygame.event.Event
+    key: Optional[int]
+
+
+@dataclass
+class DummyEnvSpec:
     id: str
 
 
 class DummyPlayEnv(gym.Env):
-    
     def step(self, action):
         ...
-        
+
     def reset(self):
         ...
-        
-    def render(self, mode):
-        return np.zeros((1,1))
+
+    def render(self, mode="rgb_array"):
+        return np.zeros((1, 1))
 
 
 def dummy_keys_to_action():
-    return {(ord('a'),): 0, (ord('d'),): 1}
+    return {(ord("a"),): 0, (ord("d"),): 1}
 
 
 def test_play_relvant_keys():
     env = DummyPlayEnv()
-    keys_to_action = {
-         (ord('a'),): 0,
-         (ord('d'),): 1
-    }
-    game = PlayableGame(env)
-    relevant_keys = game.get_relevant_keys(keys_to_action)
-    assert relevant_keys == {97, 100}
+    game = PlayableGame(env, dummy_keys_to_action())
+    assert game.relevant_keys == {97, 100}
 
 
 def test_play_revant_keys_no_mapping():
     env = DummyPlayEnv()
     env.spec = DummyEnvSpec("DummyPlayEnv")
-    game = PlayableGame(env)
-    
+
     with pytest.raises(AssertionError) as info:
-        game.get_relevant_keys()
+        PlayableGame(env)
 
 
 def test_play_relevant_keys_with_env_attribute():
-    """Env has a keys_to_action attribute
-    """
+    """Env has a keys_to_action attribute"""
     env = DummyPlayEnv()
     env.get_keys_to_action = dummy_keys_to_action
     game = PlayableGame(env)
-    relevant_keys = game.get_relevant_keys()
-    assert relevant_keys == {97, 100}
+    assert game.relevant_keys == {97, 100}
 
 
+def test_video_size_no_zoom():
+    env = DummyPlayEnv()
+    game = PlayableGame(env, dummy_keys_to_action())
+    video_size = game.get_video_size()
+    assert video_size == list(env.render().shape)
 
 
+def test_video_size_zoom():
+    env = DummyPlayEnv()
+    game = PlayableGame(env, dummy_keys_to_action())
+    zoom_value = 2.2
+    video_size = game.get_video_size(zoom=zoom_value)
+    assert video_size == tuple(int(shape * zoom_value) for shape in env.render().shape)
+
+
+def test_keyboard_quit_event():
+    env = DummyPlayEnv()
+    game = PlayableGame(env, dummy_keys_to_action())
+    quit_event = MockKeyEvent(pygame.KEYDOWN, 27)
+    game.process_event(quit_event)
+    assert game.running == False
 
 
 # def test_play_loop():

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -200,9 +200,9 @@ def test_play_loop_real_env():
     keys_to_action = dummy_keys_to_action()
 
     # first action is 0 because at the first iteration
-    # we have no input in the game
+    # we can not inject a callback event into play()
     env.step(0)
-    for e in keydown_events:  # we run the same number of steps executed with play()
+    for e in keydown_events:
         action = keys_to_action[(e.key,)]
         obs, _, _, _ = env.step(action)
 

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -10,7 +10,8 @@ from pygame.event import Event
 import gym
 from gym.utils.play import MissingKeysToAction, PlayableGame, play
 
-RELEVANT_KEY = 100
+RELEVANT_KEY_1 = ord("a")  # 97
+RELEVANT_KEY_2 = ord("d")  # 100
 IRRELEVANT_KEY = 1
 
 
@@ -45,8 +46,8 @@ class PlayStatus:
 
 # set of key events to inject into the play loop as callback
 callback_events = [
-    Event(KEYDOWN, {"key": RELEVANT_KEY}),
-    Event(KEYDOWN, {"key": RELEVANT_KEY}),
+    Event(KEYDOWN, {"key": RELEVANT_KEY_1}),
+    Event(KEYDOWN, {"key": RELEVANT_KEY_1}),
     Event(QUIT),
 ]
 
@@ -57,7 +58,7 @@ def callback(obs_t, obs_tp1, action, rew, done, info):
 
 
 def dummy_keys_to_action():
-    return {(ord("a"),): 0, (ord("d"),): 1}
+    return {(RELEVANT_KEY_1,): 0, (RELEVANT_KEY_2,): 1}
 
 
 @pytest.fixture(autouse=True)
@@ -69,7 +70,7 @@ def close_pygame():
 def test_play_relevant_keys():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
-    assert game.relevant_keys == {97, 100}
+    assert game.relevant_keys == {RELEVANT_KEY_1, RELEVANT_KEY_2}
 
 
 def test_play_relevant_keys_no_mapping():
@@ -104,7 +105,7 @@ def test_video_size_zoom():
 def test_keyboard_quit_event():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
-    event = Event(pygame.KEYDOWN, {"key": 27})
+    event = Event(pygame.KEYDOWN, {"key": pygame.K_ESCAPE})
     assert game.running == True
     game.process_event(event)
     assert game.running == False
@@ -122,9 +123,9 @@ def test_pygame_quit_event():
 def test_keyboard_relevant_keydown_event():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
-    event = Event(pygame.KEYDOWN, {"key": RELEVANT_KEY})
+    event = Event(pygame.KEYDOWN, {"key": RELEVANT_KEY_1})
     game.process_event(event)
-    assert game.pressed_keys == [RELEVANT_KEY]
+    assert game.pressed_keys == [RELEVANT_KEY_1]
 
 
 def test_keyboard_irrelevant_keydown_event():
@@ -138,9 +139,9 @@ def test_keyboard_irrelevant_keydown_event():
 def test_keyboard_keyup_event():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
-    event = Event(pygame.KEYDOWN, {"key": RELEVANT_KEY})
+    event = Event(pygame.KEYDOWN, {"key": RELEVANT_KEY_1})
     game.process_event(event)
-    event = Event(pygame.KEYUP, {"key": RELEVANT_KEY})
+    event = Event(pygame.KEYUP, {"key": RELEVANT_KEY_1})
     game.process_event(event)
     assert game.pressed_keys == []
 

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -8,7 +8,7 @@ from pygame import KEYDOWN, QUIT, event
 from pygame.event import Event
 
 import gym
-from gym.utils.play import PlayableGame, play
+from gym.utils.play import MissingKeysToAction, PlayableGame, play
 
 RELEVANT_KEY = 100
 IRRELEVANT_KEY = 1
@@ -76,7 +76,7 @@ def test_play_relevant_keys_no_mapping():
     env = DummyPlayEnv()
     env.spec = DummyEnvSpec("DummyPlayEnv")
 
-    with pytest.raises(AssertionError) as info:
+    with pytest.raises(MissingKeysToAction) as info:
         PlayableGame(env)
 
 

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
 
 import numpy as np
 import pygame
@@ -8,11 +8,15 @@ import pytest
 import gym
 from gym.utils.play import PlayableGame, play
 
+RELEVANT_KEY = 100
+IRRELEVANT_KEY = 1
+
 
 @dataclass
 class MockKeyEvent:
     type: pygame.event.Event
-    key: Optional[int]
+    key: Optional[int] = field(default=None)
+    size: Optional[Tuple[int, int]] = field(default=None)
 
 
 @dataclass
@@ -75,9 +79,45 @@ def test_video_size_zoom():
 def test_keyboard_quit_event():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
-    quit_event = MockKeyEvent(pygame.KEYDOWN, 27)
-    game.process_event(quit_event)
+    event = MockKeyEvent(pygame.KEYDOWN, 27)
+    assert game.running == True
+    game.process_event(event)
     assert game.running == False
+
+
+def test_pygame_quit_event():
+    env = DummyPlayEnv()
+    game = PlayableGame(env, dummy_keys_to_action())
+    event = MockKeyEvent(pygame.QUIT)
+    assert game.running == True
+    game.process_event(event)
+    assert game.running == False
+
+
+def test_keyboard_relevant_keydown_event():
+    env = DummyPlayEnv()
+    game = PlayableGame(env, dummy_keys_to_action())
+    event = MockKeyEvent(pygame.KEYDOWN, RELEVANT_KEY)
+    game.process_event(event)
+    assert game.pressed_keys == [RELEVANT_KEY]
+
+
+def test_keyboard_irrelevant_keydown_event():
+    env = DummyPlayEnv()
+    game = PlayableGame(env, dummy_keys_to_action())
+    event = MockKeyEvent(pygame.KEYDOWN, IRRELEVANT_KEY)
+    game.process_event(event)
+    assert game.pressed_keys == []
+
+
+def test_keyboard_keyup_event():
+    env = DummyPlayEnv()
+    game = PlayableGame(env, dummy_keys_to_action())
+    event = MockKeyEvent(pygame.KEYDOWN, RELEVANT_KEY)
+    game.process_event(event)
+    event = MockKeyEvent(pygame.KEYUP, RELEVANT_KEY)
+    game.process_event(event)
+    assert game.pressed_keys == []
 
 
 # def test_play_loop():

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -15,13 +15,6 @@ IRRELEVANT_KEY = 1
 
 
 @dataclass
-class MockKeyEvent:
-    type: pygame.event.Event
-    key: Optional[int] = field(default=None)
-    size: Optional[Tuple[int, int]] = field(default=None)
-
-
-@dataclass
 class DummyEnvSpec:
     id: str
 
@@ -111,7 +104,7 @@ def test_video_size_zoom():
 def test_keyboard_quit_event():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
-    event = MockKeyEvent(pygame.KEYDOWN, 27)
+    event = Event(pygame.KEYDOWN, {"key": 27})
     assert game.running == True
     game.process_event(event)
     assert game.running == False
@@ -120,7 +113,7 @@ def test_keyboard_quit_event():
 def test_pygame_quit_event():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
-    event = MockKeyEvent(pygame.QUIT)
+    event = Event(pygame.QUIT)
     assert game.running == True
     game.process_event(event)
     assert game.running == False
@@ -129,7 +122,7 @@ def test_pygame_quit_event():
 def test_keyboard_relevant_keydown_event():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
-    event = MockKeyEvent(pygame.KEYDOWN, RELEVANT_KEY)
+    event = Event(pygame.KEYDOWN, {"key": RELEVANT_KEY})
     game.process_event(event)
     assert game.pressed_keys == [RELEVANT_KEY]
 
@@ -137,7 +130,7 @@ def test_keyboard_relevant_keydown_event():
 def test_keyboard_irrelevant_keydown_event():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
-    event = MockKeyEvent(pygame.KEYDOWN, IRRELEVANT_KEY)
+    event = Event(pygame.KEYDOWN, {"key": IRRELEVANT_KEY})
     game.process_event(event)
     assert game.pressed_keys == []
 
@@ -145,9 +138,9 @@ def test_keyboard_irrelevant_keydown_event():
 def test_keyboard_keyup_event():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
-    event = MockKeyEvent(pygame.KEYDOWN, RELEVANT_KEY)
+    event = Event(pygame.KEYDOWN, {"key": RELEVANT_KEY})
     game.process_event(event)
-    event = MockKeyEvent(pygame.KEYUP, RELEVANT_KEY)
+    event = Event(pygame.KEYUP, {"key": RELEVANT_KEY})
     game.process_event(event)
     assert game.pressed_keys == []
 

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -26,7 +26,11 @@ class DummyEnvSpec:
 
 class DummyPlayEnv(gym.Env):
     def step(self, action):
-        ...
+        obs = np.zeros((1, 1))
+        rew = 0
+        done = False
+        info = {}
+        return obs, rew, done, info
 
     def reset(self):
         ...
@@ -64,16 +68,14 @@ def test_play_relevant_keys_with_env_attribute():
 def test_video_size_no_zoom():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
-    video_size = game.get_video_size()
-    assert video_size == list(env.render().shape)
+    assert game.video_size == list(env.render().shape)
 
 
 def test_video_size_zoom():
     env = DummyPlayEnv()
-    game = PlayableGame(env, dummy_keys_to_action())
-    zoom_value = 2.2
-    video_size = game.get_video_size(zoom=zoom_value)
-    assert video_size == tuple(int(shape * zoom_value) for shape in env.render().shape)
+    zoom = 2.2
+    game = PlayableGame(env, dummy_keys_to_action(), zoom)
+    assert game.video_size == tuple(int(shape * zoom) for shape in env.render().shape)
 
 
 def test_keyboard_quit_event():
@@ -118,12 +120,3 @@ def test_keyboard_keyup_event():
     event = MockKeyEvent(pygame.KEYUP, RELEVANT_KEY)
     game.process_event(event)
     assert game.pressed_keys == []
-
-
-# def test_play_loop():
-#     env = DummyPlayEnv()
-#     keys_to_action = {
-#         (ord('a'),): 0,
-#         (ord('d'),): 1
-#     }
-#     play(env, keys_to_action=keys_to_action)

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -6,7 +6,7 @@ import pygame
 import pytest
 
 import gym
-from gym.utils.play import PlayableGame, play
+from gym.utils.play import PlayableGame
 
 RELEVANT_KEY = 100
 IRRELEVANT_KEY = 1
@@ -41,6 +41,12 @@ class DummyPlayEnv(gym.Env):
 
 def dummy_keys_to_action():
     return {(ord("a"),): 0, (ord("d"),): 1}
+
+
+@pytest.fixture(autouse=True)
+def close_pygame():
+    yield
+    pygame.quit()
 
 
 def test_play_relvant_keys():


### PR DESCRIPTION
Referring to #2729; to add test to gym.utils.play I have refactored the play() script and extracted a PlayableGame class to have more separation and easier testing. 
Running headless the whole game is possible but it seems that pygame events are not available (https://www.pygame.org/wiki/HeadlessNoWindowsNeeded) so I prefer to mock them in tests and test the PlayableGame class
