### PR TITLE
Improve ``play``

### DIFF
--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -102,7 +102,7 @@ def play(
     fps: Optional[int] = None,
     zoom: Optional[float] = None,
     callback: Optional[Callable] = None,
-    keys_to_action: Optional[Dict[Union[Tuple[int], str], ActType]] = None,
+    keys_to_action: Optional[Dict[Union[Tuple[Union[str, int]], str], ActType]] = None,
     seed: Optional[int] = None,
     noop: ActType = 0,
 ):

--- a/gym/utils/play.py
+++ b/gym/utils/play.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Dict, Optional, Tuple, Union
 
 import pygame
 from numpy.typing import NDArray
@@ -20,6 +20,8 @@ except ImportError as e:
 from collections import deque
 
 from pygame.locals import VIDEORESIZE
+
+from gym.core import ActType
 
 
 class MissingKeysToAction(Exception):
@@ -97,11 +99,12 @@ def display_arr(
 def play(
     env: Env,
     transpose: Optional[bool] = True,
-    fps: Optional[int] = 30,
+    fps: Optional[int] = None,
     zoom: Optional[float] = None,
     callback: Optional[Callable] = None,
-    keys_to_action: Optional[Dict[Tuple[int], int]] = None,
+    keys_to_action: Optional[Dict[Union[Tuple[int], str], ActType]] = None,
     seed: Optional[int] = None,
+    noop: ActType = 0,
 ):
     """Allows one to play the game using keyboard.
 
@@ -161,7 +164,19 @@ def play(
         Random seed used when resetting the environment. If None, no seed is used.
     """
     env.reset(seed=seed)
-    game = PlayableGame(env, keys_to_action, zoom)
+
+    key_code_to_action = {}
+
+    for key_combination, action in keys_to_action.items():
+        key_code = tuple(
+            sorted(ord(key) if isinstance(key, str) else key for key in key_combination)
+        )
+        key_code_to_action[key_code] = action
+
+    game = PlayableGame(env, key_code_to_action, zoom)
+
+    if fps is None:
+        fps = env.metadata.get("render_fps", 30)
 
     done = True
     clock = pygame.time.Clock()
@@ -171,7 +186,7 @@ def play(
             done = False
             obs = env.reset(seed=seed)
         else:
-            action = keys_to_action.get(tuple(sorted(game.pressed_keys)), 0)
+            action = key_code_to_action.get(tuple(sorted(game.pressed_keys)), noop)
             prev_obs = obs
             obs, rew, done, info = env.step(action)
             if callback is not None:


### PR DESCRIPTION
This PR is supposed to make the `play` function more convenient to work with

### Changes

Changes to `key_to_action`:
- No longer require the key-combinations to be ordered when passing them to the function
- Allow characters instead of corresponding `ord("<key>")`
- Allow strings representing key-combinations keys instead of tuples

In total these changes allow `{"wa": action}` instead of `{sorted(ord("w"), ord("a")): action}` while remaining backwards compatible.

Additional changes:

- Set the default `fps` to `None` and try to infer framerate from metadata (previously default was 30)
- Previously, `play` only worked with discrete action spaces and used action `0` when an unknown key combination or no key was pressed. I introduced a keyword argument for a NOOP action for this

All of this should be mostly backward compatible (the framerate will change if `fps` was not specified and "render_fps" in metadata is not 30). 


### Example:

```
import gym
from gym.utils.play import play
import numpy as np


play(gym.make("CarRacing-v1"), keys_to_action={"w": np.array([0, 0.7, 0]),
                                               "a": np.array([-1, 0, 0]),
                                               "s": np.array([0, 0, 1]),
                                               "d": np.array([1, 0, 0]),
                                               "wa": np.array([-1, 0.7, 0]),
                                               "dw": np.array([1, 0.7, 0]),
                                               "ds": np.array([1, 0, 1]),
                                               "as": np.array([-1, 0, 1]),
                                               }, noop=np.array([0,0,0]))

```

### Docstrings
If this is merged before the PR for utils docstrings, I will add docstrings there. Otherwise, this PR will be updated.