### PR TITLE
Update the flake8 pre-commit ignores 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
         args:
-          - --ignore=E203,E402,E712,E722,E731,E741,F401,F403,F405,F524,W503,E302,E704
+          - --ignore=E203,E402,E712,E722,E741,F401,W503,E302,E704
           - --max-complexity=30
           - --max-line-length=456
           - --show-source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,8 @@ repos:
     hooks:
       - id: flake8
         args:
-          - --ignore=E203,E741,F401,W503,E302,E704
+          - '{--pre-file-ignores="*/__init__.py": "F401"}'
+          - --ignore=E203,E741,W503,E302,E704
           - --max-complexity=30
           - --max-line-length=456
           - --show-source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,10 @@ repos:
         args:
           - --ignore-words-list=nd,reacher,thist,ths
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         args:
-          - --ignore=E203,E402,E712,E722,E731,E741,F401,F403,F405,F524,F841,W503,E302,E704
           - --max-complexity=30
           - --max-line-length=456
           - --show-source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
         args:
-          - --ignore=E203,E402,E712,E722,E731,E741,F401,F403,F405,F524,F841,W503,E302,E704
+          - --ignore=E203,E402,E712,E722,E731,E741,F401,F403,F405,F524,W503,E302,E704
           - --max-complexity=30
           - --max-line-length=456
           - --show-source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
         args:
-          - '--per-file-ignores=*/__init__.py:F401 gym/envs/registration.py:E704 E302'
+          - '--per-file-ignores=*/__init__.py:F401 gym/envs/registration.py:E704'
           - --ignore=E203,W503,E741
           - --max-complexity=30
           - --max-line-length=456

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,8 @@ repos:
     hooks:
       - id: flake8
         args:
-          - '{--pre-file-ignores="*/__init__.py": "F401"}'
-          - --ignore=E203,E741,W503,E302,E704
+          - '--per-file-ignores=*/__init__.py:F401 gym/envs/registration.py:E704 E302'
+          - --ignore=E203,W503
           - --max-complexity=30
           - --max-line-length=456
           - --show-source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
         args:
-          - --ignore=E203,E402,E741,F401,W503,E302,E704
+          - --ignore=E203,E741,F401,W503,E302,E704
           - --max-complexity=30
           - --max-line-length=456
           - --show-source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args:
           - --ignore-words-list=nd,reacher,thist,ths
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
         args:
-          - --ignore=E203,E402,E712,E722,E741,F401,W503,E302,E704
+          - --ignore=E203,E402,E712,E741,F401,W503,E302,E704
           - --max-complexity=30
           - --max-line-length=456
           - --show-source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args:
           - --ignore-words-list=nd,reacher,thist,ths
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 3.9.2
     hooks:
       - id: flake8
         args:
@@ -26,7 +26,7 @@ repos:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.32.0
     hooks:
       - id: pyupgrade
         # TODO: remove `--keep-runtime-typing` option

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,12 @@ repos:
       - id: codespell
         args:
           - --ignore-words-list=nd,reacher,thist,ths
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://gitlab.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8
         args:
+          - --ignore=E203,E402,E712,E722,E731,E741,F401,F403,F405,F524,F841,W503,E302,E704
           - --max-complexity=30
           - --max-line-length=456
           - --show-source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
         args:
-          - --ignore=E203,E402,E712,E741,F401,W503,E302,E704
+          - --ignore=E203,E402,E741,F401,W503,E302,E704
           - --max-complexity=30
           - --max-line-length=456
           - --show-source

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: flake8
         args:
           - '--per-file-ignores=*/__init__.py:F401 gym/envs/registration.py:E704 E302'
-          - --ignore=E203,W503
+          - --ignore=E203,W503,E741
           - --max-complexity=30
           - --max-line-length=456
           - --show-source

--- a/gym/core.py
+++ b/gym/core.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Generic, Optional, SupportsFloat, Tuple, TypeVar, Union
 
-import gym
 from gym import spaces
 from gym.logger import deprecation
 from gym.utils import seeding

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -1,7 +1,6 @@
 __credits__ = ["Andrea PIERRÉ"]
 
 import math
-import sys
 from typing import Optional
 
 import Box2D
