### PR TITLE
Place try except around all imports of pygame 

### DIFF
--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -3,20 +3,25 @@ __credits__ = ["Andrea PIERRÉ"]
 import math
 from typing import Optional
 
-import Box2D
 import numpy as np
-from Box2D.b2 import (
-    circleShape,
-    contactListener,
-    edgeShape,
-    fixtureDef,
-    polygonShape,
-    revoluteJointDef,
-)
 
 import gym
 from gym import error, spaces
 from gym.utils import EzPickle
+
+try:
+    import Box2D
+    from Box2D.b2 import (
+        circleShape,
+        contactListener,
+        edgeShape,
+        fixtureDef,
+        polygonShape,
+        revoluteJointDef,
+    )
+except ImportError:
+    raise ImportError("Box2D is not installed, run `pip install gym[box2d]`")
+
 
 FPS = 50
 SCALE = 30.0  # affects how fast-paced the game is, forces should be adjusted as well
@@ -586,8 +591,11 @@ class BipedalWalker(gym.Env, EzPickle):
         return np.array(state, dtype=np.float32), reward, done, {}
 
     def render(self, mode: str = "human"):
-        import pygame
-        from pygame import gfxdraw
+        try:
+            import pygame
+            from pygame import gfxdraw
+        except ImportError:
+            raise ImportError("Pygame is not installed, run `pip install gym[box2d]`")
 
         if self.screen is None:
             pygame.init()

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import gym
 from gym import error, spaces
+from gym.error import DependencyNotInstalled
 from gym.utils import EzPickle
 
 try:
@@ -20,7 +21,7 @@ try:
         revoluteJointDef,
     )
 except ImportError:
-    raise ImportError("Box2D is not installed, run `pip install gym[box2d]`")
+    raise DependencyNotInstalled("box2D is not installed, run `pip install gym[box2d]`")
 
 
 FPS = 50
@@ -595,7 +596,9 @@ class BipedalWalker(gym.Env, EzPickle):
             import pygame
             from pygame import gfxdraw
         except ImportError:
-            raise ImportError("Pygame is not installed, run `pip install gym[box2d]`")
+            raise DependencyNotInstalled(
+                "pygame is not installed, run `pip install gym[box2d]`"
+            )
 
         if self.screen is None:
             pygame.init()

--- a/gym/envs/box2d/car_dynamics.py
+++ b/gym/envs/box2d/car_dynamics.py
@@ -10,7 +10,12 @@ Created by Oleg Klimov
 import math
 
 import numpy as np
-from Box2D.b2 import fixtureDef, polygonShape, revoluteJointDef
+
+try:
+    from Box2D.b2 import fixtureDef, polygonShape, revoluteJointDef
+except ImportError:
+    raise ImportError("Box2D is not installed, run `pip install gym[box2d]`")
+
 
 SIZE = 0.02
 ENGINE_POWER = 100000000 * SIZE * SIZE

--- a/gym/envs/box2d/car_dynamics.py
+++ b/gym/envs/box2d/car_dynamics.py
@@ -11,10 +11,12 @@ import math
 
 import numpy as np
 
+from gym.error import DependencyNotInstalled
+
 try:
     from Box2D.b2 import fixtureDef, polygonShape, revoluteJointDef
 except ImportError:
-    raise ImportError("Box2D is not installed, run `pip install gym[box2d]`")
+    raise DependencyNotInstalled("box2D is not installed, run `pip install gym[box2d]`")
 
 
 SIZE = 0.02

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -3,14 +3,19 @@ __credits__ = ["Andrea PIERRÉ"]
 import math
 from typing import Optional
 
-import Box2D
 import numpy as np
-from Box2D.b2 import contactListener, fixtureDef, polygonShape
 
 import gym
 from gym import spaces
 from gym.envs.box2d.car_dynamics import Car
 from gym.utils import EzPickle
+
+try:
+    import Box2D
+    from Box2D.b2 import contactListener, fixtureDef, polygonShape
+except ImportError:
+    raise ImportError("Box2D is not installed, run `pip install gym[box2d]`")
+
 
 STATE_W = 96  # less than Atari 160x192
 STATE_H = 96
