### PR TITLE
Improve performance for car racing rendering

### DIFF
--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -548,7 +548,7 @@ class CarRacing(gym.Env, EzPickle):
 
         # draw background
         self._draw_colored_polygon(
-            self.surf, field, self.bg_color, zoom, translation, angle
+            self.surf, field, self.bg_color, zoom, translation, angle, clip=False
         )
 
         # draw grass patches
@@ -645,7 +645,7 @@ class CarRacing(gym.Env, EzPickle):
             (255, 0, 0),
         )
 
-    def _draw_colored_polygon(self, surface, poly, color, zoom, translation, angle):
+    def _draw_colored_polygon(self, surface, poly, color, zoom, translation, angle, clip=True):
         import pygame
         from pygame import gfxdraw
 
@@ -653,8 +653,11 @@ class CarRacing(gym.Env, EzPickle):
         poly = [
             (c[0] * zoom + translation[0], c[1] * zoom + translation[1]) for c in poly
         ]
-        gfxdraw.aapolygon(self.surf, poly, color)
-        gfxdraw.filled_polygon(self.surf, poly, color)
+        for coord in poly:
+            if not clip or (0 < coord[0] < WINDOW_W) or (0 < coord[1] < WINDOW_H):
+                gfxdraw.aapolygon(self.surf, poly, color)
+                gfxdraw.filled_polygon(self.surf, poly, color)
+                return
 
     def _create_image_array(self, screen, size):
         import pygame

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -645,7 +645,9 @@ class CarRacing(gym.Env, EzPickle):
             (255, 0, 0),
         )
 
-    def _draw_colored_polygon(self, surface, poly, color, zoom, translation, angle, clip=True):
+    def _draw_colored_polygon(
+        self, surface, poly, color, zoom, translation, angle, clip=True
+    ):
         import pygame
         from pygame import gfxdraw
 

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -655,8 +655,13 @@ class CarRacing(gym.Env, EzPickle):
         poly = [
             (c[0] * zoom + translation[0], c[1] * zoom + translation[1]) for c in poly
         ]
+        # This checks if the polygon is out of bounds of the screen, and we skip drawing if so.
+        if not clip:
+            gfxdraw.aapolygon(self.surf, poly, color)
+            gfxdraw.filled_polygon(self.surf, poly, color)
+            return
         for coord in poly:
-            if not clip or (0 < coord[0] < WINDOW_W) or (0 < coord[1] < WINDOW_H):
+            if (0 < coord[0] < WINDOW_W) and (0 < coord[1] < WINDOW_H):
                 gfxdraw.aapolygon(self.surf, poly, color)
                 gfxdraw.filled_polygon(self.surf, poly, color)
                 return


### PR DESCRIPTION
# Description
This change eliminates unnecessary drawing by pygame if it is out of bounds

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
### Screenshots
Please attach before and after screenshots of the change if applicable.
Using cProfile, the car racing env was run for 30 seconds, and the time for each function call was computed:
Before
![image](https://user-images.githubusercontent.com/25740538/168423276-fe880a04-9d39-414e-89a4-c0388ad55cf5.png)
After
![image](https://user-images.githubusercontent.com/25740538/168424472-30985147-dd79-454d-ac38-f8ae2d0b5e24.png)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
