### PR TITLE
Remove orphan comment

### DIFF
--- a/gym/envs/mujoco/__init__.py
+++ b/gym/envs/mujoco/__init__.py
@@ -1,5 +1,3 @@
-# ^^^^^ so that user gets the correct error
-# message if mujoco is not installed correctly
 from gym.envs.mujoco.ant import AntEnv
 from gym.envs.mujoco.half_cheetah import HalfCheetahEnv
 from gym.envs.mujoco.hopper import HopperEnv

--- a/gym/envs/mujoco/__init__.py
+++ b/gym/envs/mujoco/__init__.py
@@ -1,3 +1,7 @@
+from gym.envs.mujoco.mujoco_env import MujocoEnv  # isort:skip
+
+# ^^^^^ so that user gets the correct error
+# message if mujoco is not installed correctly
 from gym.envs.mujoco.ant import AntEnv
 from gym.envs.mujoco.half_cheetah import HalfCheetahEnv
 from gym.envs.mujoco.hopper import HopperEnv
@@ -5,7 +9,6 @@ from gym.envs.mujoco.humanoid import HumanoidEnv
 from gym.envs.mujoco.humanoidstandup import HumanoidStandupEnv
 from gym.envs.mujoco.inverted_double_pendulum import InvertedDoublePendulumEnv
 from gym.envs.mujoco.inverted_pendulum import InvertedPendulumEnv
-from gym.envs.mujoco.mujoco_env import MujocoEnv
 from gym.envs.mujoco.pusher import PusherEnv
 from gym.envs.mujoco.reacher import ReacherEnv
 from gym.envs.mujoco.swimmer import SwimmerEnv


### PR DESCRIPTION
The comment used to be due to the line that is not there anymore, like:
```python
from gym.envs.mujoco.mujoco_env import MujocoEnv

# ^^^^^ so that user gets the correct error
# message if mujoco is not installed correctly
```

Now the comment is useless.