### PR TITLE
Updated mujoco to 2.2.0 from 2.1.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras = {
     "box2d": ["box2d-py==2.3.5", "pygame==2.1.0"],
     "classic_control": ["pygame==2.1.0"],
     "mujoco_py": ["mujoco_py<2.2,>=2.1"],
-    "mujoco": ["mujoco==2.1.5", "imageio>=2.14.1"],
+    "mujoco": ["mujoco==2.2.0", "imageio>=2.14.1"],
     "toy_text": ["pygame==2.1.0", "scipy>=1.4.1"],
     "other": ["lz4>=3.1.0", "opencv-python>=3.0", "matplotlib>=3.0"],
 }


### PR DESCRIPTION
Updated the mujoco module to 2.2.0 based on https://github.com/openai/gym/pull/2762#issuecomment-1136375631

The steps are identical for 2.1.5 and 2.2.0 so should not have any training difference