### PR TITLE
Fix docstring in rescale_action wrapper

### DIFF
--- a/gym/wrappers/rescale_action.py
+++ b/gym/wrappers/rescale_action.py
@@ -15,7 +15,7 @@ class RescaleAction(gym.ActionWrapper):
 
     Example:
         >>> import gym
-        >>> env = gym.make('CartPole-v1')
+        >>> env = gym.make('BipedalWalker-v3')
         >>> env.action_space
         Box(-1.0, 1.0, (4,), float32)
         >>> min_action = -0.5


### PR DESCRIPTION
Rescale action docstring example is not related to CartPole which has a discrete action space. Changed to BipedalWalker-v3 to make it consistent with the subsequent lines
