### PR TITLE
Add Pydocstyle to CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,11 +30,12 @@ repos:
     rev: 6.1.1  # pick a git hash / tag to point to
     hooks:
       - id: pydocstyle
+        exclude: ^(gym/version.py)|(gym/(wrappers|envs|spaces|utils|vector)/)|(tests/)
         args:
           - --source
           - --explain
-          - --count
           - --convention=google
+        additional_dependencies: ["toml"]
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.32.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,15 @@ repos:
     hooks:
       - id: isort
         args: ["--profile", "black"]
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.1.1  # pick a git hash / tag to point to
+    hooks:
+      - id: pydocstyle
+        args:
+          - --source
+          - --explain
+          - --count
+          - --convention=google
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:

--- a/gym/__init__.py
+++ b/gym/__init__.py
@@ -1,3 +1,4 @@
+"""Sets the available functions and modules within gym."""
 # isort: skip_file
 
 from gym import error

--- a/gym/error.py
+++ b/gym/error.py
@@ -1,122 +1,75 @@
+"""Set of Error classes."""
+
+
 class Error(Exception):
-    pass
+    """Error superclass."""
 
 
 # Local errors
 
 
 class Unregistered(Error):
-    """Raised when the user requests an item from the registry that does
-    not actually exist.
-    """
-
-    pass
+    """Raised when the user requests an item from the registry that does not actually exist."""
 
 
 class UnregisteredEnv(Unregistered):
-    """Raised when the user requests an env from the registry that does
-    not actually exist.
-    """
-
-    pass
+    """Raised when the user requests an env from the registry that does not actually exist."""
 
 
 class NamespaceNotFound(UnregisteredEnv):
-    """Raised when the user requests an env from the registry where the
-    namespace doesn't exist.
-    """
-
-    pass
+    """Raised when the user requests an env from the registry where the namespace doesn't exist."""
 
 
 class NameNotFound(UnregisteredEnv):
-    """Raised when the user requests an env from the registry where the
-    name doesn't exist.
-    """
-
-    pass
+    """Raised when the user requests an env from the registry where the name doesn't exist."""
 
 
 class VersionNotFound(UnregisteredEnv):
-    """Raised when the user requests an env from the registry where the
-    version doesn't exist.
-    """
-
-    pass
+    """Raised when the user requests an env from the registry where the version doesn't exist."""
 
 
 class UnregisteredBenchmark(Unregistered):
-    """Raised when the user requests an env from the registry that does
-    not actually exist.
-    """
-
-    pass
+    """Raised when the user requests an env from the registry that does not actually exist. unused error."""
 
 
 class DeprecatedEnv(Error):
-    """Raised when the user requests an env from the registry with an
-    older version number than the latest env with the same name.
-    """
-
-    pass
+    """Raised when the user requests an env from the registry with an older version number than the latest env with the same name."""
 
 
 class RegistrationError(Error):
-    """Raised when the user attempts to register an invalid env.
-    For example, an unversioned env when a versioned env exists.
-    """
-
-    pass
+    """Raised when the user attempts to register an invalid env. For example, an unversioned env when a versioned env exists."""
 
 
 class UnseedableEnv(Error):
-    """Raised when the user tries to seed an env that does not support
-    seeding.
-    """
-
-    pass
+    """Raised when the user tries to seed an env that does not support seeding. unused error."""
 
 
 class DependencyNotInstalled(Error):
-    pass
+    """Raised when the user has not installed a dependency."""
 
 
 class UnsupportedMode(Exception):
-    """Raised when the user requests a rendering mode not supported by the
-    environment.
-    """
-
-    pass
+    """Raised when the user requests a rendering mode not supported by the environment. unused error."""
 
 
-class ResetNeeded(Exception):
-    """When the monitor is active, raised when the user tries to step an
-    environment that's already done.
-    """
-
-    pass
+class ResetNeeded(Error):
+    """When the order enforcing is violated, i.e. step or render is called before reset."""
 
 
 class ResetNotAllowed(Exception):
-    """When the monitor is active, raised when the user tries to step an
-    environment that's not yet done.
-    """
-
-    pass
+    """When the monitor is active, raised when the user tries to step an environment that's not yet done. unused error."""
 
 
 class InvalidAction(Exception):
-    """Raised when the user performs an action not contained within the
-    action space
-    """
-
-    pass
+    """Raised when the user performs an action not contained within the action space. unused error."""
 
 
 # API errors
 
 
 class APIError(Error):
