### PR TITLE
Add gravity and wind as kwarg in Lunar Lander

### DIFF
--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -353,7 +353,7 @@ class LunarLander(gym.Env, EzPickle):
             else:
                 m_power = 1.0
             # 4 is move a bit downwards, +-2 for randomness
-            ox = +tip[0] * (4 / SCALE + 2 * dispersion[0]) + side[0] * dispersion[0]
+            ox = +tip[0] * (4 / SCALE + 2 * dispersion[0]) + side[0] * dispersion[1]
             oy = -tip[1] * (4 / SCALE + 2 * dispersion[0]) - side[1] * dispersion[1]
             impulse_pos = (self.lander.position[0] + ox, self.lander.position[1] + oy)
             p = self._create_particle(

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -351,10 +351,13 @@ class LunarLander(gym.Env, EzPickle):
         ):
             # the function used for wind is tanh(sin(2 k x) + sin(pi k x)),
             # which is proven to never be periodic, k = 0.01
-            wind_mag = math.tanh(
-                math.sin(0.02 * self.wind_idx)
-                + (math.sin(math.pi * 0.01 * self.wind_idx))
-            ) * WIND_POWER
+            wind_mag = (
+                math.tanh(
+                    math.sin(0.02 * self.wind_idx)
+                    + (math.sin(math.pi * 0.01 * self.wind_idx))
+                )
+                * WIND_POWER
+            )
             self.wind_idx += 1
             self.lander.ApplyForceToCenter(
                 (wind_mag, 0.0),

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -171,7 +171,6 @@ class LunarLander(gym.Env, EzPickle):
         self.wind_power = wind_power
 
         self.enable_wind = enable_wind
-        self.wind_power = wind_power
         self.wind_idx = np.random.randint(-9999, 9999)
 
         self.screen = None
@@ -659,7 +658,7 @@ def heuristic(env, s):
 def demo_heuristic_lander(env, seed=None, render=False):
 
     # wind power must be reduced for heuristic landing
-    env.wind_power = 1.0
+    env.wind_power = 0.2
 
     total_reward = 0
     steps = 0

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -156,7 +156,7 @@ class LunarLander(gym.Env, EzPickle):
         self,
         continuous: bool = False,
         gravity: float = -10.0,
-        enable_wind: bool = False,
+        enable_wind: bool = True,
     ):
         EzPickle.__init__(self)
 
@@ -651,6 +651,11 @@ def heuristic(env, s):
 
 
 def demo_heuristic_lander(env, seed=None, render=False):
+
+    # wind power must be reduced for heuristic landing
+    global WIND_POWER
+    WIND_POWER = 5.0
+
     total_reward = 0
     steps = 0
     s = env.reset(seed=seed)

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -156,7 +156,7 @@ class LunarLander(gym.Env, EzPickle):
         self,
         continuous: bool = False,
         gravity: float = -10.0,
-        enable_wind: bool = True,
+        enable_wind: bool = False,
     ):
         EzPickle.__init__(self)
 
@@ -654,7 +654,7 @@ def demo_heuristic_lander(env, seed=None, render=False):
 
     # wind power must be reduced for heuristic landing
     global WIND_POWER
-    WIND_POWER = 5.0
+    WIND_POWER = 3.0
 
     total_reward = 0
     steps = 0

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -151,12 +151,12 @@ class LunarLander(gym.Env, EzPickle):
 
     metadata = {"render_modes": ["human", "rgb_array"], "render_fps": FPS}
 
-    def __init__(self, continuous: bool = False):
+    def __init__(self, continuous: bool = False, gravity: float = -10.0):
         EzPickle.__init__(self)
         self.screen = None
         self.clock = None
         self.isopen = True
-        self.world = Box2D.b2World()
+        self.world = Box2D.b2World(gravity=(0, gravity))
         self.moon = None
         self.lander = None
         self.particles = []
@@ -352,9 +352,8 @@ class LunarLander(gym.Env, EzPickle):
                 assert m_power >= 0.5 and m_power <= 1.0
             else:
                 m_power = 1.0
