### PR TITLE
Remove math operations from MuJoCo xml files

### DIFF
--- a/gym/envs/mujoco/assets/hopper.xml
+++ b/gym/envs/mujoco/assets/hopper.xml
@@ -24,7 +24,7 @@
         <body name="leg" pos="0 0 0.35">
           <joint axis="0 -1 0" name="leg_joint" pos="0 0 0.6" range="-150 0" type="hinge"/>
           <geom friction="0.9" fromto="0 0 0.6 0 0 0.1" name="leg_geom" size="0.04" type="capsule"/>
-          <body name="foot" pos="0.13/2 0 0.1">
+          <body name="foot" pos="0.13 0 0">
             <joint axis="0 -1 0" name="foot_joint" pos="0 0 0.1" range="-45 45" type="hinge"/>
             <geom friction="2.0" fromto="-0.13 0 0.1 0.26 0 0.1" name="foot_geom" size="0.06" type="capsule"/>
           </body>

--- a/gym/envs/mujoco/assets/walker2d.xml
+++ b/gym/envs/mujoco/assets/walker2d.xml
@@ -20,7 +20,7 @@
         <body name="leg" pos="0 0 0.35">
           <joint axis="0 -1 0" name="leg_joint" pos="0 0 0.6" range="-150 0" type="hinge"/>
           <geom friction="0.9" fromto="0 0 0.6 0 0 0.1" name="leg_geom" size="0.04" type="capsule"/>
-          <body name="foot" pos="0.2/2 0 0.1">
+          <body name="foot" pos="0.2 0 0">
             <joint axis="0 -1 0" name="foot_joint" pos="0 0 0.1" range="-45 45" type="hinge"/>
             <geom friction="0.9" fromto="-0.0 0 0.1 0.2 0 0.1" name="foot_geom" size="0.06" type="capsule"/>
           </body>
@@ -33,7 +33,7 @@
         <body name="leg_left" pos="0 0 0.35">
           <joint axis="0 -1 0" name="leg_left_joint" pos="0 0 0.6" range="-150 0" type="hinge"/>
           <geom friction="0.9" fromto="0 0 0.6 0 0 0.1" name="leg_left_geom" rgba=".7 .3 .6 1" size="0.04" type="capsule"/>
-          <body name="foot_left" pos="0.2/2 0 0.1">
+          <body name="foot_left" pos="0.2 0 0">
             <joint axis="0 -1 0" name="foot_left_joint" pos="0 0 0.1" range="-45 45" type="hinge"/>
             <geom friction="1.9" fromto="-0.0 0 0.1 0.2 0 0.1" name="foot_left_geom" rgba=".7 .3 .6 1" size="0.06" type="capsule"/>
           </body>


### PR DESCRIPTION
# Description

Math operations are not supported in MuJoCo XML files. Unfortunately MuJoCo’s current parser does not report an error but silently stops parsing, setting the rest of of the numbers in the string to 0. In future MuJoCo releases, math operators in number strings will generate an error (see [deepmind/mujoco#302](https://github.com/deepmind/mujoco/pull/302)). This pull request converts buggy XML strings to correct ones, without altering the resulting model. This will allow future versions of gym to update your pinned MuJoCo version without causing errors.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