+    """Unused error."""
+
     def __init__(
         self,
         message=None,
@@ -125,6 +78,7 @@ class APIError(Error):
         json_body=None,
         headers=None,
     ):
+        """Initialise API error."""
         super().__init__(message)
 
         if http_body and hasattr(http_body, "decode"):
@@ -141,6 +95,7 @@ class APIError(Error):
         self.request_id = self.headers.get("request-id", None)
 
     def __unicode__(self):
+        """Returns a string, if request_id is not None then make message other use the _message."""
         if self.request_id is not None:
             msg = self._message or "<empty message>"
             return f"Request {self.request_id}: {msg}"
@@ -148,17 +103,17 @@ class APIError(Error):
             return self._message
 
     def __str__(self):
-        try:  # Python 2
-            return unicode(self).encode("utf-8")
-        except NameError:  # Python 3
-            return self.__unicode__()
+        """Returns the __unicode__."""
+        return self.__unicode__()
 
 
 class APIConnectionError(APIError):
-    pass
+    """Unused error."""
 
 
 class InvalidRequestError(APIError):
+    """Unused error."""
+
     def __init__(
         self,
         message,
@@ -168,83 +123,69 @@ class InvalidRequestError(APIError):
         json_body=None,
         headers=None,
     ):
+        """Initialises the invalid request error."""
         super().__init__(message, http_body, http_status, json_body, headers)
         self.param = param
 
 
 class AuthenticationError(APIError):
-    pass
+    """Unused error."""
 
 
 class RateLimitError(APIError):
-    pass
+    """Unused error."""
 
 
 # Video errors
 
 
 class VideoRecorderError(Error):
-    pass
+    """Unused error."""
 
 
 class InvalidFrame(Error):
-    pass
+    """Error message when an invalid frame is captured."""
 
 
 # Wrapper errors
 
 
 class DoubleWrapperError(Error):
-    pass
+    """Unused error."""
 
 
 class WrapAfterConfigureError(Error):
-    pass
+    """Unused error."""
 
 
 class RetriesExceededError(Error):
-    pass
+    """unused error."""
 
 
 # Vectorized environments errors
 
 
 class AlreadyPendingCallError(Exception):
-    """
-    Raised when `reset`, or `step` is called asynchronously (e.g. with
-    `reset_async`, or `step_async` respectively), and `reset_async`, or
-    `step_async` (respectively) is called again (without a complete call to
-    `reset_wait`, or `step_wait` respectively).
-    """
+    """Raised when `reset`, or `step` is called asynchronously (e.g. with `reset_async`, or `step_async` respectively), and `reset_async`, or `step_async` (respectively) is called again (without a complete call to `reset_wait`, or `step_wait` respectively)."""
 
-    def __init__(self, message, name):
+    def __init__(self, message: str, name: str):
+        """Initialises the exception with name attributes."""
         super().__init__(message)
         self.name = name
 
 
 class NoAsyncCallError(Exception):
-    """
-    Raised when an asynchronous `reset`, or `step` is not running, but
-    `reset_wait`, or `step_wait` (respectively) is called.
-    """
+    """Raised when an asynchronous `reset`, or `step` is not running, but `reset_wait`, or `step_wait` (respectively) is called."""
 
-    def __init__(self, message, name):
+    def __init__(self, message: str, name: str):
+        """Initialises the exception with name attributes."""
         super().__init__(message)
         self.name = name
 
 
 class ClosedEnvironmentError(Exception):
-    """
-    Trying to call `reset`, or `step`, while the environment is closed.
-    """
-
-    pass
+    """Trying to call `reset`, or `step`, while the environment is closed."""
 
 
 class CustomSpaceError(Exception):
-    """
-    The space is a custom gym.Space instance, and is not supported by
-    `AsyncVectorEnv` with `shared_memory=True`.
-    """
-
-    pass
+    """The space is a custom gym.Space instance, and is not supported by `AsyncVectorEnv` with `shared_memory=True`."""

--- a/gym/logger.py
+++ b/gym/logger.py
@@ -1,3 +1,4 @@
+"""Set of functions for logging messages."""
 import sys
 import warnings
 from typing import Optional, Type
@@ -16,20 +17,20 @@ min_level = 30
 warnings.simplefilter("once", DeprecationWarning)
 
 
-def set_level(level: int) -> None:
-    """
-    Set logging threshold on current logger.
-    """
+def set_level(level: int):
+    """Set logging threshold on current logger."""
     global min_level
     min_level = level
 
 
 def debug(msg: str, *args: object):
