### PR TITLE
Fix issue #2860

### DIFF
--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -234,6 +234,8 @@ class MujocoEnv(gym.Env):
 
     def close(self):
         if self.viewer is not None:
+            if self._mujoco_bindings.__name__ == "mujoco":
+                self.viewer.close()
             self.viewer = None
             self._viewers = {}
 

--- a/gym/envs/mujoco/mujoco_rendering.py
+++ b/gym/envs/mujoco/mujoco_rendering.py
@@ -222,6 +222,12 @@ class RenderContext:
 
         self.scn.ngeom += 1
 
+    def close(self):
+        """Override close in your rendering subclass to perform any necessary cleanup
+        after env.close() is called.
+        """
+        pass
+
 
 class RenderContextOffscreen(RenderContext):
     """Offscreen rendering class with opengl context."""
@@ -304,7 +310,7 @@ class Viewer(RenderContext):
 
         super().__init__(model, data, offscreen=False)
 
-    def _key_callback(self, key, action):
+    def _key_callback(self, window, key, scancode, action, mods):
         if action != glfw.RELEASE:
             return
         # Switch cameras


### PR DESCRIPTION
	* fix arguments key callback

	* close env in renderer

	* mujoco_rendering close base method

# Description

This PR adds missing arguments to key_callback() in the mujoco rendering window Viewer class as well as glfw termination after closing the environment

Fixes # (2860)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