-            ox = (
-                tip[0] * (4 / SCALE + 2 * dispersion[0]) + side[0] * dispersion[1]
-            )  # 4 is move a bit downwards, +-2 for randomness
+            # 4 is move a bit downwards, +-2 for randomness
+            ox = +tip[0] * (4 / SCALE + 2 * dispersion[0]) + side[0] * dispersion[0]
             oy = -tip[1] * (4 / SCALE + 2 * dispersion[0]) - side[1] * dispersion[1]
             impulse_pos = (self.lander.position[0] + ox, self.lander.position[1] + oy)
             p = self._create_particle(

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -438,7 +438,7 @@ class LunarLander(gym.Env, EzPickle):
             else:
                 m_power = 1.0
             # 4 is move a bit downwards, +-2 for randomness
-            ox = +tip[0] * (4 / SCALE + 2 * dispersion[0]) + side[0] * dispersion[1]
+            ox = tip[0] * (4 / SCALE + 2 * dispersion[0]) + side[0] * dispersion[1]
             oy = -tip[1] * (4 / SCALE + 2 * dispersion[0]) - side[1] * dispersion[1]
             impulse_pos = (self.lander.position[0] + ox, self.lander.position[1] + oy)
             p = self._create_particle(

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -654,7 +654,7 @@ def demo_heuristic_lander(env, seed=None, render=False):
 
     # wind power must be reduced for heuristic landing
     global WIND_POWER
-    WIND_POWER = 3.0
+    WIND_POWER = 1.0
 
     total_reward = 0
     steps = 0

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -171,6 +171,7 @@ class LunarLander(gym.Env, EzPickle):
         continuous: bool = False,
         gravity: float = -10.0,
         enable_wind: bool = False,
+        wind_power: float = 15.0,
     ):
         EzPickle.__init__(self)
 
@@ -178,10 +179,14 @@ class LunarLander(gym.Env, EzPickle):
             -12.0 < gravity and gravity < 0.0
         ), f"gravity (current value: {gravity}) must be between -12 and 0"
         self.gravity = gravity
+        
+        assert (
+            0.0 < wind_power and wind_power < 20.0
+        ), f"wind_power (current value: {wind_power}) must be between 0 and 20"
+        self.wind_power = wind_power
 
         self.enable_wind = enable_wind
         self.wind_idx = np.random.randint(-9999, 9999)
-        self.wind_power = 15.0
 
         self.screen = None
         self.clock = None

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -179,7 +179,7 @@ class LunarLander(gym.Env, EzPickle):
             -12.0 < gravity and gravity < 0.0
         ), f"gravity (current value: {gravity}) must be between -12 and 0"
         self.gravity = gravity
-        
+
         assert (
             0.0 < wind_power and wind_power < 20.0
         ), f"wind_power (current value: {wind_power}) must be between 0 and 20"

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -123,7 +123,13 @@ class LunarLander(gym.Env, EzPickle):
     `continuous=True` argument like below:
     ```python
     import gym
-    env = gym.make("LunarLander-v2", continuous=True)
+    env = gym.make(
+        "LunarLander-v2",
+        continuous: bool = False,
+        gravity: float = -10.0,
+        enable_wind: bool = False,
+        wind_power: float = 15.0,
+    )
     ```
     If `continuous=True` is passed, continuous actions (corresponding to the throttle of the engines) will be used and the
     action space will be `Box(-1, +1, (2,), dtype=np.float32)`.
@@ -135,6 +141,15 @@ class LunarLander(gym.Env, EzPickle):
     Similarly, if `-0.5 < lateral < 0.5`, the lateral boosters will not fire at all. If `lateral < -0.5`, the left
     booster will fire, and if `lateral > 0.5`, the right booster will fire. Again, the throttle scales affinely
     from 50% to 100% between -1 and -0.5 (and 0.5 and 1, respectively).
+
+    `gravity` dictates the gravitational constant, this is bounded to be within 0 and -12.
+
+    If `enable_wind=True` is passed, there will be wind effects applied to the lander.
+    The wind is generated using the function `tanh(sin(2 k (t+C)) + sin(pi k (t+C)))`.
+    `k` is set to 0.01.
+    `C` is sampled randomly between -9999 and 9999.
+
+    `wind_power` dictates the maximum magnitude of wind.
 
     ### Version History
     - v2: Count energy spent

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -153,6 +153,11 @@ class LunarLander(gym.Env, EzPickle):
 
     def __init__(self, continuous: bool = False, gravity: float = -10.0):
         EzPickle.__init__(self)