@@ -462,7 +467,10 @@ class CarRacing(gym.Env, EzPickle):
         return self.state, step_reward, done, {}
 
     def render(self, mode: str = "human"):
-        import pygame
+        try:
+            import pygame
+        except ImportError:
+            raise ImportError("Pygame is not installed, run `pip install gym[box2d]`")
 
         pygame.font.init()
 

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -8,13 +8,14 @@ import numpy as np
 import gym
 from gym import spaces
 from gym.envs.box2d.car_dynamics import Car
+from gym.error import DependencyNotInstalled
 from gym.utils import EzPickle
 
 try:
     import Box2D
     from Box2D.b2 import contactListener, fixtureDef, polygonShape
 except ImportError:
-    raise ImportError("Box2D is not installed, run `pip install gym[box2d]`")
+    raise DependencyNotInstalled("box2D is not installed, run `pip install gym[box2d]`")
 
 
 STATE_W = 96  # less than Atari 160x192
@@ -470,7 +471,9 @@ class CarRacing(gym.Env, EzPickle):
         try:
             import pygame
         except ImportError:
-            raise ImportError("Pygame is not installed, run `pip install gym[box2d]`")
+            raise DependencyNotInstalled(
+                "pygame is not installed, run `pip install gym[box2d]`"
+            )
 
         pygame.font.init()
 

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -3,20 +3,24 @@ __credits__ = ["Andrea PIERRÉ"]
 import math
 from typing import Optional
 
-import Box2D
 import numpy as np
-from Box2D.b2 import (
-    circleShape,
-    contactListener,
-    edgeShape,
-    fixtureDef,
-    polygonShape,
-    revoluteJointDef,
-)
 
 import gym
 from gym import error, spaces
 from gym.utils import EzPickle
+
+try:
+    import Box2D
+    from Box2D.b2 import (
+        circleShape,
+        contactListener,
+        edgeShape,
+        fixtureDef,
+        polygonShape,
+        revoluteJointDef,
+    )
+except ImportError:
+    raise ImportError("Box2d is not installed, run `pip install gym[box2d]`")
 
 FPS = 50
 SCALE = 30.0  # affects how fast-paced the game is, forces should be adjusted as well
@@ -535,8 +539,11 @@ class LunarLander(gym.Env, EzPickle):
         return np.array(state, dtype=np.float32), reward, done, {}
 
     def render(self, mode="human"):
-        import pygame
-        from pygame import gfxdraw
+        try:
+            import pygame
+            from pygame import gfxdraw
+        except ImportError:
+            raise ImportError("Pygame is not installed, run `pip install gym[box2d]`")
 
         if self.screen is None:
             pygame.init()

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import gym
 from gym import error, spaces
+from gym.error import DependencyNotInstalled
 from gym.utils import EzPickle
 
 try:
@@ -20,7 +21,7 @@ try:
         revoluteJointDef,
     )
 except ImportError:
-    raise ImportError("Box2d is not installed, run `pip install gym[box2d]`")
+    raise DependencyNotInstalled("box2d is not installed, run `pip install gym[box2d]`")
 
 FPS = 50
 SCALE = 30.0  # affects how fast-paced the game is, forces should be adjusted as well
@@ -543,7 +544,9 @@ class LunarLander(gym.Env, EzPickle):
             import pygame
             from pygame import gfxdraw
         except ImportError:
-            raise ImportError("Pygame is not installed, run `pip install gym[box2d]`")
+            raise DependencyNotInstalled(
+                "pygame is not installed, run `pip install gym[box2d]`"
+            )
 
         if self.screen is None:
             pygame.init()

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy import cos, pi, sin
 
 from gym import core, spaces
