### PR TITLE
box.contains constraint relaxation

### DIFF
--- a/gym/spaces/box.py
+++ b/gym/spaces/box.py
@@ -198,7 +198,7 @@ class Box(Space[np.ndarray]):
             x = np.asarray(x, dtype=self.dtype)
 
         return bool(
-            np.can_cast(x.dtype, self.dtype)
+            np.can_cast(x.dtype, self.dtype, casting='same_kind')
             and x.shape == self.shape
             and np.all(x >= self.low)
             and np.all(x <= self.high)


### PR DESCRIPTION
# Description

This change relaxed a constraint used by box.contains.

According to https://numpy.org/doc/stable/reference/generated/numpy.can_cast.html, np.can_cast by default sets casting to 'safe'. However, this setting may cause potential problems in practice. Consider code snippets below:

```
from gym import spaces
import numpy as np
observation_space = spaces.Box(low=np.array([0., 0.], dtype=np.float32), high=np.array([1., 1.], dtype=np.float32), shape=(2,))
observation = np.array([.5, .5], dtype=np.float64)
observation_space.contains(observation)
```

Before the proposed change, the output would be False, simply because np.can_cast(np.float64, np.float32, casting='safe') returns False. After the proposed change, the output would be True, because np.can_cast(np.float64, np.float32, casting='same_kind') returns True.

I believe that casting='same_kind', which allows only safe casts or casts within a kind, should produce intended behavior suggested by function name 'contains', as observation = np.array([.5, .5], dtype=np.float64) should be considered inside observation_space = spaces.Box(low=np.array([0., 0.], dtype=np.float32), high=np.array([1., 1.], dtype=np.float32), shape=(2,)). 

The fix provides a more general behavior.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Please attach before and after screenshots of the change if applicable.


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
