### PR TITLE
Fix scale for Car Racing

### DIFF
--- a/gym/envs/box2d/car_dynamics.py
+++ b/gym/envs/box2d/car_dynamics.py
@@ -280,9 +280,7 @@ class Car:
             for f in obj.fixtures:
                 trans = f.body.transform
                 path = [trans * v for v in f.shape.vertices]
-                path = [
-                    (coords[0], coords[1]) for coords in path
-                ]
+                path = [(coords[0], coords[1]) for coords in path]
                 path = [pygame.math.Vector2(c).rotate_rad(angle) for c in path]
                 path = [
                     (
@@ -317,10 +315,7 @@ class Car:
                 ]
                 white_poly = [trans * v for v in white_poly]
 
-                white_poly = [
-                    (coords[0], coords[1])
-                    for coords in white_poly
-                ]
+                white_poly = [(coords[0], coords[1]) for coords in white_poly]
                 white_poly = [
                     pygame.math.Vector2(c).rotate_rad(angle) for c in white_poly
                 ]

--- a/gym/envs/box2d/car_dynamics.py
+++ b/gym/envs/box2d/car_dynamics.py
@@ -45,9 +45,6 @@ WHEEL_COLOR = (0, 0, 0)
 WHEEL_WHITE = (77, 77, 77)
 MUD_COLOR = (102, 102, 0)
 
-SCALE = 6.0  # Track scale
-PLAYFIELD = 2000 / SCALE  # Game over boundary
-
 
 class Car:
     def __init__(self, world, init_angle, init_x, init_y):
@@ -267,10 +264,7 @@ class Car:
 
         if draw_particles:
             for p in self.particles:
-                poly = [
-                    (coords[0] + PLAYFIELD, coords[1] + PLAYFIELD) for coords in p.poly
-                ]
-                poly = [pygame.math.Vector2(c).rotate_rad(angle) for c in poly]
+                poly = [pygame.math.Vector2(c).rotate_rad(angle) for c in p.poly]
                 poly = [
                     (
                         coords[0] * zoom + translation[0],
@@ -287,7 +281,7 @@ class Car:
                 trans = f.body.transform
                 path = [trans * v for v in f.shape.vertices]
                 path = [
-                    (coords[0] + PLAYFIELD, coords[1] + PLAYFIELD) for coords in path
+                    (coords[0], coords[1]) for coords in path
                 ]
                 path = [pygame.math.Vector2(c).rotate_rad(angle) for c in path]
                 path = [
@@ -324,7 +318,7 @@ class Car:
                 white_poly = [trans * v for v in white_poly]
 
                 white_poly = [
-                    (coords[0] + PLAYFIELD, coords[1] + PLAYFIELD)
+                    (coords[0], coords[1])
                     for coords in white_poly
                 ]
                 white_poly = [

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -513,8 +513,8 @@ class CarRacing(gym.Env, EzPickle):
         angle = -self.car.hull.angle
         # Animating first second zoom.
         zoom = 0.1 * SCALE * max(1 - self.t, 0) + ZOOM * SCALE * min(self.t, 1)
-        scroll_x = -(self.car.hull.position[0] + PLAYFIELD) * zoom
-        scroll_y = -(self.car.hull.position[1] + PLAYFIELD) * zoom
+        scroll_x = -(self.car.hull.position[0]) * zoom
+        scroll_y = -(self.car.hull.position[1]) * zoom
         trans = pygame.math.Vector2((scroll_x, scroll_y)).rotate_rad(angle)
         trans = (WINDOW_W / 2 + trans[0], WINDOW_H / 4 + trans[1])
 
@@ -549,10 +549,10 @@ class CarRacing(gym.Env, EzPickle):
     def _render_road(self, zoom, translation, angle):
         bounds = PLAYFIELD
         field = [
-            (2 * bounds, 2 * bounds),
-            (2 * bounds, 0),
-            (0, 0),
-            (0, 2 * bounds),
+            (bounds, bounds),
+            (bounds, -bounds),
+            (-bounds, -bounds),
+            (-bounds, bounds),
         ]
 
         # draw background
@@ -562,8 +562,8 @@ class CarRacing(gym.Env, EzPickle):
 
         # draw grass patches
         grass = []
-        for x in range(0, 40, 2):
-            for y in range(0, 40, 2):
+        for x in range(-20, 20, 2):
+            for y in range(-20, 20, 2):
                 grass.append(
                     [
                         (GRASS_DIM * x + GRASS_DIM, GRASS_DIM * y + 0),
@@ -580,7 +580,7 @@ class CarRacing(gym.Env, EzPickle):
         # draw road
         for poly, color in self.road_poly:
             # converting to pixel coordinates
-            poly = [(p[0] + PLAYFIELD, p[1] + PLAYFIELD) for p in poly]
+            poly = [(p[0], p[1]) for p in poly]
             color = [int(c) for c in color]
             self._draw_colored_polygon(self.surf, poly, color, zoom, translation, angle)
 


### PR DESCRIPTION
# Description
This shifts the relative position of the rendering coordinates by `PLAYFIELD`, so that `car_dynamics` need not take it into consideration when calculating the coords to render.

Fixes #2830

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/25740538/169850004-497690a8-e397-41b5-b97f-ad4e6edcbb36.png)

After:
![image](https://user-images.githubusercontent.com/25740538/169850029-3427967c-8216-4249-adcf-1f26b28460cd.png)

After (SCALE=10), note that the change in the car size is as expected
![image](https://user-images.githubusercontent.com/25740538/169850045-3a10e576-bebb-4369-83ba-cbe2f79c8d8f.png)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
