### PR TITLE
Removed downloading mujoco in py.Dockerfile

### DIFF
--- a/py.Dockerfile
+++ b/py.Dockerfile
@@ -3,14 +3,6 @@ ARG PYTHON_VERSION
 FROM python:$PYTHON_VERSION
 RUN apt-get -y update && apt-get install -y unzip libglu1-mesa-dev libgl1-mesa-dev libosmesa6-dev xvfb patchelf ffmpeg cmake swig
 
-# Download mujoco
-RUN mkdir /root/.mujoco && \
-    cd /root/.mujoco  && \
-    wget https://github.com/deepmind/mujoco/releases/download/2.1.0/mujoco210-linux-x86_64.tar.gz &&\
-    tar -xf mujoco210-linux-x86_64.tar.gz
-
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mujoco210/bin
-
 COPY . /usr/local/gym/
 WORKDIR /usr/local/gym/
 


### PR DESCRIPTION
As we have moved to the deepmind mujoco bindings then there is no need to download mujoco anymore