### PR TITLE
Remove PlayPlot from gym.utils.play

### DIFF
--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -110,18 +110,6 @@ def play(
     verifying that the frame-level preprocessing does not render the game
     unplayable.
 
-    If you wish to plot real time statistics as you play, you can use
-    gym.utils.play.PlayPlot. Here's a sample code for plotting the reward
-    for last 5 second of gameplay.
-
-        def callback(obs_t, obs_tp1, action, rew, done, info):
-            return [rew,]
-        plotter = PlayPlot(callback, 30 * 5, ["reward"])
-
-        env = gym.make("Pong-v4")
-        play(env, callback=plotter.callback)
-
-
     Arguments
     ---------
     env: gym.Env

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -16,8 +16,6 @@ except ImportError as e:
     logger.warn(f"failed to set matplotlib backend, plotting will not work: {str(e)}")
     plt = None
 
-from collections import deque
-
 from pygame.locals import VIDEORESIZE
 
 
@@ -189,39 +187,3 @@ def play(
         pygame.display.flip()
         clock.tick(fps)
     pygame.quit()
-
-
-class PlayPlot:
-    def __init__(self, callback, horizon_timesteps, plot_names):
-        self.data_callback = callback
-        self.horizon_timesteps = horizon_timesteps
-        self.plot_names = plot_names
-
-        assert plt is not None, "matplotlib backend failed, plotting will not work"
-
-        num_plots = len(self.plot_names)
-        self.fig, self.ax = plt.subplots(num_plots)
-        if num_plots == 1:
-            self.ax = [self.ax]
-        for axis, name in zip(self.ax, plot_names):
-            axis.set_title(name)
-        self.t = 0
-        self.cur_plot = [None for _ in range(num_plots)]
-        self.data = [deque(maxlen=horizon_timesteps) for _ in range(num_plots)]
-
-    def callback(self, obs_t, obs_tp1, action, rew, done, info):
-        points = self.data_callback(obs_t, obs_tp1, action, rew, done, info)
-        for point, data_series in zip(points, self.data):
-            data_series.append(point)
-        self.t += 1
-
-        xmin, xmax = max(0, self.t - self.horizon_timesteps), self.t
-
-        for i, plot in enumerate(self.cur_plot):
-            if plot is not None:
-                plot.remove()
-            self.cur_plot[i] = self.ax[i].scatter(
-                range(xmin, xmax), list(self.data[i]), c="blue"
-            )
-            self.ax[i].set_xlim(xmin, xmax)
-        plt.pause(0.000001)


### PR DESCRIPTION
As a continuation of https://github.com/openai/gym/pull/2783 I'm removing the PlayPlot class. I will follow with a docs update to keep a reference on how to set up a callback in the play function. 
@jkterry1 any suggestion on where to put it in the docs?