+from gym.error import DependencyNotInstalled
 
 __copyright__ = "Copyright 2013, RLPy http://acl.mit.edu/RLPy"
 __credits__ = [
@@ -268,7 +269,7 @@ class AcrobotEnv(core.Env):
             import pygame
             from pygame import gfxdraw
         except ImportError:
-            raise ImportError(
+            raise DependencyNotInstalled(
                 "pygame is not installed, run `pip install gym[classic_control]`"
             )
 

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -264,8 +264,13 @@ class AcrobotEnv(core.Env):
         return (dtheta1, dtheta2, ddtheta1, ddtheta2, 0.0)
 
     def render(self, mode="human"):
-        import pygame
-        from pygame import gfxdraw
+        try:
+            import pygame
+            from pygame import gfxdraw
+        except ImportError:
+            raise ImportError(
+                "pygame is not installed, run `pip install gym[classic_control]`"
+            )
 
         if self.screen is None:
             pygame.init()

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -10,6 +10,7 @@ import numpy as np
 
 import gym
 from gym import logger, spaces
+from gym.error import DependencyNotInstalled
 
 
 class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
@@ -188,7 +189,7 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
             import pygame
             from pygame import gfxdraw
         except ImportError:
-            raise ImportError(
+            raise DependencyNotInstalled(
                 "pygame is not installed, run `pip install gym[classic_control]`"
             )
 

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -184,8 +184,13 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
             return np.array(self.state, dtype=np.float32), {}
 
     def render(self, mode="human"):
-        import pygame
-        from pygame import gfxdraw
+        try:
+            import pygame
+            from pygame import gfxdraw
+        except ImportError:
+            raise ImportError(
+                "pygame is not installed, run `pip install gym[classic_control]`"
+            )
 
         screen_width = 600
         screen_height = 400

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -20,6 +20,7 @@ import numpy as np
 
 import gym
 from gym import spaces
+from gym.error import DependencyNotInstalled
 
 
 class Continuous_MountainCarEnv(gym.Env):
@@ -176,7 +177,7 @@ class Continuous_MountainCarEnv(gym.Env):
             import pygame
             from pygame import gfxdraw
         except ImportError:
-            raise ImportError(
+            raise DependencyNotInstalled(
                 "pygame is not installed, run `pip install gym[classic_control]`"
             )
 

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -172,8 +172,13 @@ class Continuous_MountainCarEnv(gym.Env):
         return np.sin(3 * xs) * 0.45 + 0.55
 
     def render(self, mode="human"):
-        import pygame
-        from pygame import gfxdraw
+        try:
+            import pygame
+            from pygame import gfxdraw
+        except ImportError:
+            raise ImportError(
+                "pygame is not installed, run `pip install gym[classic_control]`"
+            )
 
         screen_width = 600
         screen_height = 400

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -148,8 +148,13 @@ class MountainCarEnv(gym.Env):
         return np.sin(3 * xs) * 0.45 + 0.55
 
     def render(self, mode="human"):
-        import pygame
-        from pygame import gfxdraw
+        try:
+            import pygame
+            from pygame import gfxdraw
+        except ImportError:
+            raise ImportError(
+                "pygame is not installed, run `pip install gym[classic_control]`"
+            )
 
         screen_width = 600
         screen_height = 400

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -9,6 +9,7 @@ import numpy as np
 
 import gym
 from gym import spaces
+from gym.error import DependencyNotInstalled
 
 
 class MountainCarEnv(gym.Env):
@@ -152,7 +153,7 @@ class MountainCarEnv(gym.Env):
             import pygame
             from pygame import gfxdraw
         except ImportError:
-            raise ImportError(
+            raise DependencyNotInstalled(
                 "pygame is not installed, run `pip install gym[classic_control]`"
             )
 

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import gym
 from gym import spaces
+from gym.error import DependencyNotInstalled
 
 
 class PendulumEnv(gym.Env):
@@ -144,7 +145,7 @@ class PendulumEnv(gym.Env):
             import pygame
             from pygame import gfxdraw
         except ImportError:
-            raise ImportError(
+            raise DependencyNotInstalled(
                 "pygame is not installed, run `pip install gym[classic_control]`"
             )
 

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -140,8 +140,13 @@ class PendulumEnv(gym.Env):
         return np.array([np.cos(theta), np.sin(theta), thetadot], dtype=np.float32)
 
     def render(self, mode="human"):
-        import pygame
-        from pygame import gfxdraw
+        try:
+            import pygame
+            from pygame import gfxdraw
+        except ImportError:
+            raise ImportError(
+                "pygame is not installed, run `pip install gym[classic_control]`"
+            )
 
         if self.screen is None:
             pygame.init()

--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import gym
 from gym import spaces
+from gym.error import DependencyNotInstalled
 
 
 def cmp(a, b):
@@ -173,7 +174,7 @@ class BlackjackEnv(gym.Env):
         try:
             import pygame
         except ImportError:
-            raise ImportError(
+            raise DependencyNotInstalled(
                 "pygame is not installed, run `pip install gym[toy_text]`"
             )
 

--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -170,7 +170,12 @@ class BlackjackEnv(gym.Env):
             return self._get_obs(), {}
 
     def render(self, mode="human"):
-        import pygame
+        try:
+            import pygame
+        except ImportError:
+            raise ImportError(
+                "pygame is not installed, run `pip install gym[toy_text]`"
+            )
 
         player_sum, dealer_card_value, usable_ace = self._get_obs()
         screen_width, screen_height = 600, 500

--- a/gym/envs/toy_text/frozen_lake.py
+++ b/gym/envs/toy_text/frozen_lake.py
@@ -241,7 +241,12 @@ class FrozenLakeEnv(Env):
             return self._render_gui(desc, mode)
 
     def _render_gui(self, desc, mode):
-        import pygame
+        try:
+            import pygame
+        except ImportError:
+            raise ImportError(
+                "pygame is not installed, run `pip install gym[toy_text]`"
+            )
 
         if self.window_surface is None:
             pygame.init()

--- a/gym/envs/toy_text/frozen_lake.py
+++ b/gym/envs/toy_text/frozen_lake.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from gym import Env, spaces, utils
 from gym.envs.toy_text.utils import categorical_sample
+from gym.error import DependencyNotInstalled
 
 LEFT = 0
 DOWN = 1
@@ -244,7 +245,7 @@ class FrozenLakeEnv(Env):
         try:
             import pygame
         except ImportError:
-            raise ImportError(
+            raise DependencyNotInstalled(
                 "pygame is not installed, run `pip install gym[toy_text]`"
             )
 

--- a/gym/envs/toy_text/taxi.py
+++ b/gym/envs/toy_text/taxi.py
@@ -239,7 +239,7 @@ class TaxiEnv(Env):
 
     def _render_gui(self, mode):
         try:
-            import pygame
+            import pygame  # dependency to pygame only if rendering with human
         except ImportError:
             raise DependencyNotInstalled(
                 "pygame is not installed, run `pip install gym[toy_text]`"

--- a/gym/envs/toy_text/taxi.py
+++ b/gym/envs/toy_text/taxi.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from gym import Env, spaces, utils
 from gym.envs.toy_text.utils import categorical_sample
+from gym.error import DependencyNotInstalled
 
 MAP = [
     "+---------+",
@@ -240,7 +241,7 @@ class TaxiEnv(Env):
         try:
             import pygame
         except ImportError:
-            raise ImportError(
+            raise DependencyNotInstalled(
                 "pygame is not installed, run `pip install gym[toy_text]`"
             )
 

--- a/gym/envs/toy_text/taxi.py
+++ b/gym/envs/toy_text/taxi.py
@@ -237,7 +237,12 @@ class TaxiEnv(Env):
             return self._render_gui(mode)
 
     def _render_gui(self, mode):
-        import pygame  # dependency to pygame only if rendering with human
+        try:
+            import pygame
+        except ImportError:
+            raise ImportError(
+                "pygame is not installed, run `pip install gym[toy_text]`"
+            )
 
         if self.window is None:
             pygame.init()


### PR DESCRIPTION
Currently, if a user has not installed pygame or another of the optional modules then an error is thrown without a reason
This PR wraps all of these imports with a try except that will raise the import error with a helpful message saying that the appropriate `pip install gym[...]` needs to be run. 

Inspired by https://github.com/openai/gym/issues/2781