### PR TITLE
Optional pygame import for box2d with try except

### DIFF
--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -19,6 +19,12 @@ import gym
 from gym import error, spaces
 from gym.utils import EzPickle, colorize, seeding
 
+try:
+    import pygame
+    from pygame import gfxdraw
+except ImportError:
+    pygame, gfxdraw = None, None
+
 FPS = 50
 SCALE = 30.0  # affects how fast-paced the game is, forces should be adjusted as well
 
@@ -158,6 +164,9 @@ class BipedalWalker(gym.Env, EzPickle):
 
     def __init__(self, hardcore: bool = False):
         EzPickle.__init__(self)
+        if pygame is None or gfxdraw is None:
+            raise ImportError("pygame is not installed, run `pip install gym[box2d]`")
+
         self.screen = None
         self.clock = None
         self.isopen = True
@@ -590,9 +599,6 @@ class BipedalWalker(gym.Env, EzPickle):
         return np.array(state, dtype=np.float32), reward, done, {}
 
     def render(self, mode: str = "human"):
-        import pygame
-        from pygame import gfxdraw
-
         if self.screen is None:
             pygame.init()
             pygame.display.init()
@@ -725,8 +731,6 @@ class BipedalWalker(gym.Env, EzPickle):
 
     def close(self):
         if self.screen is not None:
-            import pygame
-
             pygame.display.quit()
             pygame.quit()
             self.isopen = False

--- a/gym/envs/box2d/car_dynamics.py
+++ b/gym/envs/box2d/car_dynamics.py
@@ -21,6 +21,11 @@ from Box2D.b2 import (
     shape,
 )
 
+try:
+    import pygame
+except ImportError:
+    pygame = None
+
 SIZE = 0.02
 ENGINE_POWER = 100000000 * SIZE * SIZE
 WHEEL_MOMENT_OF_INERTIA = 4000 * SIZE * SIZE
@@ -53,6 +58,9 @@ PLAYFIELD = 2000 / SCALE  # Game over boundary
 
 class Car:
     def __init__(self, world, init_angle, init_x, init_y):
+        if pygame is None:
+            raise ImportError("pygame is not installed, run `pip install gym[box2d]`")
+
         self.world = world
         self.hull = self.world.CreateDynamicBody(
             position=(init_x, init_y),
@@ -265,8 +273,6 @@ class Car:
             )
 
     def draw(self, surface, zoom, translation, angle, draw_particles=True):
-        import pygame.draw
-
         if draw_particles:
             for p in self.particles:
                 poly = [

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -19,6 +19,12 @@ import gym
 from gym import error, spaces
 from gym.utils import EzPickle, seeding
 
+try:
+    import pygame
+    from pygame import gfxdraw
+except ImportError:
+    pygame, gfxdraw = None, None
+
 FPS = 50
 SCALE = 30.0  # affects how fast-paced the game is, forces should be adjusted as well
 
@@ -173,6 +179,8 @@ class LunarLander(gym.Env, EzPickle):
         enable_wind: bool = False,
         wind_power: float = 15.0,
     ):
+        if pygame is None or gfxdraw is None:
+            raise ImportError("pygame is not installed. Run `pip install gym[box2d]`")
         EzPickle.__init__(self)
 
         assert (
@@ -536,9 +544,6 @@ class LunarLander(gym.Env, EzPickle):
         return np.array(state, dtype=np.float32), reward, done, {}
 
     def render(self, mode="human"):
-        import pygame
-        from pygame import gfxdraw
-
         if self.screen is None:
             pygame.init()
             pygame.display.init()
@@ -641,8 +646,6 @@ class LunarLander(gym.Env, EzPickle):
 
     def close(self):
         if self.screen is not None:
-            import pygame
-
             pygame.display.quit()
             pygame.quit()
             self.isopen = False


### PR DESCRIPTION
Currently the CI is seg faulting without reporting an error (I know, not good), see https://github.com/openai/gym/pull/2750/checks in the run tests. 
The cause of it was 07fd227a4fc0ecbd4fdac5563c0f48deeb5688ed in car racing somehow effecting async vector environments due to pygame.quit() . 
I was not able to isolate the issue to a single cause so have instead rewritten the fix to use try except rather than local imports which seems to have solved the seg fault issue and the original issue.

I have modified all of the box2d environment as pygame was made optional in all of them and to prevent the seg fault happening in the future. 

@RedTachyon @gianlucadecola I believe you were both involved in the optional pygame PRs, was there a reason you chose local imports over try except? 
If there isn't an issue with this approach, could you review this PR?