+    """Logs a debug message to the user."""
     if min_level <= DEBUG:
         print(f"DEBUG: {msg % args}", file=sys.stderr)
 
 
 def info(msg: str, *args: object):
+    """Logs an info message to the user."""
     if min_level <= INFO:
         print(f"INFO: {msg % args}", file=sys.stderr)
 
@@ -40,6 +41,14 @@ def warn(
     category: Optional[Type[Warning]] = None,
     stacklevel: int = 1,
 ):
+    """Raises a warning to the user if the min_level <= WARN.
+
+    Args:
+        msg: The message to warn the user
+        *args: Additional information to warn the user
+        category: The category of warning
+        stacklevel: The stack level to raise to
+    """
     if min_level <= WARN:
         warnings.warn(
             colorize(f"WARN: {msg % args}", "yellow"),
@@ -49,10 +58,12 @@ def warn(
 
 
 def deprecation(msg: str, *args: object):
+    """Logs a deprecation warning to users."""
     warn(msg, *args, category=DeprecationWarning, stacklevel=2)
 
 
 def error(msg: str, *args: object):
+    """Logs an error message if min_level <= ERROR in red on the sys.stderr."""
     if min_level <= ERROR:
         print(colorize(f"ERROR: {msg % args}", "red"), file=sys.stderr)
 

--- a/gym/wrappers/autoreset.py
+++ b/gym/wrappers/autoreset.py
@@ -33,7 +33,7 @@ class AutoResetWrapper(gym.Wrapper):
     new observation from after calling self.env.reset() is returned
     by self.step() alongside the terminal reward and done state from the
     previous episode . If you need the terminal state from the previous
-    episode, you need to retrieve it via the the "terminal_observation" key
+    episode, you need to retrieve it via the "terminal_observation" key
     in the info dict. Make sure you know what you're doing if you
     use this wrapper!
     """

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+"""Setups the project."""
 import itertools
 import os.path
 import sys

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -1,3 +1,5 @@
+"""Tests the gym.wrapper.AutoResetWrapper operates as expected."""
+
 from typing import Optional
 from unittest.mock import MagicMock
 
@@ -10,33 +12,31 @@ from tests.envs.spec_list import spec_list
 
 
 class DummyResetEnv(gym.Env):
-    """
-    A dummy environment which returns ascending numbers starting
-    at 0 when self.step() is called. After the third call to self.step()
-    done is true. Info dicts are also returned containing the same number
-    returned as an observation, accessible via the key "count".
-    This environment is provided for the purpose of testing the
-    autoreset wrapper.
+    """A dummy environment which returns ascending numbers starting at 0 when self.step() is called.
+
+    After the second call to self.step() done is true.
+    Info dicts are also returned containing the same number returned as an observation, accessible via the key "count".
+    This environment is provided for the purpose of testing the autoreset wrapper.
     """
 
     metadata = {}
 
     def __init__(self):
+        """Initialise the DummyResetEnv."""
         self.action_space = gym.spaces.Box(
-            low=np.array([-1.0]), high=np.array([1.0]), dtype=np.float64
+            low=np.array([0]), high=np.array([2]), dtype=np.int64
         )
-        self.observation_space = gym.spaces.Box(
-            low=np.array([-1.0]), high=np.array([1.0])
-        )
+        self.observation_space = gym.spaces.Discrete(2)
         self.count = 0
 
-    def step(self, action):
+    def step(self, action: int):
+        """Steps the DummyEnv with the incremented step, reward and done if self.count > 1 and updated info."""
         self.count += 1
         return (
-            np.array([self.count]),
-            1 if self.count > 2 else 0,
-            self.count > 2,
-            {"count": self.count},
+            np.array([self.count]),  # Obs
+            self.count > 1,  # Reward
+            self.count > 1,  # Done
+            {"count": self.count},  # Info
         )
 
     def reset(
@@ -46,6 +46,7 @@ class DummyResetEnv(gym.Env):
         return_info: Optional[bool] = False,
         options: Optional[dict] = None
     ):
+        """Resets the DummyEnv to return the count array and info with count."""
         self.count = 0
         if not return_info:
             return np.array([self.count])
@@ -53,79 +54,73 @@ class DummyResetEnv(gym.Env):
             return np.array([self.count]), {"count": self.count}
 
 
-def test_autoreset_reset_info():
-    env = gym.make("CartPole-v1")
-    env = AutoResetWrapper(env)
-    ob_space = env.observation_space
-    obs = env.reset()
-    assert ob_space.contains(obs)
-    obs = env.reset(return_info=False)
-    assert ob_space.contains(obs)
-    obs, info = env.reset(return_info=True)
-    assert ob_space.contains(obs)
-    assert isinstance(info, dict)
-    env.close()
-
-
 @pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
 def test_make_autoreset_true(spec):
-    """
-    Note: This test assumes that the outermost wrapper is AutoResetWrapper
-    so if that is being changed in the future, this test will break and need
-    to be updated.
+    """Tests gym.make with autoreset=True, and check that the reset actually happens.
+
+    Note: This test assumes that the outermost wrapper is AutoResetWrapper so if that
+     is being changed in the future, this test will break and need to be updated.
     Note: This test assumes that all first-party environments will terminate in a finite
-    amount of time with random actions, which is true as of the time of adding this test.
+     amount of time with random actions, which is true as of the time of adding this test.
     """
     with pytest.warns(None):
-        env = spec.make(autoreset=True)
+        env = gym.make(spec.id, autoreset=True)
+    assert isinstance(env, AutoResetWrapper)
 
     env.reset(seed=0)
-    env.action_space.seed(0)
-
     env.unwrapped.reset = MagicMock(side_effect=env.unwrapped.reset)
 
     done = False
     while not done:
         obs, reward, done, info = env.step(env.action_space.sample())
 
-    assert isinstance(env, AutoResetWrapper)
     assert env.unwrapped.reset.called
     env.close()
 
 
 @pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
-def test_make_autoreset_false(spec):
+def test_gym_make_autoreset(spec):
+    """Tests that gym.make autoreset wrapper is applied only when gym.make(..., autoreset=True)."""
     with pytest.warns(None):
-        env = spec.make(autoreset=False)
+        env = gym.make(spec.id)
+    assert not isinstance(
+        env, AutoResetWrapper
+    )  # todo improve through iteratively unwrapped until gym.Env
+    env.close()
+
+    with pytest.warns(None):
+        env = gym.make(spec.id, autoreset=False)
     assert not isinstance(env, AutoResetWrapper)
     env.close()
 
-
-@pytest.mark.parametrize("spec", spec_list, ids=[spec.id for spec in spec_list])
-def test_make_autoreset_default_false(spec):
     with pytest.warns(None):
-        env = spec.make()
-    assert not isinstance(env, AutoResetWrapper)
+        env = gym.make(spec.id, autoreset=True)
+    assert isinstance(env, AutoResetWrapper)
     env.close()
 
 
-def test_autoreset_autoreset():
+def test_autoreset_wrapper_autoreset():
+    """Tests the autoreset wrapper actually automatically resets correctly."""
     env = DummyResetEnv()
     env = AutoResetWrapper(env)
+
     obs, info = env.reset(return_info=True)
     assert obs == np.array([0])
     assert info == {"count": 0}
-    action = 1
+
+    action = 0
     obs, reward, done, info = env.step(action)
     assert obs == np.array([1])
     assert reward == 0
     assert done is False
     assert info == {"count": 1}
+
     obs, reward, done, info = env.step(action)
     assert obs == np.array([2])
     assert done is False
     assert reward == 0
     assert info == {"count": 2}
+
     obs, reward, done, info = env.step(action)
     assert obs == np.array([0])
     assert done is True
@@ -135,14 +130,11 @@ def test_autoreset_autoreset():
         "terminal_observation": np.array([3]),
         "terminal_info": {"count": 3},
     }
+
     obs, reward, done, info = env.step(action)
     assert obs == np.array([1])
     assert reward == 0
     assert done is False
     assert info == {"count": 1}
-    obs, reward, done, info = env.step(action)
-    assert obs == np.array([2])
-    assert reward == 0
-    assert done is False
-    assert info == {"count": 2}
+
     env.close()


### PR DESCRIPTION
Currently gym has a variety of docstrings style across the project
This PR adds pydocstyle to the pre-commit CI to ensure that functions have a docstring

Pydocstyle has three docstyles: google, numpy and pep257, and @RedTachyon and I agree that the google docstyle is the best of those. 

Due to the number of docstrings, we have excluded all folders except the root folder and gym/ root folder (I accidentally added test_autoreset and autoreset wrapper) 
The aim is to add more PRs for each of the gym folders with docstrings 