### PR TITLE
Fix docstring format on seed arg to reset

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -106,8 +106,9 @@ class Env(Generic[ObsType, ActType]):
         integer seed right after initialization and then never again.
 
         Args:
-            seed (int or None): The seed that is used to initialize the environment's PRNG. If the environment does not already have a PRNG and ``seed=None`` (the default option) is passed, a seed will be chosen from some source of entropy (e.g. timestamp or /dev/urandom).
-            However, if the environment already has a PRNG and ``seed=None`` is passed, the PRNG will *not* be reset. If you pass an integer, the PRNG will be reset even if it already exists. Usually, you want to pass an integer *right after the environment has been initialized and then never again*. Please refer to the minimal example above to see this paradigm in action.
+            seed (int or None):
+                The seed that is used to initialize the environment's PRNG. If the environment does not already have a PRNG and ``seed=None`` (the default option) is passed, a seed will be chosen from some source of entropy (e.g. timestamp or /dev/urandom).
+                However, if the environment already has a PRNG and ``seed=None`` is passed, the PRNG will *not* be reset. If you pass an integer, the PRNG will be reset even if it already exists. Usually, you want to pass an integer *right after the environment has been initialized and then never again*. Please refer to the minimal example above to see this paradigm in action.
             return_info (bool): If true, return additional information along with initial observation. This info should be analogous to the info returned in :meth:`step`
             options (dict or None): Additional information to specify how the environment is reset (optional, depending on the specific environment)
 


### PR DESCRIPTION
I have a copy of this string in another project and it failed the darglint docstring style check.
This fixes that, if it's something you care to fix.

## Type of change

Docstring-only fix

This PR is not locally tested, lmk if it requires local testing before merge.