### PR TITLE
Fix edge case for out of bounds

### DIFF
--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -656,15 +656,17 @@ class CarRacing(gym.Env, EzPickle):
             (c[0] * zoom + translation[0], c[1] * zoom + translation[1]) for c in poly
         ]
         # This checks if the polygon is out of bounds of the screen, and we skip drawing if so.
-        if not clip:
+        # instead of calculating exactly if the polygon and screen overlap,
+        # we simply check if the polygon is in a larger bounding box whose dimension
+        # is greater than the screen by the (approximate) maximum length of an object's side
+        max_shape_dim = 100
+        if not clip or any(
+            (-max_shape_dim <= coord[0] <= WINDOW_W + max_shape_dim)
+            and (-max_shape_dim <= coord[1] <= WINDOW_H + max_shape_dim)
+            for coord in poly
+        ):
             gfxdraw.aapolygon(self.surf, poly, color)
             gfxdraw.filled_polygon(self.surf, poly, color)
-            return
-        for coord in poly:
-            if (0 < coord[0] < WINDOW_W) and (0 < coord[1] < WINDOW_H):
-                gfxdraw.aapolygon(self.surf, poly, color)
-                gfxdraw.filled_polygon(self.surf, poly, color)
-                return
 
     def _create_image_array(self, screen, size):
         import pygame

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -38,6 +38,10 @@ TRACK_TURN_RATE = 0.31
 TRACK_WIDTH = 40 / SCALE
 BORDER = 8 / SCALE
 BORDER_MIN_COUNT = 4
+GRASS_DIM = PLAYFIELD / 20.0
+MAX_SHAPE_DIM = (
+    max(GRASS_DIM, TRACK_WIDTH, TRACK_DETAIL_STEP) * math.sqrt(2) * ZOOM * SCALE
+)
 
 
 class FrictionDetector(contactListener):
@@ -552,16 +556,15 @@ class CarRacing(gym.Env, EzPickle):
         )
 
         # draw grass patches
-        k = bounds / (20.0)
         grass = []
         for x in range(0, 40, 2):
             for y in range(0, 40, 2):
                 grass.append(
                     [
-                        (k * x + k, k * y + 0),
-                        (k * x + 0, k * y + 0),
-                        (k * x + 0, k * y + k),
-                        (k * x + k, k * y + k),
+                        (GRASS_DIM * x + GRASS_DIM, GRASS_DIM * y + 0),
+                        (GRASS_DIM * x + 0, GRASS_DIM * y + 0),
+                        (GRASS_DIM * x + 0, GRASS_DIM * y + GRASS_DIM),
+                        (GRASS_DIM * x + GRASS_DIM, GRASS_DIM * y + GRASS_DIM),
                     ]
                 )
         for poly in grass:
@@ -656,13 +659,13 @@ class CarRacing(gym.Env, EzPickle):
             (c[0] * zoom + translation[0], c[1] * zoom + translation[1]) for c in poly
         ]
         # This checks if the polygon is out of bounds of the screen, and we skip drawing if so.
-        # instead of calculating exactly if the polygon and screen overlap,
+        # Instead of calculating exactly if the polygon and screen overlap,
         # we simply check if the polygon is in a larger bounding box whose dimension
-        # is greater than the screen by the (approximate) maximum length of an object's side
-        max_shape_dim = 100
+        # is greater than the screen by MAX_SHAPE_DIM, which is the maximum
+        # diagonal length of an environment object
         if not clip or any(
-            (-max_shape_dim <= coord[0] <= WINDOW_W + max_shape_dim)
-            and (-max_shape_dim <= coord[1] <= WINDOW_H + max_shape_dim)
+            (-MAX_SHAPE_DIM <= coord[0] <= WINDOW_W + MAX_SHAPE_DIM)
+            and (-MAX_SHAPE_DIM <= coord[1] <= WINDOW_H + MAX_SHAPE_DIM)
             for coord in poly
         ):
             gfxdraw.aapolygon(self.surf, poly, color)


### PR DESCRIPTION
# Description
This deals with the edge case where an object's corner may not be in the screen, but the object still overlaps and should be drawn.

Additionally, more tests were performed to ensure that both the performance as well as consistency to the previous version was maintained. The resulting observations from `step()` are unaffected between changes.
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots
There is still significant performance increase from not drawing out of bounds objects, and loosening the condition does not adversely affect these changes by a significant margin.
Before clipping:
![image](https://user-images.githubusercontent.com/25740538/168623635-6382d1b3-5c64-41a9-bb82-782c39c6ebe4.png)

After:
![image](https://user-images.githubusercontent.com/25740538/168640263-6b1f480f-5824-4a8a-ad59-8ec2c089f472.png)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