+
+        assert (
+            -12.0 < gravity and gravity < 0
+        ), f"gravity (current value: {gravity}) must be between -12 and 0"
+
         self.screen = None
         self.clock = None
         self.isopen = True

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -171,7 +171,6 @@ class LunarLander(gym.Env, EzPickle):
         continuous: bool = False,
         gravity: float = -10.0,
         enable_wind: bool = False,
-        wind_power: float = 15.0,
     ):
         EzPickle.__init__(self)
 
@@ -180,13 +179,9 @@ class LunarLander(gym.Env, EzPickle):
         ), f"gravity (current value: {gravity}) must be between -12 and 0"
         self.gravity = gravity
 
-        assert (
-            0.0 < wind_power and wind_power < 20.0
-        ), f"wind_power (current value: {wind_power}) must be between 0 and 20"
-        self.wind_power = wind_power
-
         self.enable_wind = enable_wind
         self.wind_idx = np.random.randint(-9999, 9999)
+        self.wind_power = 15.0
 
         self.screen = None
         self.clock = None

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -26,7 +26,6 @@ MAIN_ENGINE_POWER = 13.0
 SIDE_ENGINE_POWER = 0.6
 
 INITIAL_RANDOM = 1000.0  # Set 1500 to make game harder
-WIND_POWER = 15.0
 
 LANDER_POLY = [(-14, +17), (-17, 0), (-17, -10), (+17, -10), (+17, 0), (+14, +17)]
 LEG_AWAY = 20
@@ -157,6 +156,7 @@ class LunarLander(gym.Env, EzPickle):
         continuous: bool = False,
         gravity: float = -10.0,
         enable_wind: bool = False,
+        wind_power: float = 15.0,
     ):
         EzPickle.__init__(self)
 
@@ -165,7 +165,13 @@ class LunarLander(gym.Env, EzPickle):
         ), f"gravity (current value: {gravity}) must be between -12 and 0"
         self.gravity = gravity
 
+        assert (
+            0.0 < wind_power and wind_power < 20.0
+        ), f"wind_power (current value: {wind_power}) must be between 0 and 20"
+        self.wind_power = wind_power
+
         self.enable_wind = enable_wind
+        self.wind_power = wind_power
         self.wind_idx = np.random.randint(-9999, 9999)
 
         self.screen = None
@@ -356,7 +362,7 @@ class LunarLander(gym.Env, EzPickle):
                     math.sin(0.02 * self.wind_idx)
                     + (math.sin(math.pi * 0.01 * self.wind_idx))
                 )
