### PR TITLE
Add check before rendering Frozen Lake

### DIFF
--- a/gym/envs/toy_text/frozen_lake.py
+++ b/gym/envs/toy_text/frozen_lake.py
@@ -234,6 +234,9 @@ class FrozenLakeEnv(Env):
             return int(self.s), {"prob": 1}
 
     def render(self, mode="human"):
+        if not hasattr(self, "lastaction"):
+            raise AttributeError("Reset the environment before rendering")
+
         desc = self.desc.tolist()
         if mode == "ansi":
             return self._render_text(desc)


### PR DESCRIPTION
Issue #2751 reported that `lastaction` was not an attribute of Frozen Lake in the following code
```
import gym

env = gym.make("FrozenLake-v1")
env.render()
```

This PR adds a check within `render()` that `lastaction` is an attribute otherwise raises an AttributeError explaining the problem 