### PR TITLE
mountain_car reward set to 0 if reaching goal

### DIFF
--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -127,6 +127,8 @@ class MountainCarEnv(gym.Env):
 
         done = bool(position >= self.goal_position and velocity >= self.goal_velocity)
         reward = -1.0
+        if done:
+            reward = 0
 
         self.state = (position, velocity)
         return np.array(self.state, dtype=np.float32), reward, done, {}


### PR DESCRIPTION
# Description

mountain_car reward was always -1

description states it should  be 0 if goal is reached.:
 The goal is to reach the flag placed on top of the right hill as quickly as possible, as such the agent is penalised with a reward of -1 for each timestep it isn't at the goal and is not penalised (reward = 0) for when it reaches the goal.

now code behaves as description defines.

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