-                * WIND_POWER
+                * self.wind_power
             )
             self.wind_idx += 1
             self.lander.ApplyForceToCenter(
@@ -653,8 +659,7 @@ def heuristic(env, s):
 def demo_heuristic_lander(env, seed=None, render=False):
 
     # wind power must be reduced for heuristic landing
-    global WIND_POWER
-    WIND_POWER = 1.0
+    env.wind_power = 1.0
 
     total_reward = 0
     steps = 0

--- a/tests/envs/test_lunar_lander.py
+++ b/tests/envs/test_lunar_lander.py
@@ -30,7 +30,5 @@ def test_lunar_lander_wind_continuous():
 
 @pytest.mark.skipif(Box2D is None, reason="Box2D not installed")
 def _test_lander(env, seed=None, render=False):
-    total_reward = 0
-    for _ in range(10):
-        total_reward += demo_heuristic_lander(env, seed=seed, render=render)
-    assert total_reward / 10 > 100
+    total_reward = demo_heuristic_lander(env, seed=seed, render=render)
+    assert total_reward > 100

--- a/tests/envs/test_lunar_lander.py
+++ b/tests/envs/test_lunar_lander.py
@@ -19,6 +19,16 @@ def test_lunar_lander_continuous():
 
 
 @pytest.mark.skipif(Box2D is None, reason="Box2D not installed")
+def test_lunar_lander_wind():
+    _test_lander(LunarLander(enable_wind=True), seed=0)
+
+
+@pytest.mark.skipif(Box2D is None, reason="Box2D not installed")
+def test_lunar_lander_wind_continuous():
+    _test_lander(LunarLander(continuous=True, enable_wind=True), seed=0)
+
+
+@pytest.mark.skipif(Box2D is None, reason="Box2D not installed")
 def _test_lander(env, seed=None, render=False):
     total_reward = demo_heuristic_lander(env, seed=seed, render=render)
     assert total_reward > 100

--- a/tests/envs/test_lunar_lander.py
+++ b/tests/envs/test_lunar_lander.py
@@ -30,5 +30,7 @@ def test_lunar_lander_wind_continuous():
 
 @pytest.mark.skipif(Box2D is None, reason="Box2D not installed")
 def _test_lander(env, seed=None, render=False):
-    total_reward = demo_heuristic_lander(env, seed=seed, render=render)
-    assert total_reward > 100
+    total_reward = 0
+    for _ in range(10):
+        total_reward += demo_heuristic_lander(env, seed=seed, render=render)
+    assert total_reward / 10 > 100

--- a/tests/envs/test_lunar_lander.py
+++ b/tests/envs/test_lunar_lander.py
@@ -21,15 +21,11 @@ def test_lunar_lander_continuous():
 @pytest.mark.skipif(Box2D is None, reason="Box2D not installed")
 def test_lunar_lander_wind():
     _test_lander(LunarLander(enable_wind=True), seed=0)
-    _test_lander(LunarLander(enable_wind=True, wind_power=5.0), seed=0)
-    _test_lander(LunarLander(enable_wind=True, wind_power=0.1), seed=0)
 
 
 @pytest.mark.skipif(Box2D is None, reason="Box2D not installed")
 def test_lunar_lander_wind_continuous():
     _test_lander(LunarLander(continuous=True, enable_wind=True), seed=0)
-    _test_lander(LunarLander(continuous=True, enable_wind=True, wind_power=5.0), seed=0)
-    _test_lander(LunarLander(continuous=True, enable_wind=True, wind_power=0.1), seed=0)
 
 
 @pytest.mark.skipif(Box2D is None, reason="Box2D not installed")

--- a/tests/envs/test_lunar_lander.py
+++ b/tests/envs/test_lunar_lander.py
@@ -21,11 +21,15 @@ def test_lunar_lander_continuous():
 @pytest.mark.skipif(Box2D is None, reason="Box2D not installed")
 def test_lunar_lander_wind():
     _test_lander(LunarLander(enable_wind=True), seed=0)
+    _test_lander(LunarLander(enable_wind=True, wind_power=5.0), seed=0)
+    _test_lander(LunarLander(enable_wind=True, wind_power=0.1), seed=0)
 
 
 @pytest.mark.skipif(Box2D is None, reason="Box2D not installed")
 def test_lunar_lander_wind_continuous():
     _test_lander(LunarLander(continuous=True, enable_wind=True), seed=0)
+    _test_lander(LunarLander(continuous=True, enable_wind=True, wind_power=5.0), seed=0)
+    _test_lander(LunarLander(continuous=True, enable_wind=True, wind_power=0.1), seed=0)
 
 
 @pytest.mark.skipif(Box2D is None, reason="Box2D not installed")


### PR DESCRIPTION
# Description

This change is for LunarLander.
This adds adjustable gravity and wind to the env.
More changes to this env and perhaps other envs are possible in due time.

To set gravity value to say, 5, simply pass `gravity=-5`.

To enable wind, pass the wind kwarg `enable_wind=True`.
By default, the wind function is ` C tanh(sin(2 k x) + sin(pi k x)`, which is proven to be non-periodic for all `k` (see [this](https://math.stackexchange.com/questions/1776688/why-sinx-sin-pi-x-is-not-periodic)).
In implementation, I've set `k = 0.01`, `C=15`.
This is just a simpler version instead of using a Dryden wind field or Perlin noise sampling.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
