### PR TITLE
Change opencv to tinyscaler

### DIFF
--- a/gym/wrappers/atari_preprocessing.py
+++ b/gym/wrappers/atari_preprocessing.py
@@ -4,9 +4,9 @@ import gym
 from gym.spaces import Box
 
 try:
-    import cv2
+    import tinyscaler
 except ImportError:
-    cv2 = None
+    tinyscaler = None
 
 
 class AtariPreprocessing(gym.Wrapper):
@@ -54,8 +54,8 @@ class AtariPreprocessing(gym.Wrapper):
     ):
         super().__init__(env)
         assert (
-            cv2 is not None
-        ), "opencv-python package not installed! Try running pip install gym[other] to get dependencies  for atari"
+            tinyscaler is not None
+        ), "tinyscaler not installed! Try running pip install gym[atari] to get dependencies for atari"
         assert frame_skip > 0
         assert screen_size > 0
         assert noop_max >= 0
@@ -169,10 +169,9 @@ class AtariPreprocessing(gym.Wrapper):
     def _get_obs(self):
         if self.frame_skip > 1:  # more efficient in-place pooling
             np.maximum(self.obs_buffer[0], self.obs_buffer[1], out=self.obs_buffer[0])
-        obs = cv2.resize(
+        obs = tinyscaler.scale(
             self.obs_buffer[0],
             (self.screen_size, self.screen_size),
-            interpolation=cv2.INTER_AREA,
         )
 
         if self.scale_obs:

--- a/gym/wrappers/gray_scale_observation.py
+++ b/gym/wrappers/gray_scale_observation.py
@@ -27,9 +27,11 @@ class GrayScaleObservation(ObservationWrapper):
             )
 
     def observation(self, observation):
-        import cv2
-
-        observation = cv2.cvtColor(observation, cv2.COLOR_RGB2GRAY)
+        grayscale_obs = (
+            observation[..., 0] * 0.2126
+            + observation[..., 1] * 0.587
+            + observation[..., 2] * 0.114
+        )
         if self.keep_dim:
-            observation = np.expand_dims(observation, -1)
-        return observation
+            grayscale_obs = np.expand_dims(grayscale_obs, -1)
+        return grayscale_obs

--- a/gym/wrappers/resize_observation.py
+++ b/gym/wrappers/resize_observation.py
@@ -3,11 +3,21 @@ import numpy as np
 from gym import ObservationWrapper
 from gym.spaces import Box
 
+try:
+    import tinyscaler
+except ImportError:
+    tinyscaler = None
+
 
 class ResizeObservation(ObservationWrapper):
     r"""Downsample the image observation to a square image."""
 
     def __init__(self, env, shape):
+        if tinyscaler is None:
+            raise ImportError(
+                "Tinyscaler is not installed, run `pip install gym[atari]`"
+            )
+
         super().__init__(env)
         if isinstance(shape, int):
             shape = (shape, shape)
@@ -19,11 +29,7 @@ class ResizeObservation(ObservationWrapper):
         self.observation_space = Box(low=0, high=255, shape=obs_shape, dtype=np.uint8)
 
     def observation(self, observation):
-        import cv2
-
-        observation = cv2.resize(
-            observation, self.shape[::-1], interpolation=cv2.INTER_AREA
-        )
+        observation = tinyscaler.scale(observation, self.shape[::-1])
         if observation.ndim == 2:
             observation = np.expand_dims(observation, -1)
         return observation

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from version import VERSION
 
 # Environment-specific dependencies.
 extras = {
-    "atari": ["ale-py~=0.7.4"],
+    "atari": ["ale-py~=0.7.4", "tinyscaler>=1.0.0"],
     "accept-rom-license": ["autorom[accept-rom-license]~=0.4.2"],
     "box2d": ["box2d-py==2.3.5", "pygame==2.1.0"],
     "classic_control": ["pygame==2.1.0"],

--- a/tests/wrappers/test_atari_preprocessing.py
+++ b/tests/wrappers/test_atari_preprocessing.py
@@ -13,7 +13,7 @@ def env_fn():
 
 
 def test_atari_preprocessing_grayscale(env_fn):
-    import cv2
+    import tinyscaler
 
     env1 = env_fn()
     env2 = AtariPreprocessing(
@@ -42,8 +42,10 @@ def test_atari_preprocessing_grayscale(env_fn):
     assert obs2.shape == (84, 84)
     assert obs3.shape == (84, 84, 3)
     assert obs4.shape == (84, 84, 1)
-    assert np.allclose(obs3, cv2.resize(obs1, (84, 84), interpolation=cv2.INTER_AREA))
-    obs3_gray = cv2.cvtColor(obs3, cv2.COLOR_RGB2GRAY)
+    assert np.allclose(obs3, tinyscaler.scale(obs1, (84, 84)))
+    obs3_gray = (
+        obs3[:, :, 0] * 0.2126 + obs3[:, :, 1] * 0.587 + obs3[:, :, 2] * 0.114
+    )  # Convert rgb to grayscale
     # the edges of the numbers do not render quite the same in the grayscale, so we ignore them
     assert np.allclose(obs2[10:38], obs3_gray[10:38])
     # the paddle also do not render quite the same

--- a/tests/wrappers/test_gray_scale_observation.py
+++ b/tests/wrappers/test_gray_scale_observation.py
@@ -5,7 +5,6 @@ import gym
 from gym.wrappers import AtariPreprocessing, GrayScaleObservation
 
 pytest.importorskip("gym.envs.atari")
-pytest.importorskip("cv2")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Tinyscaler is a new module specially built to provide an efficient and small module that solely resizes / scales NumPy ndarrays

This is backward compatibility breaking PR as all resizing implementations are unique so tinyscaler does not produce the same ndarrays as opencv however opencv is an annoying module that we have wanted to change for a while.

