### PR TITLE
Adding docstring and tests to `PlayPlot`

### DIFF
--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import pygame
 from numpy.typing import NDArray
@@ -112,18 +112,6 @@ def play(
     verifying that the frame-level preprocessing does not render the game
     unplayable.
 
-    If you wish to plot real time statistics as you play, you can use
-    gym.utils.play.PlayPlot. Here's a sample code for plotting the reward
-    for last 5 second of gameplay.
-
-        def callback(obs_t, obs_tp1, action, rew, done, info):
-            return [rew,]
-        plotter = PlayPlot(callback, 30 * 5, ["reward"])
-
-        env = gym.make("Pong-v4")
-        play(env, callback=plotter.callback)
-
-
     Arguments
     ---------
     env: gym.Env
@@ -192,7 +180,34 @@ def play(
 
 
 class PlayPlot:
-    def __init__(self, callback, horizon_timesteps, plot_names):
+    """Plot real time statistics as playing with an
+    environment.
+
+    Sample code for plotting the reward
+    of the last 5 second of gameplay.
+
+        def callback(obs_t, obs_tp1, action, rew, done, info):
+            return [rew,]
+        plotter = PlayPlot(callback, 30 * 5, ["reward"])
+
+        env = gym.make("Pong-v4")
+        play(env, callback=plotter.callback)
+
+    Arguments
+    ---------
+    callback: Callable
+        callback function which will be called after every step inside the `play` function.
+
+    horizon_timesteps: int
+        number of timesteps to show on the plot axis.
+
+    plot_name: List[string]
+        titles of the plots.
+    """
+
+    def __init__(
+        self, callback: Callable, horizon_timesteps: int, plot_names: List[str]
+    ):
         self.data_callback = callback
         self.horizon_timesteps = horizon_timesteps
         self.plot_names = plot_names

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -201,7 +201,7 @@ class PlayPlot:
     horizon_timesteps: int
         number of timesteps to show on the plot axis.
 
-    plot_name: List[string]
+    plot_names: List[string]
         titles of the plots.
     """
 

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -180,11 +180,11 @@ def play(
 
 
 class PlayPlot:
-    """Plot real time statistics as playing with an
+    """Plot real time statistics while playing with an
     environment.
 
     Sample code for plotting the reward
-    of the last 5 second of gameplay.
+    of the last 5 seconds of gameplay.
 
         def callback(obs_t, obs_tp1, action, rew, done, info):
             return [rew,]

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -7,6 +7,11 @@ import pytest
 from pygame import KEYDOWN, KEYUP, QUIT, event
 from pygame.event import Event
 
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
 import gym
 from gym.utils.play import MissingKeysToAction, PlayableGame, PlayPlot, play
 
@@ -186,8 +191,12 @@ def test_play_loop_real_env():
     assert (status.last_observation == obs).all()
 
 
+@pytest.mark.skipif(matplotlib is None, reason="Module Matplolib not found")
 def test_play_plot_horizon():
     """Test if plot length is limited at horizon_timesteps datapoints"""
+    # plot window remains open until all tests are finished
+    # https://github.com/matplotlib/matplotlib/issues/8560/
+    # https://github.com/matplotlib/matplotlib/issues/17109
     HORIZON_TIMESTEPS = 10
     NUM_STEPS = 20
 
@@ -205,9 +214,10 @@ def test_play_plot_horizon():
     assert plotter.data[0][-1] == i
 
 
+@pytest.mark.skipif(matplotlib is None, reason="Module Matplolib not found")
 def test_play_plot_multiple_plots():
     """Test if multiple plots (> 1) are managed correctly"""
-    HORIZON_TIMESTEPS = 10
+    HORIZON_TIMESTEPS = 5
     PLOT_NAMES = ["reward", "done"]
 
     def callback(obs_t, obs_tp1, action, rew, done, info):


### PR DESCRIPTION
In a previous PR (https://github.com/openai/gym/pull/2743) I was working on adding tests to `gym.utils.play`. 
`PlayPlot` was left outside; I've now added docstring, type hints and tests.
Tests are actually skipped in the current CI configuration since matplotlib is not a requirement.

The only thing that bothers me is that the window created for plotting hangs on the screen until all tests are finished