### PR TITLE
Remove try except from box2d __init__.py 

### DIFF
--- a/gym/envs/box2d/__init__.py
+++ b/gym/envs/box2d/__init__.py
@@ -1,8 +1,3 @@
-try:
-    import Box2D
-
-    from gym.envs.box2d.bipedal_walker import BipedalWalker, BipedalWalkerHardcore
-    from gym.envs.box2d.car_racing import CarRacing
-    from gym.envs.box2d.lunar_lander import LunarLander, LunarLanderContinuous
-except ImportError:
-    Box2D = None
+from gym.envs.box2d.bipedal_walker import BipedalWalker, BipedalWalkerHardcore
+from gym.envs.box2d.car_racing import CarRacing
+from gym.envs.box2d.lunar_lander import LunarLander, LunarLanderContinuous


### PR DESCRIPTION
With https://github.com/openai/gym/pull/2782, we added try except to all of the Box2d environment, however I had not realised that the box2d `__init__.py` contains a similar try except that was not removed.
Thanks https://github.com/openai/gym/issues/2795#issuecomment-1117630203 for spotting it

This shouldn't cause any issues, as unless you import box2d environments without box2d this should not raise any new errors (hopefully) 