### PR TITLE
Remove a redundant warning in registration

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -417,17 +417,7 @@ current_namespace: Optional[str] = None
 
 def _check_spec_register(spec: EnvSpec):
     """Checks whether the spec is valid to be registered. Helper function for `register`."""
-    global registry, current_namespace
-    if current_namespace is not None:
-        if spec.namespace is not None:
-            logger.warn(
-                f"Custom namespace `{spec.namespace}` is being overridden "
-                f"by namespace `{current_namespace}`. If you are developing a "
-                "plugin you shouldn't specify a namespace in `register` "
-                "calls. The namespace is specified through the "
-                "entry point package metadata."
-            )
-
+    global registry
     latest_versioned_spec = max(
         (
             spec_
@@ -496,7 +486,7 @@ def register(id: str, **kwargs):
     ns, name, version = parse_env_id(id)
 
     if current_namespace is not None:
-        if kwargs.get("namespace") is not None:
+        if kwargs.get("namespace") is not None and kwargs.get("namespace") != current_namespace:
             logger.warn(
                 f"Custom namespace `{kwargs.get('namespace')}` is being overridden "
                 f"by namespace `{current_namespace}`. If you are developing a "

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -486,7 +486,10 @@ def register(id: str, **kwargs):
     ns, name, version = parse_env_id(id)
 
     if current_namespace is not None:
-        if kwargs.get("namespace") is not None and kwargs.get("namespace") != current_namespace:
+        if (
+            kwargs.get("namespace") is not None
+            and kwargs.get("namespace") != current_namespace
+        ):
             logger.warn(
                 f"Custom namespace `{kwargs.get('namespace')}` is being overridden "
                 f"by namespace `{current_namespace}`. If you are developing a "


### PR DESCRIPTION
I accidentally doubled one check for the namespace in the new registration mechanism, which caused some erroneous warnings. I removed one instance of this check, and added a sanity check in the remaining one (if we're overriding a namespace with the same namespace, we don't really care)

Fixes #2849 
