### PR TITLE
Docstrings for wrappers

### DIFF
--- a/gym/wrappers/gray_scale_observation.py
+++ b/gym/wrappers/gray_scale_observation.py
@@ -5,9 +5,13 @@ from gym.spaces import Box
 
 
 class GrayScaleObservation(ObservationWrapper):
-    r"""Convert the image observation from RGB to gray scale."""
+    """Convert the image observation from RGB to gray scale.
 
-    def __init__(self, env, keep_dim=False):
+    Args:
+        keep_dim (bool): If `True`, a singleton dimension will be added, i.e. observations are of the shape AxBx1. Otherwise they are of shape AxB
+    """
+
+    def __init__(self, env, keep_dim: bool = False):
         super().__init__(env)
         self.keep_dim = keep_dim
 

--- a/gym/wrappers/normalize.py
+++ b/gym/wrappers/normalize.py
@@ -40,6 +40,16 @@ def update_mean_var_count_from_moments(
 
 
 class NormalizeObservation(gym.core.Wrapper):
+    """This wrapper will normalize observations s.t. each coordinate is centered with unit variance.
+
+    .. note ::
+        The normalization depends on past trajectories and observations will not be normalized correctly if the wrapper was
+        newly instantiated or the policy was changed recently.
+
+    Args:
+         epsilon: A stability parameter that is used when scaling the observations.
+    """
+
     def __init__(
         self,
         env,
@@ -83,6 +93,19 @@ class NormalizeObservation(gym.core.Wrapper):
 
 
 class NormalizeReward(gym.core.Wrapper):
+    """This wrapper will normalize immediate rewards s.t. their exponential moving average has a fixed variance.
+
+    The exponential moving average will have variance (1 - `gamma`)**2.
+
+    .. note ::
+        The scaling depends on past trajectories and rewards will not be scaled correctly if the wrapper was newly
+        instantiated or the policy was changed recently.
+
+    Args:
+        epsilon (float): A stability parameter
+        gamma (float): The discount factor that is used in the exponential moving average.
+    """
+
     def __init__(
         self,
         env,

--- a/gym/wrappers/order_enforcing.py
+++ b/gym/wrappers/order_enforcing.py
@@ -2,6 +2,8 @@ import gym
 
 
 class OrderEnforcing(gym.Wrapper):
+    """This will produce an error if `step` is called before an initial `reset`"""
+
     def __init__(self, env):
         super().__init__(env)
         self._has_reset = False

--- a/gym/wrappers/record_episode_statistics.py
+++ b/gym/wrappers/record_episode_statistics.py
@@ -7,6 +7,34 @@ import gym
 
 
 class RecordEpisodeStatistics(gym.Wrapper):
+    """This wrapper will keep track of cumulative rewards and episode lengths.
+
+    At the end of an episode, the statistics of the episode will be added to `info`. After the completion
+    of an episode, `info` will look like this:
+
+    ```
+    info = {
+        ...
+        "episode": {
+            "r": <cumulative reward>,
+            "l": <episode length>,
+            "t": <elapsed time since instantiation of wrapper>,
+        }
+        ...
+    }
+    ```
+
+    Moreover, the most recent rewards and episode lengths are stored in buffers that can be accessed via
+    `wrapped_env.return_queue` and wrapped_env.length_queue respectively.
+
+    Args:
+        deque_size: The size of the buffers `return_queue` and `length_queue`
+
+    Attributes:
+        return_queue: The cumulative rewards of the last `deque_size`-many episodes
+        length_queue: The lengths of the last `deque_size`-many episodes
+    """
+
     def __init__(self, env, deque_size=100):
         super().__init__(env)
         self.num_envs = getattr(env, "num_envs", 1)

--- a/gym/wrappers/record_video.py
+++ b/gym/wrappers/record_video.py
@@ -14,6 +14,27 @@ def capped_cubic_video_schedule(episode_id):
 
 
 class RecordVideo(gym.Wrapper):
+    """This wrapper records videos of rollouts.
+
+    Usually, you only want to record episodes intermittently, say every hundreth episode.
+    To do this, you can specify **either** `episode_trigger` **or** `step_trigger` (not both).
+    They should be functions returning a boolean that indicates whether a recording should be started at the
+    current episode or step, respectively.
+    If neither `episode_trigger` nor `step_trigger` is passed, a default `episode_trigger` will be employed.
+
+    By default, the recording will be stopped once a `done` signal has been emitted by the environment. However, you can
+    also create recordings of fixed length (possibly spanning several episodes) by passing a strictly positive value for
+    `video_length`.
+
+    Args:
+        env: The environment that will be wrapped
+        video_folder (str): The folder where the recordings will be stored
+        epidsode_trigger: Function that accepts an integer and returns `True` iff a recording should be started at this episode
+        step_trigger: Function that accepts an integer and returns `True` iff a recording should be started at this step
+        video_length (int): The length of recorded episodes. If 0, entire episodes are recorded. Otherwise, snippets of the specified length are captured
+        name_prefix (str): Will be prepended to the filename of the recordings
+    """
+
     def __init__(
         self,
         env,

--- a/gym/wrappers/rescale_action.py
+++ b/gym/wrappers/rescale_action.py
@@ -7,11 +7,18 @@ from gym import spaces
 class RescaleAction(gym.ActionWrapper):
     r"""Rescales the continuous action space of the environment to a range [min_action, max_action].
 
+    The wrapped environment `env` must have an action space of type `spaces.Box`. If `min_action`
+    or `max_action` are numpy arrays, the shape must match the shape of the environment's action space.
+
     Example::
 
         >>> RescaleAction(env, min_action, max_action).action_space == Box(min_action, max_action)
         True
 
+    Args:
+        env: The environment that will be wrapped
+        min_action (Union[np.array, float]): The lower bound of the new action space. This may be a numpy array or a scalar.
+        max_action (Union[np.array, float]): The upper bound of the new action space. This may be a numpy array or a scalar.
     """
 
     def __init__(self, env, min_action, max_action):

--- a/gym/wrappers/resize_observation.py
+++ b/gym/wrappers/resize_observation.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import numpy as np
 
 from gym import ObservationWrapper
@@ -5,9 +7,17 @@ from gym.spaces import Box
 
 
 class ResizeObservation(ObservationWrapper):
-    r"""Downsample the image observation to a square image."""
+    """Resize the image observation.
 
-    def __init__(self, env, shape):
+    This wrapper works on environments with image observations (or more generally observations of shape AxBxC) and resizes
+    the observation to the shape given by the 2-tuple `shape`. The argument `shape` may also be an integer. In that case, the
+    observation is scaled to a square of side-length `shape`.
+
+    Args:
+        shape (Union[tuple, int]): The dimensions of the resized observation
+    """
+
+    def __init__(self, env, shape: Union[tuple, int]):
         super().__init__(env)
         if isinstance(shape, int):
             shape = (shape, shape)

--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -1,8 +1,24 @@
+from typing import Optional
+
 import gym
 
 
 class TimeLimit(gym.Wrapper):
-    def __init__(self, env, max_episode_steps=None):
+    """This wrapper will issue a `done` signal if a maximum number of timesteps is exceeded.
+
+    Oftentimes, it is **very** important to distinguish `done` signals that were produced by the
+    `TimeLimit` wrapper (truncations) and those that originate from the underlying environment (terminations).
+    This can be done by looking at the `info` that is returned when `done` signal was issued.
+
+    The done-signal originates from the time limit (i.e. it signifies a *truncation*) if and only if
+    the key `"TimeLimit.truncated"` exists in `info` and the corresponding value is `True`.
+
+    Args:
+        env: The environment that will be wrapped
+        max_episode_steps (Optional[int]): The maximum number of steps until a done-signal occurs. If it is `None`, the value from `env.spec` (if available) will be used
+    """
+
+    def __init__(self, env, max_episode_steps: Optional[int] = None):
         super().__init__(env)
         if max_episode_steps is None and self.env.spec is not None:
             max_episode_steps = env.spec.max_episode_steps


### PR DESCRIPTION
# Description
I added docstrings (corresponding to the table in the docs) for a few wrappers. 

Since I was already adding typing stuff for the docstrings, I added type hints for three constructors. We might want to move that to a different PR though, especially because I have no idea how type hints work.

## Changes
- New docstrings
- Type hints for GrayScaleObservation, ResizeObservation, TimeLimit