@@ -17,7 +16,7 @@ from Box2D.b2 import (
 
 import gym
 from gym import error, spaces
-from gym.utils import EzPickle, colorize, seeding
+from gym.utils import EzPickle
 
 FPS = 50
 SCALE = 30.0  # affects how fast-paced the game is, forces should be adjusted as well

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -421,9 +421,6 @@ class BipedalWalker(gym.Env, EzPickle):
         self.scroll = 0.0
         self.lidar_render = 0
 
-        W = VIEWPORT_W / SCALE
-        H = VIEWPORT_H / SCALE
-
         self._generate_terrain(self.hardcore)
         self._generate_clouds()
 

--- a/gym/envs/box2d/car_dynamics.py
+++ b/gym/envs/box2d/car_dynamics.py
@@ -9,17 +9,8 @@ Created by Oleg Klimov
 
 import math
 
-import Box2D
 import numpy as np
-from Box2D.b2 import (
-    circleShape,
-    contactListener,
-    edgeShape,
-    fixtureDef,
-    polygonShape,
-    revoluteJointDef,
-    shape,
-)
+from Box2D.b2 import fixtureDef, polygonShape, revoluteJointDef
 
 SIZE = 0.02
 ENGINE_POWER = 100000000 * SIZE * SIZE

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -699,6 +699,6 @@ if __name__ == "__main__":
                 print(f"step {steps} total_reward {total_reward:+0.2f}")
             steps += 1
             isopen = env.render()
-            if done or restart or isopen == False:
+            if done or restart or isopen is False:
                 break
     env.close()

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -1,7 +1,6 @@
 __credits__ = ["Andrea PIERRÉ"]
 
 import math
-import sys
 from typing import Optional
 
 import Box2D
@@ -11,7 +10,7 @@ from Box2D.b2 import contactListener, fixtureDef, polygonShape
 import gym
 from gym import spaces
 from gym.envs.box2d.car_dynamics import Car
-from gym.utils import EzPickle, seeding
+from gym.utils import EzPickle
 
 STATE_W = 96  # less than Atari 160x192
 STATE_H = 96

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -712,7 +712,7 @@ def demo_heuristic_lander(env, seed=None, render=False):
 
         if render:
             still_open = env.render()
-            if still_open == False:
+            if still_open is False:
                 break
 
         if steps % 20 == 0 or done:

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -1,7 +1,6 @@
 __credits__ = ["Andrea PIERRÉ"]
 
 import math
-import sys
 from typing import Optional
 
 import Box2D
@@ -17,7 +16,7 @@ from Box2D.b2 import (
 
 import gym
 from gym import error, spaces
-from gym.utils import EzPickle, seeding
+from gym.utils import EzPickle
 
 FPS = 50
 SCALE = 30.0  # affects how fast-paced the game is, forces should be adjusted as well

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -5,7 +5,6 @@ import numpy as np
 from numpy import cos, pi, sin
 
 from gym import core, spaces
-from gym.utils import seeding
 
 __copyright__ = "Copyright 2013, RLPy http://acl.mit.edu/RLPy"
 __credits__ = [

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -10,7 +10,6 @@ import numpy as np
 
 import gym
 from gym import logger, spaces
-from gym.utils import seeding
 
 
 class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -20,7 +20,6 @@ import numpy as np
 
 import gym
 from gym import spaces
-from gym.utils import seeding
 
 
 class Continuous_MountainCarEnv(gym.Env):

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -9,7 +9,6 @@ import numpy as np
 
 import gym
 from gym import spaces
-from gym.utils import seeding
 
 
 class MountainCarEnv(gym.Env):

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -7,7 +7,6 @@ import numpy as np
 
 import gym
 from gym import spaces
-from gym.utils import seeding
 
 
 class PendulumEnv(gym.Env):

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -7,7 +7,6 @@ import numpy as np
 
 import gym
 from gym import error, spaces
-from gym.utils import seeding
 
 try:
     import mujoco_py

--- a/gym/envs/mujoco/pusher.py
+++ b/gym/envs/mujoco/pusher.py
@@ -1,4 +1,3 @@
-import mujoco_py
 import numpy as np
 
 from gym import utils

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -271,6 +271,8 @@ def load_env_plugins(entry_point: str = "gym.envs") -> None:
 # fmt: off
 # Classic control
 # ----------------------------------------
+
+
 @overload
 def make(id: Literal["CartPole-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload
@@ -284,6 +286,8 @@ def make(id: Literal["Acrobot-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | in
 
 # Box2d
 # ----------------------------------------
+
+
 @overload
 def make(id: Literal["LunarLander-v2", "LunarLanderContinuous-v2"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload
@@ -293,6 +297,8 @@ def make(id: Literal["CarRacing-v1", "CarRacingDomainRandomize-v1"], **kwargs) -
 
 # Toy Text
 # ----------------------------------------
+
+
 @overload
 def make(id: Literal["Blackjack-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload
@@ -304,6 +310,8 @@ def make(id: Literal["Taxi-v3"], **kwargs) -> Env[np.ndarray, np.ndarray | int]:
 
 # Mujoco
 # ----------------------------------------
+
+
 @overload
 def make(id: Literal[
     "Reacher-v2",

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -264,8 +264,10 @@ def load_env_plugins(entry_point: str = "gym.envs") -> None:
 
 
 # fmt: off
+# Classic control
+# ----------------------------------------
 @overload
-def make(id: Literal["CartPole-v0", "CartPole-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
+def make(id: Literal["CartPole-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload
 def make(id: Literal["MountainCar-v0"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload
@@ -277,7 +279,6 @@ def make(id: Literal["Acrobot-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | in
 
 # Box2d
 # ----------------------------------------
-
 @overload
 def make(id: Literal["LunarLander-v2", "LunarLanderContinuous-v2"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload
@@ -287,7 +288,6 @@ def make(id: Literal["CarRacing-v1", "CarRacingDomainRandomize-v1"], **kwargs) -
 
 # Toy Text
 # ----------------------------------------
-
 @overload
 def make(id: Literal["Blackjack-v1"], **kwargs) -> Env[np.ndarray, np.ndarray | int]: ...
 @overload

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -232,7 +232,7 @@ def load_env_plugins(entry_point: str = "gym.envs") -> None:
                 module, attr = plugin.value.split(":", maxsplit=1)
             else:
                 module, attr = plugin.value, None
-        except:
+        except Exception:
             module, attr = None, None
         finally:
             if attr is None:

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -7,6 +7,7 @@ import importlib
 import importlib.util
 import re
 import sys
+import warnings
 from dataclasses import dataclass, field
 from typing import (
     Any,
@@ -225,6 +226,7 @@ def load_env_plugins(entry_point: str = "gym.envs") -> None:
     for plugin in metadata.entry_points(group=entry_point):
         # Python 3.8 doesn't support plugin.module, plugin.attr
         # So we'll have to try and parse this ourselves
+        module, attr = None, None
         try:
             module, attr = plugin.module, plugin.attr  # type: ignore  ## error: Cannot access member "attr" for type "EntryPoint"
         except AttributeError:
@@ -232,7 +234,10 @@ def load_env_plugins(entry_point: str = "gym.envs") -> None:
                 module, attr = plugin.value.split(":", maxsplit=1)
             else:
                 module, attr = plugin.value, None
-        except Exception:
+        except Exception as e:
+            warnings.warn(
+                f"While trying to load plugin `{plugin}` from {entry_point}, an exception occurred: {e}"
+            )
             module, attr = None, None
         finally:
             if attr is None:

--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -5,7 +5,6 @@ import numpy as np
 
 import gym
 from gym import spaces
-from gym.utils import seeding
 
 
 def cmp(a, b):

--- a/gym/envs/toy_text/frozen_lake.py
+++ b/gym/envs/toy_text/frozen_lake.py
@@ -242,7 +242,6 @@ class FrozenLakeEnv(Env):
 
     def _render_gui(self, desc, mode):
         import pygame
-        from pygame.constants import SRCALPHA
 
         if self.window_surface is None:
             pygame.init()

--- a/gym/error.py
+++ b/gym/error.py
@@ -130,7 +130,7 @@ class APIError(Error):
         if http_body and hasattr(http_body, "decode"):
             try:
                 http_body = http_body.decode("utf-8")
-            except:
+            except Exception:
                 http_body = "<Could not decode body as utf-8.>"
 
         self._message = message

--- a/gym/error.py
+++ b/gym/error.py
@@ -1,6 +1,3 @@
-import sys
-
-
 class Error(Exception):
     pass
 

--- a/gym/utils/__init__.py
+++ b/gym/utils/__init__.py
@@ -5,5 +5,5 @@ not intended as API functions, and will not remain stable over time.
 # These submodules should not have any import-time dependencies.
 # We want this since we use `utils` during our import-time sanity checks
 # that verify that our dependencies are actually present.
-from .colorize import colorize
-from .ezpickle import EzPickle
+from gym.utils.colorize import colorize
+from gym.utils.ezpickle import EzPickle

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -5,7 +5,6 @@ from numpy.typing import NDArray
 from pygame import Surface
 from pygame.event import Event
 
-import gym
 from gym import Env, logger
 
 try:

--- a/gym/utils/seeding.py
+++ b/gym/utils/seeding.py
@@ -4,7 +4,7 @@ import struct
 from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
-from numpy.random import Generator
+from numpy.random import Generator  # noqa: F401
 
 from gym import error
 from gym.logger import deprecation

--- a/gym/utils/seeding.py
+++ b/gym/utils/seeding.py
@@ -4,7 +4,6 @@ import struct
 from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
-from numpy.random import Generator  # noqa: F401
 
 from gym import error
 from gym.logger import deprecation

--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -14,7 +14,6 @@ from gym.error import (
     CustomSpaceError,
     NoAsyncCallError,
 )
-from gym.logger import warn
 from gym.vector.utils import (
     CloudpickleWrapper,
     clear_mpi_env_vars,

--- a/gym/vector/async_vector_env.py
+++ b/gym/vector/async_vector_env.py
@@ -638,7 +638,7 @@ def _worker(index, env_fn, pipe, parent_pipe, shared_memory, error_queue):
         while True:
             command, data = pipe.recv()
             if command == "reset":
-                if "return_info" in data and data["return_info"] == True:
+                if "return_info" in data and data["return_info"] is True:
                     observation, info = env.reset(**data)
                     pipe.send(((observation, info), True))
                 else:
@@ -702,7 +702,7 @@ def _worker_shared_memory(index, env_fn, pipe, parent_pipe, shared_memory, error
         while True:
             command, data = pipe.recv()
             if command == "reset":
-                if "return_info" in data and data["return_info"] == True:
+                if "return_info" in data and data["return_info"] is True:
                     observation, info = env.reset(**data)
                     write_to_shared_memory(
                         observation_space, index, observation, shared_memory

--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -106,7 +106,7 @@ class SyncVectorEnv(VectorEnv):
                 kwargs["seed"] = single_seed
             if options is not None:
                 kwargs["options"] = options
-            if return_info == True:
+            if return_info is True:
                 kwargs["return_info"] = return_info
 
             if not return_info:

--- a/gym/vector/sync_vector_env.py
+++ b/gym/vector/sync_vector_env.py
@@ -3,8 +3,6 @@ from typing import List, Optional, Union
 
 import numpy as np
 
-from gym import logger
-from gym.logger import warn
 from gym.vector.utils import concatenate, create_empty_array, iterate
 from gym.vector.vector_env import VectorEnv
 

--- a/gym/vector/utils/numpy_utils.py
+++ b/gym/vector/utils/numpy_utils.py
@@ -4,7 +4,6 @@ from functools import singledispatch
 import numpy as np
 
 from gym.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Space, Tuple
-from gym.vector.utils.spaces import _BaseGymSpaces
 
 __all__ = ["concatenate", "create_empty_array"]
 

--- a/gym/vector/utils/shared_memory.py
+++ b/gym/vector/utils/shared_memory.py
@@ -5,10 +5,8 @@ from functools import singledispatch
 
 import numpy as np
 
-from gym import logger
 from gym.error import CustomSpaceError
-from gym.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Space, Tuple
-from gym.vector.utils.spaces import _BaseGymSpaces
+from gym.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Tuple
 
 __all__ = ["create_shared_memory", "read_from_shared_memory", "write_to_shared_memory"]
 

--- a/gym/vector/vector_env.py
+++ b/gym/vector/vector_env.py
@@ -1,8 +1,7 @@
 from typing import List, Optional, Union
 
 import gym
-from gym.logger import deprecation, warn
-from gym.spaces import Tuple
+from gym.logger import deprecation
 from gym.vector.utils.spaces import batch_space
 
 __all__ = ["VectorEnv"]

--- a/gym/wrappers/__init__.py
+++ b/gym/wrappers/__init__.py
@@ -1,4 +1,3 @@
-from gym import error
 from gym.wrappers.atari_preprocessing import AtariPreprocessing
 from gym.wrappers.autoreset import AutoResetWrapper
 from gym.wrappers.clip_action import ClipAction

--- a/gym/wrappers/frame_stack.py
+++ b/gym/wrappers/frame_stack.py
@@ -1,5 +1,4 @@
 from collections import deque
-from typing import Optional
 
 import numpy as np
 

--- a/gym/wrappers/monitoring/video_recorder.py
+++ b/gym/wrappers/monitoring/video_recorder.py
@@ -418,7 +418,7 @@ class ImageEncoder:
 
         try:
             self.proc.stdin.write(frame.tobytes())
-        except Exception as e:
+        except Exception:
             stdout, stderr = self.proc.communicate()
             logger.error("VideoRecorder encoder failed: %s", stderr)
 

--- a/gym/wrappers/monitoring/video_recorder.py
+++ b/gym/wrappers/monitoring/video_recorder.py
@@ -424,7 +424,7 @@ class ImageEncoder:
                 self.proc.stdin.write(frame.tobytes())
             else:
                 self.proc.stdin.write(frame.tostring())
-        except Exception as e:
+        except Exception:
             stdout, stderr = self.proc.communicate()
             logger.error("VideoRecorder encoder failed: %s", stderr)
 

--- a/gym/wrappers/normalize.py
+++ b/gym/wrappers/normalize.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 import gym

--- a/gym/wrappers/order_enforcing.py
+++ b/gym/wrappers/order_enforcing.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import gym
 
 

--- a/gym/wrappers/record_episode_statistics.py
+++ b/gym/wrappers/record_episode_statistics.py
@@ -1,6 +1,5 @@
 import time
 from collections import deque
-from typing import Optional
 
 import numpy as np
 

--- a/gym/wrappers/record_video.py
+++ b/gym/wrappers/record_video.py
@@ -1,5 +1,5 @@
 import os
-from typing import Callable, Optional
+from typing import Callable
 
 import gym
 from gym import logger

--- a/gym/wrappers/time_aware_observation.py
+++ b/gym/wrappers/time_aware_observation.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import ObservationWrapper

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import gym
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 # Don't import gym module here, since deps may not be installed
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "gym"))
-from version import VERSION
+from version import VERSION  # noqa:E402
 
 # Environment-specific dependencies.
 extras = {

--- a/tests/envs/spec_list.py
+++ b/tests/envs/spec_list.py
@@ -11,7 +11,7 @@ SKIP_MUJOCO_WARNING_MESSAGE = (
 skip_mujoco = not (os.environ.get("MUJOCO_KEY"))
 if not skip_mujoco:
     try:
-        import mujoco_py
+        import mujoco_py  # noqa:F401
     except ImportError:
         skip_mujoco = True
 
@@ -24,12 +24,12 @@ def should_skip_env_spec_for_tests(spec):
     if skip_mujoco and ep.startswith("gym.envs.mujoco"):
         return True
     try:
-        import gym.envs.atari
+        import gym.envs.atari  # noqa:F401
     except ImportError:
         if ep.startswith("gym.envs.atari"):
             return True
     try:
-        import Box2D
+        import Box2D  # noqa:F401
     except ImportError:
         if ep.startswith("gym.envs.box2d"):
             return True

--- a/tests/envs/test_action_dim_check.py
+++ b/tests/envs/test_action_dim_check.py
@@ -1,5 +1,3 @@
-import pickle
-
 import pytest
 
 from gym import envs

--- a/tests/envs/test_atari_legacy_env_specs.py
+++ b/tests/envs/test_atari_legacy_env_specs.py
@@ -1,10 +1,10 @@
-import pytest
-
-pytest.importorskip("gym.envs.atari")
-
 from itertools import product
 
+import pytest
+
 from gym.envs.registration import registry
+
+pytest.importorskip("gym.envs.atari")
 
 
 def test_ale_legacy_env_specs():

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -61,7 +61,7 @@ def test_env(spec):
 @pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_reset_info(spec):
 
-    with pytest.warns():
+    with pytest.warns(None):
         env = spec.make()
 
     ob_space = env.observation_space

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -61,7 +61,7 @@ def test_env(spec):
 @pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_reset_info(spec):
 
-    with pytest.warns(None) as warnings:
+    with pytest.warns():
         env = spec.make()
 
     ob_space = env.observation_space

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -78,13 +78,12 @@ def test_reset_info(spec):
 # Run a longer rollout on some environments
 def test_random_rollout():
     for env in [envs.make("CartPole-v1"), envs.make("FrozenLake-v1")]:
-        agent = lambda ob: env.action_space.sample()
         ob = env.reset()
         for _ in range(10):
             assert env.observation_space.contains(ob)
-            a = agent(ob)
-            assert env.action_space.contains(a)
-            (ob, _reward, done, _info) = env.step(a)
+            action = env.action_space.sample()
+            assert env.action_space.contains(action)
+            (ob, _reward, done, _info) = env.step(action)
             if done:
                 break
         env.close()

--- a/tests/envs/test_frozenlake_dfs.py
+++ b/tests/envs/test_frozenlake_dfs.py
@@ -1,6 +1,3 @@
-import numpy as np
-import pytest
-
 from gym.envs.toy_text.frozen_lake import generate_random_map
 
 

--- a/tests/envs/test_registration.py
+++ b/tests/envs/test_registration.py
@@ -2,9 +2,8 @@ import pytest
 
 import gym
 from gym import envs, error
-from gym.envs import register, registration, registry, spec
+from gym.envs import register, spec
 from gym.envs.classic_control import cartpole
-from gym.envs.registration import EnvSpec
 
 
 class ArgumentEnv(gym.Env):

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -569,20 +569,20 @@ def test_infinite_space(space):
     # but floats are unbounded for infinite
     if np.any(space.high != 0):
         assert (
-            space.is_bounded("above") == False
+            space.is_bounded("above") is False
         ), "inf upper bound supposed to be unbounded"
     else:
         assert (
-            space.is_bounded("above") == True
+            space.is_bounded("above") is True
         ), "non-inf upper bound supposed to be bounded"
 
     if np.any(space.low != 0):
         assert (
-            space.is_bounded("below") == False
+            space.is_bounded("below") is False
         ), "inf lower bound supposed to be unbounded"
     else:
         assert (
-            space.is_bounded("below") == True
+            space.is_bounded("below") is True
         ), "non-inf lower bound supposed to be bounded"
 
     # check for dtype

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -67,7 +67,7 @@ def test_play_relevant_keys_no_mapping():
     env = DummyPlayEnv()
     env.spec = DummyEnvSpec("DummyPlayEnv")
 
-    with pytest.raises(MissingKeysToAction) as info:
+    with pytest.raises(MissingKeysToAction):
         PlayableGame(env)
 
 

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass, field
-from typing import Callable, Optional, Tuple
+from dataclasses import dataclass
+from typing import Callable
 
 import numpy as np
 import pygame
@@ -76,7 +76,7 @@ def test_play_relevant_keys_with_env_attribute():
     env = DummyPlayEnv()
     env.get_keys_to_action = dummy_keys_to_action
     game = PlayableGame(env)
-    assert game.relevant_keys == {97, 100}
+    assert game.relevant_keys == {RELEVANT_KEY_1, RELEVANT_KEY_2}
 
 
 def test_video_size_no_zoom():
@@ -134,33 +134,6 @@ def test_keyboard_keyup_event():
     event = Event(pygame.KEYUP, {"key": RELEVANT_KEY_1})
     game.process_event(event)
     assert game.pressed_keys == []
-
-
-def test_play_loop():
-    # set of key events to inject into the play loop as callback
-    callback_events = [
-        Event(KEYDOWN, {"key": RELEVANT_KEY_1}),
-        Event(KEYDOWN, {"key": RELEVANT_KEY_1}),
-        Event(QUIT),
-    ]
-
-    def callback(obs_t, obs_tp1, action, rew, done, info):
-        event.post(callback_events.pop(0))
-        return obs_t, obs_tp1, action, rew, done, info
-
-    env = DummyPlayEnv()
-    cumulative_env_reward = 0
-    for s in range(
-        len(callback_events)
-    ):  # we run the same number of steps executed with play()
-        _, rew, _, _ = env.step(None)
-        cumulative_env_reward += rew
-
-    env_play = DummyPlayEnv()
-    status = PlayStatus(callback)
-    play(env_play, callback=status.callback, keys_to_action=dummy_keys_to_action())
-
-    assert status.cumulative_reward == cumulative_env_reward
 
 
 def test_play_loop_real_env():

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -96,18 +96,18 @@ def test_keyboard_quit_event():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
     event = Event(pygame.KEYDOWN, {"key": pygame.K_ESCAPE})
-    assert game.running == True
+    assert game.running is True
     game.process_event(event)
-    assert game.running == False
+    assert game.running is False
 
 
 def test_pygame_quit_event():
     env = DummyPlayEnv()
     game = PlayableGame(env, dummy_keys_to_action())
     event = Event(pygame.QUIT)
-    assert game.running == True
+    assert game.running is True
     game.process_event(event)
-    assert game.running == False
+    assert game.running is False
 
 
 def test_keyboard_relevant_keydown_event():

--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -167,7 +167,7 @@ def test_reset_timeout_async_vector_env(shared_memory):
         try:
             env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)
             env.reset_async()
-            observations = env.reset_wait(timeout=0.1)
+            env.reset_wait(timeout=0.1)
         finally:
             env.close(terminate=True)
 
@@ -178,7 +178,7 @@ def test_step_timeout_async_vector_env(shared_memory):
     with pytest.raises(TimeoutError):
         try:
             env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)
-            observations = env.reset()
+            env.reset()
             env.step_async([0.1, 0.1, 0.3, 0.1])
             observations, rewards, dones, _ = env.step_wait(timeout=0.1)
         finally:
@@ -192,7 +192,7 @@ def test_reset_out_of_order_async_vector_env(shared_memory):
     with pytest.raises(NoAsyncCallError):
         try:
             env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)
-            observations = env.reset_wait()
+            env.reset_wait()
         except NoAsyncCallError as exception:
             assert exception.name == "reset"
             raise
@@ -203,7 +203,7 @@ def test_reset_out_of_order_async_vector_env(shared_memory):
         try:
             env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)
             actions = env.action_space.sample()
-            observations = env.reset()
+            env.reset()
             env.step_async(actions)
             env.reset_async()
         except NoAsyncCallError as exception:
@@ -248,7 +248,7 @@ def test_already_closed_async_vector_env(shared_memory):
     with pytest.raises(ClosedEnvironmentError):
         env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)
         env.close()
-        observations = env.reset()
+        env.reset()
 
 
 @pytest.mark.parametrize("shared_memory", [True, False])

--- a/tests/vector/test_shared_memory.py
+++ b/tests/vector/test_shared_memory.py
@@ -65,8 +65,7 @@ def test_create_shared_memory(space, expected_type, n, ctx):
             # Assert the length of the array
             assert len(lhs[:]) == n * len(rhs[:])
             # Assert the data type
-            assert type(lhs[0]) == type(rhs[0])  # noqa: E721
-
+            assert isinstance(lhs[0], type(rhs[0]))
         else:
             raise TypeError(f"Got unknown type `{type(lhs)}`.")
 

--- a/tests/vector/test_shared_memory.py
+++ b/tests/vector/test_shared_memory.py
@@ -83,7 +83,7 @@ def test_create_shared_memory(space, expected_type, n, ctx):
 def test_create_shared_memory_custom_space(n, ctx, space):
     ctx = mp if (ctx is None) else mp.get_context(ctx)
     with pytest.raises(CustomSpaceError):
-        shared_memory = create_shared_memory(space, n=n, ctx=ctx)
+        create_shared_memory(space, n=n, ctx=ctx)
 
 
 @pytest.mark.parametrize(

--- a/tests/vector/test_spaces.py
+++ b/tests/vector/test_spaces.py
@@ -5,7 +5,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from gym import Space
-from gym.spaces import Box, Dict, Discrete, MultiDiscrete, Tuple
+from gym.spaces import Box, Dict, MultiDiscrete, Tuple
 from gym.vector.utils.spaces import batch_space, iterate
 from tests.vector.utils import CustomSpace, assert_rng_equal, custom_spaces, spaces
 

--- a/tests/vector/test_vector_env_wrapper.py
+++ b/tests/vector/test_vector_env_wrapper.py
@@ -1,4 +1,3 @@
-import gym
 from gym.vector import VectorEnvWrapper, make
 
 

--- a/tests/wrappers/nested_dict_test.py
+++ b/tests/wrappers/nested_dict_test.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 import gym
-from gym.spaces import Box, Dict, Discrete, Tuple
+from gym.spaces import Box, Dict, Tuple
 from gym.wrappers import FilterObservation, FlattenObservation
 
 

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -22,7 +22,9 @@ class DummyResetEnv(gym.Env):
     metadata = {}
 
     def __init__(self):
-        self.action_space = gym.spaces.Box(low=np.array([-1.0]), high=np.array([1.0]))
+        self.action_space = gym.spaces.Box(
+            low=np.array([-1.0]), high=np.array([1.0]), dtype=np.float64
+        )
         self.observation_space = gym.spaces.Box(
             low=np.array([-1.0]), high=np.array([1.0])
         )
@@ -62,6 +64,7 @@ def test_autoreset_reset_info():
     obs, info = env.reset(return_info=True)
     assert ob_space.contains(obs)
     assert isinstance(info, dict)
+    env.close()
 
 
 @pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
@@ -73,7 +76,7 @@ def test_make_autoreset_true(spec):
     Note: This test assumes that all first-party environments will terminate in a finite
     amount of time with random actions, which is true as of the time of adding this test.
     """
-    with pytest.warns():
+    with pytest.warns(None):
         env = spec.make(autoreset=True)
 
     env.reset(seed=0)
@@ -87,22 +90,23 @@ def test_make_autoreset_true(spec):
 
     assert isinstance(env, AutoResetWrapper)
     assert env.unwrapped.reset.called
+    env.close()
 
 
 @pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_make_autoreset_false(spec):
-    env = None
-    with pytest.warns():
+    with pytest.warns(None):
         env = spec.make(autoreset=False)
     assert not isinstance(env, AutoResetWrapper)
+    env.close()
 
 
 @pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_make_autoreset_default_false(spec):
-    env = None
-    with pytest.warns():
+    with pytest.warns(None):
         env = spec.make()
     assert not isinstance(env, AutoResetWrapper)
+    env.close()
 
 
 def test_autoreset_autoreset():
@@ -141,3 +145,4 @@ def test_autoreset_autoreset():
     assert reward == 0
     assert done is False
     assert info == {"count": 2}
+    env.close()

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -115,16 +115,16 @@ def test_autoreset_autoreset():
     obs, reward, done, info = env.step(action)
     assert obs == np.array([1])
     assert reward == 0
-    assert done == False
+    assert done is False
     assert info == {"count": 1}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([2])
-    assert done == False
+    assert done is False
     assert reward == 0
     assert info == {"count": 2}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([0])
-    assert done == True
+    assert done is True
     assert reward == 1
     assert info == {
         "count": 0,
@@ -134,10 +134,10 @@ def test_autoreset_autoreset():
     obs, reward, done, info = env.step(action)
     assert obs == np.array([1])
     assert reward == 0
-    assert done == False
+    assert done is False
     assert info == {"count": 1}
     obs, reward, done, info = env.step(action)
     assert obs == np.array([2])
     assert reward == 0
-    assert done == False
+    assert done is False
     assert info == {"count": 2}

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -1,4 +1,3 @@
-import types
 from typing import Optional
 from unittest.mock import MagicMock
 

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -73,12 +73,10 @@ def test_make_autoreset_true(spec):
     Note: This test assumes that all first-party environments will terminate in a finite
     amount of time with random actions, which is true as of the time of adding this test.
     """
-    env = None
-    with pytest.warns(None) as warnings:
+    with pytest.warns():
         env = spec.make(autoreset=True)
 
-    ob_space = env.observation_space
-    obs = env.reset(seed=0)
+    env.reset(seed=0)
     env.action_space.seed(0)
 
     env.unwrapped.reset = MagicMock(side_effect=env.unwrapped.reset)
@@ -94,7 +92,7 @@ def test_make_autoreset_true(spec):
 @pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_make_autoreset_false(spec):
     env = None
-    with pytest.warns(None) as warnings:
+    with pytest.warns():
         env = spec.make(autoreset=False)
     assert not isinstance(env, AutoResetWrapper)
 
@@ -102,7 +100,7 @@ def test_make_autoreset_false(spec):
 @pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_make_autoreset_default_false(spec):
     env = None
-    with pytest.warns(None) as warnings:
+    with pytest.warns():
         env = spec.make()
     assert not isinstance(env, AutoResetWrapper)
 

--- a/tests/wrappers/test_clip_action.py
+++ b/tests/wrappers/test_clip_action.py
@@ -6,9 +6,8 @@ from gym.wrappers import ClipAction
 
 def test_clip_action():
     # mountaincar: action-based rewards
-    make_env = lambda: gym.make("MountainCarContinuous-v0")
-    env = make_env()
-    wrapped_env = ClipAction(make_env())
+    env = gym.make("MountainCarContinuous-v0")
+    wrapped_env = ClipAction(gym.make("MountainCarContinuous-v0"))
 
     seed = 0
 

--- a/tests/wrappers/test_frame_stack.py
+++ b/tests/wrappers/test_frame_stack.py
@@ -1,8 +1,5 @@
-import pytest
-
-pytest.importorskip("gym.envs.atari")
-
 import numpy as np
+import pytest
 
 import gym
 from gym.wrappers import FrameStack
@@ -11,6 +8,9 @@ try:
     import lz4
 except ImportError:
     lz4 = None
+
+
+pytest.importorskip("gym.envs.atari")
 
 
 @pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v1", "Pong-v0"])

--- a/tests/wrappers/test_order_enforcing.py
+++ b/tests/wrappers/test_order_enforcing.py
@@ -1,6 +1,3 @@
-import numpy as np
-import pytest
-
 import gym
 from gym.wrappers import OrderEnforcing
 

--- a/tests/wrappers/test_record_episode_statistics.py
+++ b/tests/wrappers/test_record_episode_statistics.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 import gym

--- a/tests/wrappers/test_record_video.py
+++ b/tests/wrappers/test_record_video.py
@@ -1,15 +1,8 @@
 import os
 import shutil
 
-import numpy as np
-import pytest
-
 import gym
-from gym.wrappers import (
-    RecordEpisodeStatistics,
-    RecordVideo,
-    capped_cubic_video_schedule,
-)
+from gym.wrappers import capped_cubic_video_schedule
 
 
 def test_record_video_using_default_trigger():

--- a/tests/wrappers/test_time_limit.py
+++ b/tests/wrappers/test_time_limit.py
@@ -1,6 +1,3 @@
-import numpy as np
-import pytest
-
 import gym
 from gym.wrappers import TimeLimit
 

--- a/tests/wrappers/test_transform_observation.py
+++ b/tests/wrappers/test_transform_observation.py
@@ -7,7 +7,9 @@ from gym.wrappers import TransformObservation
 
 @pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v1"])
 def test_transform_observation(env_id):
-    affine_transform = lambda x: 3 * x + 2
+    def affine_transform(x):
+        return 3 * x + 2
+
     env = gym.make(env_id)
     wrapped_env = TransformObservation(
         gym.make(env_id), lambda obs: affine_transform(obs)


### PR DESCRIPTION
# Description

While investigating the pre-commit to add docstring checks and saw that the pre-commit flake8 had a very large number of ignores for seeming no reason. 
So I have experimented with the errors that each was giving and if the problems could be simply addressed with no backward compatibility issues

This is the original list of ignores and their meaning
- E203 = whitespace before ‘,’, ‘;’, or ‘:‘
- E402 = module level import not at top of file
- E712 = comparison to True should be ‘if cond is True:’ or ‘if cond:’
- E722 = do not use bare except, specify exception instead
- E731 = do not assign a lambda expression, use a def
- E741 = do not use variables named ‘l’, ‘O’, or ‘I’
- F401 = `module` imported but unused
- F403 = 'from `module` import *' used; unable to detect undefined names
- F405 = `name` may be undefined, or defined from star imports: `module`
- F524 = `.format(...)` mixing automatic and manual numbering
- F841 = local variable `name` is assigned to but never used
- W503 = line break before binary operator
- E302 = expected 2 blank lines, found 0
- E704 = multiple statements on one line (def)

Source
* https://flake8.pycqa.org/en/3.9.2/user/error-codes.html
* https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes

## Type of change

Removed ignores
* E402 - This is an issue primary with `importorskip` however these can be moved to after the imports so it doesn't matter. Of the four remaining `noqa` comments in the code, all of them are for E402, however, these are rare occurrence. This is one of the ignores that could be reasonably added again. 
* E712 - This is a simple change to find all of the cases of `bool == bool` and change to `bool is bool` and has no impact on implementation has `is` is used already by python behind the scenes
* E722 - There were two cases where a bare except as used and were replaced with `Exception`. The only cases where an exception thrown is not a sub-class of `Exception` is `KeyboardInterrupt` and `SystemExit` [source](https://stackoverflow.com/questions/54948548/what-is-wrong-with-using-a-bare-except). Therefore this shouldn't be an issue
* E731 - Again, in a couple of places where lambda's were used, most were unnecessary and replaced with def or not needed
* F403 - Was not throwing an error so just removed
* F405 - Was not throwing an error so just removed
* F524 - Was not throwing an error so just removed
* F841 - In a couple of tests, variables were defined but never used, removed the variables that were unused. If they want to be defined then they should be used in the tests. 

per-file-ignores
* F401 - A majority of the modifications in this work were to remove modules imported but not used. However for the `__init__.py` files then their whole purpose is to have unused import statements. Therefore I have added every `__init__.py` file to `--per-file-ignores` to ignore only this error
* E302 - In `gym/envs/registration.py`, we overload the make function with all of the environments and for styling reasons, it looks nicer to have a comment that is not separated by 2 lines. Therefore, we ignore this style for only registration.py

Ignores
* E203 - Black is causing two parts of the code to have whitespaces after `:` so this is necessary to keep as this could happen in the future as well by black that is uncaused by the programmer. Therefore, safer to keep as an ignore
* E741 - Currently in `BipedalWalker` and `Pendulum` there are single character variables that I dont know their meaning so I have left them. This could be removed quite easily. @RedTachyon do you know what `Pendulum.l` variable means? The bipedal walker chaneg is much simplier but I haven't made the change yet.  
* W503 - Like E203, black likes to spread a statement across multiple lines. Therefore, W503 is ignored to prevent users running into this style issue again and having to add # noqa everywhere. 

This is the updated ignore list (and could be reduced by at least one) 
```
'--per-file-ignores=*/__init__.py:F401 gym/envs/registration.py:E704 E302'
--ignore=E203,W503,E741
```

Of the remaining code, there are only four `noqa` comments (3 in spec_list.py and 1 in setup.py) so the code is following flake8 much closer than before

I suspect there is good reason to keep a couple of the stylings that I have removed but I have just tried to remove all that possible without major problems with the code now or in the future. 