### PR TITLE
Change gym environment spec entry points

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -10,41 +10,41 @@ _load_env_plugins()
 
 register(
     id="CartPole-v0",
-    entry_point="gym.envs.classic_control:CartPoleEnv",
+    entry_point="gym.envs.classic_control.cartpole:CartPoleEnv",
     max_episode_steps=200,
     reward_threshold=195.0,
 )
 
 register(
     id="CartPole-v1",
-    entry_point="gym.envs.classic_control:CartPoleEnv",
+    entry_point="gym.envs.classic_control.cartpole:CartPoleEnv",
     max_episode_steps=500,
     reward_threshold=475.0,
 )
 
 register(
     id="MountainCar-v0",
-    entry_point="gym.envs.classic_control:MountainCarEnv",
+    entry_point="gym.envs.classic_control.mountain_car:MountainCarEnv",
     max_episode_steps=200,
     reward_threshold=-110.0,
 )
 
 register(
     id="MountainCarContinuous-v0",
-    entry_point="gym.envs.classic_control:Continuous_MountainCarEnv",
+    entry_point="gym.envs.classic_control.continuous_mountain_car:Continuous_MountainCarEnv",
     max_episode_steps=999,
     reward_threshold=90.0,
 )
 
 register(
     id="Pendulum-v1",
-    entry_point="gym.envs.classic_control:PendulumEnv",
+    entry_point="gym.envs.classic_control.pendulum:PendulumEnv",
     max_episode_steps=200,
 )
 
 register(
     id="Acrobot-v1",
-    entry_point="gym.envs.classic_control:AcrobotEnv",
+    entry_point="gym.envs.classic_control.acrobot:AcrobotEnv",
     reward_threshold=-100.0,
     max_episode_steps=500,
 )
@@ -54,14 +54,14 @@ register(
 
 register(
     id="LunarLander-v2",
-    entry_point="gym.envs.box2d:LunarLander",
+    entry_point="gym.envs.box2d.lunar_lander:LunarLander",
     max_episode_steps=1000,
     reward_threshold=200,
 )
 
 register(
     id="LunarLanderContinuous-v2",
-    entry_point="gym.envs.box2d:LunarLander",
+    entry_point="gym.envs.box2d.lunar_lander:LunarLander",
     kwargs={"continuous": True},
     max_episode_steps=1000,
     reward_threshold=200,
@@ -69,14 +69,14 @@ register(
 
 register(
     id="BipedalWalker-v3",
-    entry_point="gym.envs.box2d:BipedalWalker",
+    entry_point="gym.envs.box2d.bipedal_walker:BipedalWalker",
     max_episode_steps=1600,
     reward_threshold=300,
 )
 
 register(
     id="BipedalWalkerHardcore-v3",
-    entry_point="gym.envs.box2d:BipedalWalker",
+    entry_point="gym.envs.box2d.bipedal_walker:BipedalWalker",
     kwargs={"hardcore": True},
     max_episode_steps=2000,
     reward_threshold=300,
@@ -84,14 +84,14 @@ register(
 
 register(
     id="CarRacing-v1",
-    entry_point="gym.envs.box2d:CarRacing",
+    entry_point="gym.envs.box2d.car_racing:CarRacing",
     max_episode_steps=1000,
     reward_threshold=900,
 )
 
 register(
     id="CarRacingDomainRandomize-v1",
-    entry_point="gym.envs.box2d:CarRacing",
+    entry_point="gym.envs.box2d.car_racing:CarRacing",
     kwargs={"domain_randomize": True},
     max_episode_steps=1000,
     reward_threshold=900,
@@ -99,7 +99,7 @@ register(
 
 register(
     id="CarRacingDiscrete-v1",
-    entry_point="gym.envs.box2d:CarRacing",
+    entry_point="gym.envs.box2d.car_racing:CarRacing",
     kwargs={"continuous": False},
     max_episode_steps=1000,
     reward_threshold=900,
@@ -107,7 +107,7 @@ register(
 
 register(
     id="CarRacingDomainRandomizeDiscrete-v1",
-    entry_point="gym.envs.box2d:CarRacing",
+    entry_point="gym.envs.box2d.car_racing:CarRacing",
     kwargs={"domain_randomize": True, "continuous": False},
     max_episode_steps=1000,
     reward_threshold=900,
@@ -118,13 +118,13 @@ register(
 
 register(
     id="Blackjack-v1",
-    entry_point="gym.envs.toy_text:BlackjackEnv",
+    entry_point="gym.envs.toy_text.blackjack:BlackjackEnv",
     kwargs={"sab": True, "natural": False},
 )
 
 register(
     id="FrozenLake-v1",
-    entry_point="gym.envs.toy_text:FrozenLakeEnv",
+    entry_point="gym.envs.toy_text.frozen_lake:FrozenLakeEnv",
     kwargs={"map_name": "4x4"},
     max_episode_steps=100,
     reward_threshold=0.70,  # optimum = 0.74
@@ -132,7 +132,7 @@ register(
 
 register(
     id="FrozenLake8x8-v1",
-    entry_point="gym.envs.toy_text:FrozenLakeEnv",
+    entry_point="gym.envs.toy_text.frozen_lake:FrozenLakeEnv",
     kwargs={"map_name": "8x8"},
     max_episode_steps=200,
     reward_threshold=0.85,  # optimum = 0.91
@@ -140,12 +140,12 @@ register(
 
 register(
     id="CliffWalking-v0",
-    entry_point="gym.envs.toy_text:CliffWalkingEnv",
+    entry_point="gym.envs.toy_text.cliffwalking:CliffWalkingEnv",
 )
 
 register(
     id="Taxi-v3",
-    entry_point="gym.envs.toy_text:TaxiEnv",
+    entry_point="gym.envs.toy_text.taxi:TaxiEnv",
     reward_threshold=8,  # optimum = 8.46
     max_episode_steps=200,
 )


### PR DESCRIPTION
Inspired by https://github.com/openai/gym/issues/2786 and https://github.com/openai/gym/issues/2733
When importing from `__init__.py` and the true import statement also fails as in the cases above.
Then the python right is not very help just saying that the import fails

This PR changes the entry points of all gym environments - mujoco to their true environment point
Therefore, if a user has not imported all of the necessary parts for the environment then a more helpful error will occur
Example
```
import gym
gym.make('CarRacing-v1')

# new PR 
gym.error.DependencyNotInstalled: box2D is not installed, run `pip install gym[box2d]`
# old 
ImportError: cannot import name 'CarRacing' from 'gym.envs.box2d' (/gym/gym/envs/box2d/__init__.py)
```

This should be completely backward compatible