### PR TITLE
Add a compatibility layer for the new registration mechanism

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -340,6 +340,8 @@ def make(id: EnvSpec, **kwargs) -> Env: ...
 class EnvRegistry(dict):
     """A glorified dictionary for compatibility reasons"""
 
+    # TODO: remove this at 1.0
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -349,22 +351,34 @@ class EnvRegistry(dict):
         )
         return make(path, **kwargs)
 
+    def register(self, id: str, **kwargs) -> None:
+        logger.warn(
+            "The `registry.register` method is deprecated. Please use `gym.register` instead."
+        )
+        return register(id, **kwargs)
+
     def all(self) -> Iterable[EnvSpec]:
         logger.warn(
             "The `registry.all` method is deprecated. Please use `registry.values` instead."
         )
         return self.values()
 
-    def spec(self, path: str):
+    def spec(self, path: str) -> EnvSpec:
         logger.warn(
             "The `registry.spec` method is deprecated. Please use `gym.spec` instead."
         )
         return spec(path)
 
+    def namespace(self, ns: str):
+        logger.warn(
+            "The `registry.namespace` method is deprecated. Please use `gym.namespace` instead."
+        )
+        return namespace(ns)
+
     @property
     def env_specs(self):
         logger.warn(
-            "The `registry.env_specs` property is deprecated. Please use `registry` directly instead."
+            "The `registry.env_specs` property along with `EnvSpecTree` is deprecated. Please use `registry` directly as a dictionary instead."
         )
         return self
 

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -338,7 +338,11 @@ def make(id: EnvSpec, **kwargs) -> Env: ...
 
 
 class EnvRegistry(dict):
-    """A glorified dictionary for compatibility reasons"""
+    """A glorified dictionary for compatibility reasons. 
+    Turns out that some exising code directly used the old `EnvRegistry` code, 
+    even though the intended API was just `register` and `make`. This reimplements some
+    of the old methods, so that e.g. pybullet environments will still work.
+    Ideally, nobody should ever use these methods, and they will be removed soon."""
 
     # TODO: remove this at 1.0
 

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -338,16 +338,13 @@ def make(id: EnvSpec, **kwargs) -> Env: ...
 
 
 class EnvRegistry(dict):
-    """A glorified dictionary for compatibility reasons. 
-    Turns out that some exising code directly used the old `EnvRegistry` code, 
+    """A glorified dictionary for compatibility reasons.
+    Turns out that some existing code directly used the old `EnvRegistry` code,
     even though the intended API was just `register` and `make`. This reimplements some
     of the old methods, so that e.g. pybullet environments will still work.
     Ideally, nobody should ever use these methods, and they will be removed soon."""
 
     # TODO: remove this at 1.0
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     def make(self, path: str, **kwargs) -> Env:
         logger.warn(

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import (
     Any,
     Callable,
+    Iterable,
     Optional,
     Sequence,
     SupportsFloat,
@@ -336,8 +337,40 @@ def make(id: EnvSpec, **kwargs) -> Env: ...
 # fmt: on
 
 
+class EnvRegistry(dict):
+    """A glorified dictionary for compatibility reasons"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def make(self, path: str, **kwargs) -> Env:
+        logger.warn(
+            "The `registry.make` method is deprecated. Please use `gym.make` instead."
+        )
+        return make(path, **kwargs)
+
+    def all(self) -> Iterable[EnvSpec]:
+        logger.warn(
+            "The `registry.all` method is deprecated. Please use `registry.values` instead."
+        )
+        return self.values()
+
+    def spec(self, path: str):
+        logger.warn(
+            "The `registry.spec` method is deprecated. Please use `gym.spec` instead."
+        )
+        return spec(path)
+
+    @property
+    def env_specs(self):
+        logger.warn(
+            "The `registry.env_specs` property is deprecated. Please use `registry` directly instead."
+        )
+        return self
+
+
 # Global registry of environments. Meant to be accessed through `register` and `make`
-registry: dict[str, EnvSpec] = dict()
+registry: dict[str, EnvSpec] = EnvRegistry()
 current_namespace: Optional[str] = None
 
 


### PR DESCRIPTION
As I now found out, some envs like pybullet were too clever for their own good, and added extra logic instead of just calling `gym.register(...)`, so they will break with the new registration mechanism (which was meant to be backwards compatible for reasonable uses - I didn't expect someone would inspect the registry directly, since all that is handled by gym anyways)

This PR adds a thin layer around the registry, which is a dict, and it will remain a dict with a few extra methods. This should give you a warning if you try to do something weird, and not change the dict behavior in any way. Ideally, this will be removed in 1.0

I'm not sure if we actually need this (because maybe we can let pybullet people know so that they can update their code), but I'm leaning towards keeping the interoperability for now.