### PR TITLE
BugFix - VecEnvWrapper doesn't forward call, set_attr to self.env

### DIFF
--- a/gym/vector/vector_env.py
+++ b/gym/vector/vector_env.py
@@ -262,6 +262,12 @@ class VectorEnvWrapper(VectorEnv):
     def seed(self, seed=None):
         return self.env.seed(seed)
 
+    def call(self, name, *args, **kwargs):
+        return self.env.call(name, *args, **kwargs)
+
+    def set_attr(self, name, values):
+        return self.env.set_attr(name, values)
+
     # implicitly forward all other methods and attributes to self.env
     def __getattr__(self, name):
         if name.startswith("_"):
@@ -274,3 +280,6 @@ class VectorEnvWrapper(VectorEnv):
 
     def __repr__(self):
         return f"<{self.__class__.__name__}, {self.env}>"
+
+    def __del__(self):
+        self.env.__del__()

--- a/tests/vector/test_vector_env_wrapper.py
+++ b/tests/vector/test_vector_env_wrapper.py
@@ -21,6 +21,7 @@ def test_vector_env_wrapper_inheritance():
 
 
 def test_vector_env_wrapper_attributes():
+    """Test if `set_attr`, `call` methods for VecEnvWrapper get correctly forwarded to the vector env it is wrapping."""
     env = make("CartPole-v1", num_envs=3)
     wrapped = DummyWrapper(make("CartPole-v1", num_envs=3))
 

--- a/tests/vector/test_vector_env_wrapper.py
+++ b/tests/vector/test_vector_env_wrapper.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from gym.vector import VectorEnvWrapper, make
 
 
@@ -16,3 +18,13 @@ def test_vector_env_wrapper_inheritance():
     wrapped = DummyWrapper(env)
     wrapped.reset()
     assert wrapped.counter == 1
+
+
+def test_vector_env_wrapper_attributes():
+    env = make("CartPole-v1", num_envs=3)
+    wrapped = DummyWrapper(make("CartPole-v1", num_envs=3))
+
+    assert np.allclose(wrapped.call("gravity"), env.call("gravity"))
+    env.set_attr("gravity", [20.0, 20.0, 20.0])
+    wrapped.set_attr("gravity", [20.0, 20.0, 20.0])
+    assert np.allclose(wrapped.get_attr("gravity"), env.get_attr("gravity"))


### PR DESCRIPTION
# Description 

1. `VecEnvWrapper` only forwards some select methods to self.env. I added those methods which cause issues now with the current implementations of `SyncVectorEnv` and `AsyncVectorEnv`. (example code below). If for eg. `reset` is implemented in a new vector env, this would later need to also be added to `VecEnvWrapper`. 
2. Added a corresponding test. 

```python
import gym 
from gym.vector import VectorEnvWrapper

class DummyVecEnvWrapper(VectorEnvWrapper):
    def __init__(self, env):
        super().__init__(env)

if __name__=='__main__':
    env = gym.vector.make("CartPole-v1", num_envs=3)
    wrapped = DummyVecEnvWrapper(gym.vector.make("CartPole-v1", num_envs=3))

    # works fine
    env.call("gravity")
    env.set_attr("gravity", [20, 20, 20])

    # Error - goes to VectorEnv where these methods raise not implemented errors
    wrapped.call("gravity")
    wrapped.set_attr("gravity", [20, 20, 20])

```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes