### PR TITLE
Add Graph to Spaces

### DIFF
--- a/gym/spaces/__init__.py
+++ b/gym/spaces/__init__.py
@@ -11,6 +11,7 @@ are vectors in the two-dimensional unit cube, the environment code may contain t
 from gym.spaces.box import Box
 from gym.spaces.dict import Dict
 from gym.spaces.discrete import Discrete
+from gym.spaces.graph import Graph
 from gym.spaces.multi_binary import MultiBinary
 from gym.spaces.multi_discrete import MultiDiscrete
 from gym.spaces.space import Space
@@ -21,6 +22,7 @@ __all__ = [
     "Space",
     "Box",
     "Discrete",
+    "Graph",
     "MultiDiscrete",
     "MultiBinary",
     "Tuple",

--- a/gym/spaces/__init__.py
+++ b/gym/spaces/__init__.py
@@ -11,7 +11,7 @@ are vectors in the two-dimensional unit cube, the environment code may contain t
 from gym.spaces.box import Box
 from gym.spaces.dict import Dict
 from gym.spaces.discrete import Discrete
-from gym.spaces.graph import Graph
+from gym.spaces.graph import Graph, GraphInstance
 from gym.spaces.multi_binary import MultiBinary
 from gym.spaces.multi_discrete import MultiDiscrete
 from gym.spaces.space import Space
@@ -23,6 +23,7 @@ __all__ = [
     "Box",
     "Discrete",
     "Graph",
+    "GraphInstance",
     "MultiDiscrete",
     "MultiBinary",
     "Tuple",

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -16,15 +16,15 @@ class GraphObj:
         self,
         nodes: np.ndarray,
         edges: Optional[np.ndarray] = None,
-        node_list: Optional[np.ndarray] = None,
+        edge_links: Optional[np.ndarray] = None,
     ):
 
         self.nodes = nodes
         self.edges = edges
-        self.node_list = node_list
+        self.edge_links = edge_links
 
     def __repr__(self) -> str:
-        return f"GraphObj(nodes: \n{self.nodes}, \n\nedges: \n{self.edges}, \n\nnode_list\n{self.node_list})"
+        return f"GraphObj(nodes: \n{self.nodes}, \n\nedges: \n{self.edges}, \n\nedge_links\n{self.edge_links})"
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, GraphObj):
@@ -37,14 +37,14 @@ class GraphObj:
             elif np.all(self.edges != other.edges):
                 return False
 
-            if other.node_list is None:
+            if other.edge_links is None:
                 return False
-            elif np.all(self.node_list != other.node_list):
+            elif np.all(self.edge_links != other.edge_links):
                 return False
         else:
             if other.edges is not None:
                 return False
-            if other.node_list is not None:
+            if other.edge_links is not None:
                 return False
 
         return True
@@ -52,7 +52,7 @@ class GraphObj:
 
 class Graph(Space):
     """
-    A dictionary representing graph spaces with `node_features`, `edge_features` and `edge_list`.
+    A dictionary representing graph spaces with `node_features`, `edge_features` and `edge_links`.
 
     Example usage::
 
@@ -149,19 +149,19 @@ class Graph(Space):
                 if not self.edge_space.contains(edge):
                     return False
 
-            if len(x.node_list) != len(x.edges):
+            if len(x.edge_links) != len(x.edges):
                 return False
 
-            if x.node_list.shape[-1] != 2:
+            if x.edge_links.shape[-1] != 2:
                 return False
 
-            if not np.issubdtype(x.node_list.dtype, np.integer):
+            if not np.issubdtype(x.edge_links.dtype, np.integer):
                 return False
 
-            if x.node_list.max() >= len(x.edges):
+            if x.edge_links.max() >= len(x.edges):
                 return False
 
-            if x.node_list.min() < 0:
+            if x.edge_links.min() < 0:
                 return False
 
         return True
@@ -185,7 +185,7 @@ class Graph(Space):
             ret["nodes"] = sample.nodes.tolist()
             if sample.edges is not None:
                 ret["edges"] = sample.edges.tolist()
-                ret["node_list"] = sample.node_list.tolist()
+                ret["edge_links"] = sample.edge_links.tolist()
             ret_n.append(ret)
         return ret_n
 
@@ -197,7 +197,7 @@ class Graph(Space):
                 ret_n = GraphObj(
                     np.asarray(sample["nodes"]),
                     np.asarray(sample["edges"]),
-                    np.asarray(sample["node_list"]),
+                    np.asarray(sample["edge_links"]),
                 )
             else:
                 ret_n = GraphObj(

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -57,7 +57,7 @@ class Graph(Space):
     def graph_obj(
         nodes: np.ndarray, edges: np.ndarray, edge_links: np.array
     ) -> NamedTuple:
-        r"""Returns a NamedTuple representing a graph object
+        r"""Returns a NamedTuple representing a graph object.
 
         Args:
             nodes (np.ndarray): an (n x ...) sized array representing the features for n nodes.

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -12,17 +12,6 @@ from gym.utils import seeding
 class GraphObj:
     """
     A base for constructing information as graphs.
-
-    `nodes` must be a nx... sized vector, where ... denotes the shape of
-    the base shape that each node feature must be.
-
-    `edges` must be either None or a np.ndarray where the first
-    dimension (denoted n) is the number of edges.
-    If edges is None, then edge_links must also be None.
-
-    `edge_links` must be a nx2 sized array of ints, where edge_links.max()
-    is not to be equal or larger than the size of the first dimension of nodes, and
-    edge_links.min() is not to be smaller than 0.
     """
     def __init__(
         self,
@@ -30,7 +19,18 @@ class GraphObj:
         edges: Optional[np.ndarray] = None,
         edge_links: Optional[np.ndarray] = None,
     ):
+        """
+        ``nodes`` must be a nx... sized vector, where ... denotes the shape of
+        the base shape that each node feature must be.
 
+        ``edges`` must be either None or a np.ndarray where the first
+        dimension (denoted n) is the number of edges.
+        If edges is None, then edge_links must also be None.
+
+        ``edge_links`` must be a nx2 sized array of ints, where edge_links.max()
+        is not to be equal or larger than the size of the first dimension of nodes, and
+        edge_links.min() is not to be smaller than 0.
+        """
         self.nodes = nodes
         self.edges = edges
         self.edge_links = edge_links
@@ -82,9 +82,22 @@ class Graph(Space):
     def __init__(
         self,
         node_space: Union[Box, Discrete],
-        edge_space: Union[Box, Discrete],
+        edge_space: Union[None, Box, Discrete],
         seed: Optional[Union[int, seeding.RandomNumberGenerator]] = None,
     ):
+        r"""Constructor of :class:`Graph`.
+
+        The argument ``node_space`` specifies the base space that each node feature will use.
+        This argument must be either a Box or Discrete instance.
+
+        The argument ``edge_space`` specifies the base space that each edge feature will use.
+        This argument must be either a Box or Discrete instance.
+
+        Args:
+            node_space (Union[Box, Discrete]): space of the node features.
+            edge_space (Union[None, Box, Discrete]): space of the node features.
+            seed: Optionally, you can use this argument to seed the RNG that is used to sample from the space.
+        """
         self._np_random = None
         if seed is not None:
             if isinstance(seed, seeding.RandomNumberGenerator):
@@ -95,9 +108,10 @@ class Graph(Space):
         assert isinstance(
             node_space, (Box, Discrete)
         ), "Values of the node_space should be instances of Box or Discrete"
-        assert isinstance(
-            edge_space, (Box, Discrete)
-        ), "Values of the edge_space should be instances of Box or Discrete"
+        if edge_space is not None:
+            assert isinstance(
+                edge_space, (Box, Discrete)
+            ), "Values of the edge_space should be instances of Box or Discrete"
 
         self.node_space = node_space
         self.edge_space = edge_space
@@ -122,6 +136,8 @@ class Graph(Space):
             )
         elif isinstance(base_space, Discrete):
             return MultiDiscrete(nvec=[base_space.n] * num, seed=self._np_random)
+        elif base_space == None:
+            return None
         else:
             raise AssertionError(
                 "Only Box and Discrete can be accepted as a base_space."

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -1,3 +1,4 @@
+"""Implementation of a space that represents graph information where nodes and edges can be represented with euclidean space."""
 from typing import Optional, Sequence, Union
 
 import numpy as np
@@ -154,7 +155,7 @@ class Graph(Space):
             return None
 
     def sample(self) -> GraphObj:
-        """Returns a random sized graph space with num_nodes between 1 and 10"""
+        """Returns a random sized graph space with num_nodes between 1 and 10."""
         num_nodes = self.np_random.integers(low=1, high=10)
 
         # we only have edges when we have at least 2 nodes

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -129,31 +129,38 @@ class Graph(Space):
     def contains(self, x: GraphInstance) -> bool:
         """Return boolean specifying if x is a valid member of this space."""
         if not isinstance(x, GraphInstance):
+            print("fail 1")
             return False
-        if x.nodes is not None:
-            for node in x.nodes:
-                if not self.node_space.contains(node):
-                    return False
+        for node in x.nodes:
+            if not self.node_space.contains(node):
+                return False
         if x.edges is not None:
             for edge in x.edges:
                 if self.edge_space is None:
+                    print("fail 3")
                     return False
                 if not self.edge_space.contains(edge):
+                    print("fail 4")
                     return False
 
             if len(x.edge_links) != len(x.edges):
+                print("fail 5")
                 return False
 
             if x.edge_links.shape[-1] != 2:
+                print("fail 6")
                 return False
 
             if not np.issubdtype(x.edge_links.dtype, np.integer):
+                print("fail 7")
                 return False
 
             if x.edge_links.max() >= len(x.edges):
+                print("fail 8")
                 return False
 
             if x.edge_links.min() < 0:
+                print("fail 9")
                 return False
 
         return True

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -11,6 +11,7 @@ from gym.utils import seeding
 
 class GraphObj:
     r"""A base for constructing information as graphs."""
+
     def __init__(
         self,
         nodes: np.ndarray,
@@ -52,23 +53,23 @@ class GraphObj:
             return False
         if self.edges is not None:
             if other.edges is None:
-                print('fail1')
+                print("fail1")
                 return False
             if np.all(self.edges != other.edges):
-                print('fail2')
+                print("fail2")
                 return False
             if other.edge_links is None:
-                print('fail3')
+                print("fail3")
                 return False
             if np.all(self.edge_links != other.edge_links):
-                print('fail4')
+                print("fail4")
                 return False
         else:
             if other.edges is not None:
-                print('fail6')
+                print("fail6")
                 return False
             if other.edge_links is not None:
-                print('fail7')
+                print("fail7")
                 return False
 
         return True

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -10,16 +10,15 @@ from gym.utils import seeding
 
 
 class GraphObj:
-    """
-    A base for constructing information as graphs.
-    """
+    r"""A base for constructing information as graphs."""
     def __init__(
         self,
         nodes: np.ndarray,
         edges: Optional[np.ndarray] = None,
         edge_links: Optional[np.ndarray] = None,
     ):
-        """
+        r"""Constructor for Graph information.
+
         ``nodes`` must be a nx... sized vector, where ... denotes the shape of
         the base shape that each node feature must be.
 
@@ -71,8 +70,7 @@ class GraphObj:
 
 
 class Graph(Space):
-    """
-    A dictionary representing graph spaces with `node_features`, `edge_features` and `edge_links`.
+    r"""A dictionary representing graph spaces with `node_features`, `edge_features` and `edge_links`.
 
     Example usage::
 
@@ -136,7 +134,7 @@ class Graph(Space):
             )
         elif isinstance(base_space, Discrete):
             return MultiDiscrete(nvec=[base_space.n] * num, seed=self._np_random)
-        elif base_space == None:
+        elif base_space is None:
             return None
         else:
             raise AssertionError(

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -33,7 +33,7 @@ class Graph(Space):
         This argument must be either a Box or Discrete instance.
 
         The argument ``edge_space`` specifies the base space that each edge feature will use.
-        This argument must be either a Box or Discrete instance.
+        This argument must be either a None, Box or Discrete instance.
 
         Args:
             node_space (Union[Box, Discrete]): space of the node features.

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -143,6 +143,8 @@ class Graph(Space):
                     return False
         if x.edges is not None:
             for edge in x.edges:
+                if self.edge_space is None:
+                    return False
                 if not self.edge_space.contains(edge):
                     return False
 

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Optional, Sequence, Union
 
 import numpy as np
@@ -63,7 +61,7 @@ class Graph(Space):
         self,
         node_space: Union[Box, Discrete],
         edge_space: Union[Box, Discrete],
-        seed: Optional[int | seeding.RandomNumberGenerator] = None,
+        seed: Optional[Union[int, seeding.RandomNumberGenerator]] = None,
     ):
         self._np_random = None
         if seed is not None:
@@ -87,7 +85,7 @@ class Graph(Space):
 
         super().__init__(None, None, seed)
 
-    def _generate_sample_space(self, base_space, num) -> Optional[Box | Discrete]:
+    def _generate_sample_space(self, base_space, num) -> Optional[Union[Box, Discrete]]:
         # the possibility of this space having nothing
         if num == 0:
             return None
@@ -176,7 +174,7 @@ class Graph(Space):
             and (self.edge_space == other.edge_space)
         )
 
-    def to_jsonable(self, sample_n: GraphObj) -> list[dict]:
+    def to_jsonable(self, sample_n: GraphObj) -> list:
         """Convert a batch of samples from this space to a JSONable data type."""
         # serialize as list of dicts
         ret_n = []
@@ -189,7 +187,7 @@ class Graph(Space):
             ret_n.append(ret)
         return ret_n
 
-    def from_jsonable(self, sample_n: Sequence[dict]) -> list[GraphObj]:
+    def from_jsonable(self, sample_n: Sequence[dict]) -> list:
         """Convert a JSONable data type to a batch of samples from this space."""
         ret = []
         for sample in sample_n:

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -139,29 +139,29 @@ class Graph(Space):
         - any edge in edges is not contained in Graph.edge_space
         """
         if not isinstance(x, GraphInstance):
-            print('fail 1')
+            print("fail 1")
             return False
         if x.edges is not None:
             if not np.issubdtype(x.edge_links.dtype, np.integer):
-                print('fail 2')
+                print("fail 2")
                 return False
             if x.edge_links.shape[-1] != 2:
-                print('fail 3')
+                print("fail 3")
                 return False
             if self.edge_space is None:
-                print('fail 4')
+                print("fail 4")
                 return False
             if x.edge_links.min() < 0:
-                print('fail 5')
+                print("fail 5")
                 return False
             if x.edge_links.max() >= len(x.nodes):
-                print('fail 6')
+                print("fail 6")
                 return False
             if len(x.edges) != len(x.edge_links):
-                print('fail 7')
+                print("fail 7")
                 return False
             if any(edge not in self.edge_space for edge in x.edges):
-                print('fail 8')
+                print("fail 8")
                 return False
         if any(node not in self.node_space for node in x.nodes):
             return False

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -121,7 +121,7 @@ class Graph(Space):
         sampled_edge_links = None
         if sampled_edges is not None and num_edges > 0:
             sampled_edge_links = self.np_random.integers(
-                low=0, high=num_edges, size=(num_edges, 2)
+                low=0, high=num_nodes, size=(num_edges, 2)
             )
 
         return GraphInstance(sampled_nodes, sampled_edges, sampled_edge_links)
@@ -139,21 +139,29 @@ class Graph(Space):
         - any edge in edges is not contained in Graph.edge_space
         """
         if not isinstance(x, GraphInstance):
+            print('fail 1')
             return False
         if x.edges is not None:
             if not np.issubdtype(x.edge_links.dtype, np.integer):
+                print('fail 2')
                 return False
             if x.edge_links.shape[-1] != 2:
+                print('fail 3')
                 return False
             if self.edge_space is None:
+                print('fail 4')
                 return False
             if x.edge_links.min() < 0:
+                print('fail 5')
                 return False
             if x.edge_links.max() >= len(x.nodes):
+                print('fail 6')
                 return False
             if len(x.edges) != len(x.edge_links):
+                print('fail 7')
                 return False
             if any(edge not in self.edge_space for edge in x.edges):
+                print('fail 8')
                 return False
         if any(node not in self.node_space for node in x.nodes):
             return False

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -139,29 +139,21 @@ class Graph(Space):
         - any edge in edges is not contained in Graph.edge_space
         """
         if not isinstance(x, GraphInstance):
-            print("fail 1")
             return False
         if x.edges is not None:
             if not np.issubdtype(x.edge_links.dtype, np.integer):
-                print("fail 2")
                 return False
             if x.edge_links.shape[-1] != 2:
-                print("fail 3")
                 return False
             if self.edge_space is None:
-                print("fail 4")
                 return False
             if x.edge_links.min() < 0:
-                print("fail 5")
                 return False
             if x.edge_links.max() >= len(x.nodes):
-                print("fail 6")
                 return False
             if len(x.edges) != len(x.edge_links):
-                print("fail 7")
                 return False
             if any(edge not in self.edge_space for edge in x.edges):
-                print("fail 8")
                 return False
         if any(node not in self.node_space for node in x.nodes):
             return False

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -52,18 +52,23 @@ class GraphObj:
             return False
         if self.edges is not None:
             if other.edges is None:
+                print('fail1')
                 return False
-            elif np.all(self.edges != other.edges):
+            if np.all(self.edges != other.edges):
+                print('fail2')
                 return False
-
             if other.edge_links is None:
+                print('fail3')
                 return False
-            elif np.all(self.edge_links != other.edge_links):
+            if np.all(self.edge_links != other.edge_links):
+                print('fail4')
                 return False
         else:
             if other.edges is not None:
+                print('fail6')
                 return False
             if other.edge_links is not None:
+                print('fail7')
                 return False
 
         return True
@@ -164,10 +169,11 @@ class Graph(Space):
         sampled_edges = self._sample_sample_space(edge_sample_space)
 
         sampled_node_list = None
-        if num_edges > 0:
-            sampled_node_list = self.np_random.integers(
-                low=0, high=num_edges, size=(num_edges, 2)
-            )
+        if sampled_edges is not None:
+            if num_edges > 0:
+                sampled_node_list = self.np_random.integers(
+                    low=0, high=num_edges, size=(num_edges, 2)
+                )
 
         return GraphObj(sampled_nodes, sampled_edges, sampled_node_list)
 

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from typing import Optional, Sequence, Union
+
+import numpy as np
+
+from gym.spaces.box import Box
+from gym.spaces.discrete import Discrete
+from gym.spaces.space import Space
+from gym.utils import seeding
+
+
+class GraphObj:
+    def __init__(
+        self,
+        nodes: Optional[np.ndarray] = None,
+        edges: Optional[np.ndarray] = None,
+        node_list: Optional[np.ndarray] = None,
+    ):
+
+        self.nodes = nodes
+        self.edges = edges
+        self.node_list = node_list
+
+    def __repr__(self) -> str:
+        return f"GraphObj(nodes: \n{self.nodes}, \n\nedges: \n{self.edges}, \n\nnode_list\n{self.node_list})"
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, GraphObj)
+            and (self.nodes == other.nodes)
+            and (self.edges == other.edges)
+            and (self.node_list == other.node_list)
+        )
+
+
+class Graph(Space):
+    """
+    A dictionary representing graph spaces with `node_features`, `edge_features` and `edge_list`.
+
+    Example usage::
+
+        self.observation_space = spaces.Graph(node_space=space.Box(low=-100, high=100, shape=(3,)), edge_space=spaces.Discrete(3))
+    """
+
+    def __init__(
+        self,
+        node_space: Union[Box, Discrete],
+        edge_space: Union[Box, Discrete],
+        seed: Optional[int | seeding.RandomNumberGenerator] = None,
+    ):
+        self._np_random = None
+        if seed is not None:
+            if isinstance(seed, seeding.RandomNumberGenerator):
+                self._np_random = seed
+            else:
+                self.seed(seed)
+
+        assert isinstance(
+            node_space, (Box, Discrete)
+        ), "Values of the node_space should be instances of Box or Discrete"
+        assert isinstance(
+            edge_space, (Box, Discrete)
+        ), "Values of the edge_space should be instances of Box or Discrete"
+
+        self.node_space = node_space
+        self.edge_space = edge_space
+
+        # graph object creator
+        self.graphObj = GraphObj
+
+        super().__init__(None, None, seed)
+
+    def _generate_sample_space(self, base_space, num) -> Optional[Box | Discrete]:
+        # the possibility of this space having nothing
+        if num == 0:
+            return None
+
+        if isinstance(base_space, Box):
+            return Box(
+                low=np.array(max(1, num) * [base_space.low]),
+                high=np.array(max(1, num) * [base_space.high]),
+                shape=(num, *base_space.shape),
+                dtype=base_space.dtype,
+                seed=self._np_random,
+            )
+        elif isinstance(base_space, Discrete):
+            return Discrete(
+                n=base_space.n, seed=self._np_random, start=base_space.start
+            )
+        else:
+            raise AssertionError(
+                "Only Box and Discrete can be accepted as a base_space."
+            )
+
+    def _sample_sample_space(self, sample_space) -> Optional[np.ndarray]:
+        if sample_space is not None:
+            return sample_space.sample()
+        else:
+            return None
+
+    def sample(self) -> GraphObj:
+        """Returns a random sized graph space with num_nodes between 1 and 10"""
+        num_nodes = self.np_random.integers(low=1, high=10)
+
+        # we only have edges when we have at least 2 nodes
+        num_edges = 0
+        if num_nodes > 1:
+            # maximal number of edges is (n*n) allowing self connections and two way is allowed
+            num_edges = self.np_random.integers(num_nodes * num_nodes)
+
+        node_sample_space = self._generate_sample_space(self.node_space, num_nodes)
+        edge_sample_space = self._generate_sample_space(self.edge_space, num_edges)
+
+        sampled_nodes = self._sample_sample_space(node_sample_space)
+        sampled_edges = self._sample_sample_space(edge_sample_space)
+
+        sampled_node_list = None
+        if num_edges > 0:
+            sampled_node_list = self.np_random.integers(
+                low=0, high=num_edges, size=(num_edges, 2)
+            )
+
+        return GraphObj(sampled_nodes, sampled_edges, sampled_node_list)
+
+    def contains(self, x: GraphObj) -> bool:
+        if not isinstance(x, GraphObj):
+            return False
+        if x.nodes is not None:
+            for node in x.nodes:
+                if not self.node_space.contains(node):
+                    return False
+        if x.edges is not None:
+            for edge in x.edges:
+                if not self.node_space.contains(edge):
+                    return False
+
+            if len(x.node_list) != len(x.edges):
+                return False
+
+            if x.node_list.shape[-1] != 2:
+                return False
+
+            if not np.issubdtype(x.node_list.dtype, np.integer):
+                return False
+
+            if x.node_list.max() >= len(x.edges):
+                return False
+
+            if x.node_list.min() < 0:
+                return False
+
+        return True
+
+    def __repr__(self) -> str:
+        return f"Graph({self.node_space}, {self.edge_space})"
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, Graph)
+            and (self.node_space == other.node_space)
+            and (self.edge_space == other.edge_space)
+        )
+
+    def to_jsonable(self, sample_n: GraphObj) -> list[dict]:
+        """Convert a batch of samples from this space to a JSONable data type."""
+        # serialize as list of dicts
+        ret_n = []
+        for sample in sample_n:
+            ret = {}
+            ret["nodes"] = sample.nodes
+            ret["edges"] = sample.edges
+            ret["node_list"] = sample.node_list
+            ret_n.append(ret)
+        return ret_n
+
+    def from_jsonable(self, sample_n: Sequence[dict]) -> list[GraphObj]:
+        """Convert a JSONable data type to a batch of samples from this space."""
+        ret = []
+        for sample in sample_n:
+            ret_n = GraphObj(
+                sample_n["nodes"], sample_n["edges"], sample_n["node_list"]
+            )
+            ret.append(ret_n)
+        return ret

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -12,7 +12,7 @@ from gym.utils import seeding
 
 
 class Graph(Space):
-    r"""A dictionary representing graph spaces with `node_features`, `edge_features` and `edge_links`.
+    r"""A space representing graph information as a series of `nodes` connected with `edges` according to an adjacency matrix represented as a series of `edge_links`.
 
     Example usage::
 

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -103,13 +103,6 @@ class Graph(Space):
             edge_space (Union[None, Box, Discrete]): space of the node features.
             seed: Optionally, you can use this argument to seed the RNG that is used to sample from the space.
         """
-        self._np_random = None
-        if seed is not None:
-            if isinstance(seed, seeding.RandomNumberGenerator):
-                self._np_random = seed
-            else:
-                self.seed(seed)
-
         assert isinstance(
             node_space, (Box, Discrete)
         ), "Values of the node_space should be instances of Box or Discrete"
@@ -126,7 +119,7 @@ class Graph(Space):
 
         super().__init__(None, None, seed)
 
-    def _generate_sample_space(self, base_space, num) -> Optional[Union[Box, Discrete]]:
+    def _generate_sample_space(self, base_space: Union[None, Box, Discrete], num: int) -> Optional[Union[Box, Discrete]]:
         # the possibility of this space having nothing
         if num == 0:
             return None
@@ -170,14 +163,14 @@ class Graph(Space):
         sampled_nodes = self._sample_sample_space(node_sample_space)
         sampled_edges = self._sample_sample_space(edge_sample_space)
 
-        sampled_node_list = None
+        sampled_edge_links = None
         if sampled_edges is not None:
             if num_edges > 0:
-                sampled_node_list = self.np_random.integers(
+                sampled_edge_links = self.np_random.integers(
                     low=0, high=num_edges, size=(num_edges, 2)
                 )
 
-        return GraphObj(sampled_nodes, sampled_edges, sampled_node_list)
+        return GraphObj(sampled_nodes, sampled_edges, sampled_edge_links)
 
     def contains(self, x: GraphObj) -> bool:
         """Return boolean specifying if x is a valid member of this space."""

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -10,6 +10,20 @@ from gym.utils import seeding
 
 
 class GraphObj:
+    """
+    A base for constructing information as graphs.
+
+    `nodes` must be a nx... sized vector, where ... denotes the shape of
+    the base shape that each node feature must be.
+
+    `edges` must be either None or a np.ndarray where the first
+    dimension (denoted n) is the number of edges.
+    If edges is None, then edge_links must also be None.
+
+    `edge_links` must be a nx2 sized array of ints, where edge_links.max()
+    is not to be equal or larger than the size of the first dimension of nodes, and
+    edge_links.min() is not to be smaller than 0.
+    """
     def __init__(
         self,
         nodes: np.ndarray,
@@ -22,9 +36,17 @@ class GraphObj:
         self.edge_links = edge_links
 
     def __repr__(self) -> str:
+        """A string representation of this graph.
+
+        The representation will include nodes, edges, and edge_links
+
+        Returns:
+            The information in this graph.
+        """
         return f"GraphObj(nodes: \n{self.nodes}, \n\nedges: \n{self.edges}, \n\nedge_links\n{self.edge_links})"
 
     def __eq__(self, other) -> bool:
+        """Check whether `other` is equivalent to this instance."""
         if not isinstance(other, GraphObj):
             return False
         if np.any(self.nodes != other.nodes):
@@ -136,6 +158,7 @@ class Graph(Space):
         return GraphObj(sampled_nodes, sampled_edges, sampled_node_list)
 
     def contains(self, x: GraphObj) -> bool:
+        """Return boolean specifying if x is a valid member of this space."""
         if not isinstance(x, GraphObj):
             return False
         if x.nodes is not None:
@@ -165,9 +188,17 @@ class Graph(Space):
         return True
 
     def __repr__(self) -> str:
+        """A string representation of this space.
+
+        The representation will include node_space and edge_space
+
+        Returns:
+            A representation of the space
+        """
         return f"Graph({self.node_space}, {self.edge_space})"
 
     def __eq__(self, other) -> bool:
+        """Check whether `other` is equivalent to this instance."""
         return (
             isinstance(other, Graph)
             and (self.node_space == other.node_space)

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -87,10 +87,15 @@ def flatten(space: Space[T], x: T) -> np.ndarray:
         x: The value to flatten
 
     Returns:
-        The flattened ``x``, always returns a 1D array for non-graph spaces.
-        For graph spaces, returns a `GraphInstance` where the `nodes` are
-        n x k arrays, `edges` are either m x k arrays or `None`, and
-        `edge_links` are either m x 2 arrays or `None`.
+        - The flattened ``x``, always returns a 1D array for non-graph spaces.
+        - For graph spaces, returns `GraphInstance` where:
+            - `nodes` are n x k arrays
+            - `edges` are either:
+                - m x k arrays
+                - None
+            - `edge_links` are either:
+                - m x 2 arrays
+                - None
 
     Raises:
         NotImplementedError: If the space is not defined in ``gym.spaces``.

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -10,7 +10,16 @@ from typing import TypeVar, Union, cast
 
 import numpy as np
 
-from gym.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Space, Tuple
+from gym.spaces import (
+    Box,
+    Dict,
+    Discrete,
+    Graph,
+    MultiBinary,
+    MultiDiscrete,
+    Space,
+    Tuple,
+)
 
 
 @singledispatch
@@ -253,6 +262,18 @@ def _flatten_space_tuple(space: Tuple) -> Box:
 @flatten_space.register(Dict)
 def _flatten_space_dict(space: Dict) -> Box:
     space_list = [flatten_space(s) for s in space.spaces.values()]
+    return Box(
+        low=np.concatenate([s.low for s in space_list]),
+        high=np.concatenate([s.high for s in space_list]),
+        dtype=np.result_type(*[s.dtype for s in space_list]),
+    )
+
+
+@flatten_space.register(Graph)
+def _flatten_space_graph(space: Graph) -> Box:
+    space_list = []
+    space_list.append(flatten_space(space.node_space))
+    space_list.append(flatten_space(space.edge_space))
     return Box(
         low=np.concatenate([s.low for s in space_list]),
         high=np.concatenate([s.high for s in space_list]),

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -266,7 +266,7 @@ def flatten_space(space: Space) -> Box:
 
         >>> space = Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5))
         >>> flatten_space(space)
-        Box(17,)
+        Graph(Box(-100.0, 100.0, (12,), float32), Box(0, 1, (5,), int64))
         >>> flatten(space, space.sample()) in flatten_space(space)
         True
 

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -138,6 +138,7 @@ def _flatten_dict(space, x) -> np.ndarray:
 
 @flatten.register(Graph)
 def _flatten_graph(space, x) -> np.ndarray:
+    """We're not using `.flatten()` here because a graph is not a homogenous space, see `.flatten` docstring."""
     def _graph_unflatten(space, x):
         ret = None
         if space is not None and x is not None:
@@ -219,6 +220,10 @@ def _unflatten_dict(space: Dict, x: np.ndarray) -> dict:
 
 @unflatten.register(Graph)
 def _unflatten_graph(space: Graph, x: GraphInstance) -> GraphInstance:
+    """We're not using `.unflatten()` here because a graph is not a homogenous space.
+    The size of the outcome is actually not fixed, but determined based on the number of
+    nodes and edges in the graph.
+    """
     def _graph_unflatten(space, x):
         ret = None
         if space is not None and x is not None:

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -138,7 +138,7 @@ def _flatten_dict(space, x) -> np.ndarray:
 
 @flatten.register(Graph)
 def _flatten_graph(space, x) -> np.ndarray:
-    """We're not using `.flatten()` here because a graph is not a homogeneous space, see `.flatten` docstring."""
+    """We're not using `.unflatten() for :class:`Box` and :class:`Discrete` because a graph is not a homogeneous space, see `.flatten` docstring."""
 
     def _graph_unflatten(space, x):
         ret = None
@@ -221,7 +221,7 @@ def _unflatten_dict(space: Dict, x: np.ndarray) -> dict:
 
 @unflatten.register(Graph)
 def _unflatten_graph(space: Graph, x: GraphInstance) -> GraphInstance:
-    """We're not using `.unflatten()` here because a graph is not a homogeneous space.
+    """We're not using `.unflatten() for :class:`Box` and :class:`Discrete` because a graph is not a homogeneous space.
 
     The size of the outcome is actually not fixed, but determined based on the number of
     nodes and edges in the graph.

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -221,6 +221,7 @@ def _unflatten_dict(space: Dict, x: np.ndarray) -> dict:
 @unflatten.register(Graph)
 def _unflatten_graph(space: Graph, x: GraphInstance) -> GraphInstance:
     """We're not using `.unflatten()` here because a graph is not a homogenous space.
+
     The size of the outcome is actually not fixed, but determined based on the number of
     nodes and edges in the graph.
     """

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -139,6 +139,7 @@ def _flatten_dict(space, x) -> np.ndarray:
 @flatten.register(Graph)
 def _flatten_graph(space, x) -> np.ndarray:
     """We're not using `.flatten()` here because a graph is not a homogenous space, see `.flatten` docstring."""
+
     def _graph_unflatten(space, x):
         ret = None
         if space is not None and x is not None:
@@ -225,6 +226,7 @@ def _unflatten_graph(space: Graph, x: GraphInstance) -> GraphInstance:
     The size of the outcome is actually not fixed, but determined based on the number of
     nodes and edges in the graph.
     """
+
     def _graph_unflatten(space, x):
         ret = None
         if space is not None and x is not None:

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -138,7 +138,7 @@ def _flatten_dict(space, x) -> np.ndarray:
 
 @flatten.register(Graph)
 def _flatten_graph(space, x) -> np.ndarray:
-    """We're not using `.flatten()` here because a graph is not a homogenous space, see `.flatten` docstring."""
+    """We're not using `.flatten()` here because a graph is not a homogeneous space, see `.flatten` docstring."""
 
     def _graph_unflatten(space, x):
         ret = None
@@ -221,7 +221,7 @@ def _unflatten_dict(space: Dict, x: np.ndarray) -> dict:
 
 @unflatten.register(Graph)
 def _unflatten_graph(space: Graph, x: GraphInstance) -> GraphInstance:
-    """We're not using `.unflatten()` here because a graph is not a homogenous space.
+    """We're not using `.unflatten()` here because a graph is not a homogeneous space.
 
     The size of the outcome is actually not fixed, but determined based on the number of
     nodes and edges in the graph.

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -15,6 +15,7 @@ from gym.spaces import (
     Dict,
     Discrete,
     Graph,
+    GraphInstance,
     MultiBinary,
     MultiDiscrete,
     Space,
@@ -127,6 +128,24 @@ def _flatten_dict(space, x) -> np.ndarray:
     return np.concatenate([flatten(s, x[key]) for key, s in space.spaces.items()])
 
 
+@flatten.register(Graph)
+def _flatten_graph(space, x) -> np.ndarray:
+    def _graph_unflatten(space, x):
+        ret = None
+        if space is not None and x is not None:
+            if isinstance(space, Box):
+                ret = x.reshape(x.shape[0], -1)
+            elif isinstance(space, Discrete):
+                ret = np.zeros((x.shape[0], space.n - space.start), dtype=space.dtype)
+                ret[np.arange(x.shape[0]), x - space.start] = 1
+        return ret
+
+    nodes = _graph_unflatten(space.node_space, x.nodes)
+    edges = _graph_unflatten(space.edge_space, x.edges)
+
+    return GraphInstance(nodes, edges, x.edge_links)
+
+
 @singledispatch
 def unflatten(space: Space[T], x: np.ndarray) -> T:
     """Unflatten a data point from a space.
@@ -190,6 +209,23 @@ def _unflatten_dict(space: Dict, x: np.ndarray) -> dict:
     )
 
 
+@unflatten.register(Graph)
+def _unflatten_graph(space: Graph, x: GraphInstance) -> GraphInstance:
+    def _graph_unflatten(space, x):
+        ret = None
+        if space is not None and x is not None:
+            if isinstance(space, Box):
+                ret = x.reshape(-1, *space.shape)
+            elif isinstance(space, Discrete):
+                ret = np.asarray(np.nonzero(x))[-1, :]
+        return ret
+
+    nodes = _graph_unflatten(space.node_space, x.nodes)
+    edges = _graph_unflatten(space.edge_space, x.edges)
+
+    return GraphInstance(nodes, edges, x.edge_links)
+
+
 @singledispatch
 def flatten_space(space: Space) -> Box:
     """Flatten a space into a single ``Box``.
@@ -222,6 +258,15 @@ def flatten_space(space: Space) -> Box:
         >>> space = Dict({"position": Discrete(2), "velocity": Box(0, 1, shape=(2, 2))})
         >>> flatten_space(space)
         Box(6,)
+        >>> flatten(space, space.sample()) in flatten_space(space)
+        True
+
+
+    Example that flattens a graph::
+
+        >>> space = Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5))
+        >>> flatten_space(space)
+        Box(17,)
         >>> flatten(space, space.sample()) in flatten_space(space)
         True
 
@@ -270,12 +315,10 @@ def _flatten_space_dict(space: Dict) -> Box:
 
 
 @flatten_space.register(Graph)
-def _flatten_space_graph(space: Graph) -> Box:
-    space_list = []
-    space_list.append(flatten_space(space.node_space))
-    space_list.append(flatten_space(space.edge_space))
-    return Box(
-        low=np.concatenate([s.low for s in space_list]),
-        high=np.concatenate([s.high for s in space_list]),
-        dtype=np.result_type(*[s.dtype for s in space_list]),
+def _flatten_space_graph(space: Graph) -> Graph:
+    return Graph(
+        node_space=flatten_space(space.node_space),
+        edge_space=flatten_space(space.edge_space)
+        if space.edge_space is not None
+        else None,
     )

--- a/gym/spaces/utils.py
+++ b/gym/spaces/utils.py
@@ -87,7 +87,10 @@ def flatten(space: Space[T], x: T) -> np.ndarray:
         x: The value to flatten
 
     Returns:
-        The flattened ``x``, always returns a 1D array.
+        The flattened ``x``, always returns a 1D array for non-graph spaces.
+        For graph spaces, returns a `GraphInstance` where the `nodes` are
+        n x k arrays, `edges` are either m x k arrays or `None`, and
+        `edge_links` are either m x 2 arrays or `None`.
 
     Raises:
         NotImplementedError: If the space is not defined in ``gym.spaces``.
@@ -231,9 +234,12 @@ def flatten_space(space: Space) -> Box:
     """Flatten a space into a single ``Box``.
 
     This is equivalent to :func:`flatten`, but operates on the space itself. The
-    result always is a `Box` with flat boundaries. The box has exactly
-    :func:`flatdim` dimensions. Flattening a sample of the original space
-    has the same effect as taking a sample of the flattenend space.
+    result for non-graph spaces is always a `Box` with flat boundaries. While
+    the result for graph spaces is always a `Graph` with `node_space` being a `Box`
+    with flat boundaries and `edge_space` being a `Box` with flat boundaries or
+    `None`. The box has exactly :func:`flatdim` dimensions. Flattening a sample
+    of the original space has the same effect as taking a sample of the flattenend
+    space.
 
     Example::
 

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -6,7 +6,7 @@ import tempfile
 import numpy as np
 import pytest
 
-from gym.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Tuple
+from gym.spaces import Box, Dict, Discrete, Graph, MultiBinary, MultiDiscrete, Tuple
 
 
 @pytest.mark.parametrize(
@@ -40,6 +40,8 @@ from gym.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Tuple
                 ),
             }
         ),
+        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
+        Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
     ],
 )
 def test_roundtripping(space):
@@ -94,6 +96,8 @@ def test_roundtripping(space):
                 ),
             }
         ),
+        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
+        Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
     ],
 )
 def test_equality(space):
@@ -130,6 +134,14 @@ def test_equality(space):
         ),
         (Dict({"position": Discrete(5)}), Dict({"position": Discrete(4)})),
         (Dict({"position": Discrete(5)}), Dict({"speed": Discrete(5)})),
+        (
+            Graph(
+                node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)
+            ),
+            Graph(
+                node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))
+            ),
+        ),
     ],
 )
 def test_inequality(spaces):
@@ -191,6 +203,14 @@ def test_sample(space):
         (
             Box(low=np.array([-np.inf, 0.0]), high=np.array([0.0, np.inf])),
             Box(low=np.array([-np.inf, 1.0]), high=np.array([0.0, np.inf])),
+        ),
+        (
+            Graph(
+                node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)
+            ),
+            Graph(
+                node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))
+            ),
         ),
     ],
 )
@@ -306,6 +326,8 @@ def test_box_dtype_check():
                 ),
             }
         ),
+        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
+        Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
     ],
 )
 def test_seed_returns_list(space):
@@ -365,6 +387,8 @@ def sample_equal(sample1, sample2):
                 ),
             }
         ),
+        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
+        Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
     ],
 )
 def test_seed_reproducibility(space):
@@ -405,10 +429,18 @@ def test_seed_reproducibility(space):
                 ),
             }
         ),
+        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
+        Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
     ],
 )
 def test_seed_subspace_incorrelated(space):
-    subspaces = space.spaces if isinstance(space, Tuple) else space.spaces.values()
+    subspaces = []
+    if isinstance(space, Tuple):
+        subspaces = space.spaces
+    elif isinstance(space, Dict):
+        subspaces = space.spaces.values()
+    elif isinstance(space, Graph):
+        subspaces = [space.node_space, space.edge_space]
 
     space.seed(0)
     states = [
@@ -657,6 +689,8 @@ def test_box_legacy_state_pickling():
                 ),
             }
         ),
+        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
+        Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
     ],
 )
 def test_pickle(space):

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -42,6 +42,7 @@ from gym.spaces import Box, Dict, Discrete, Graph, MultiBinary, MultiDiscrete, T
         ),
         Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
         Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
+        Graph(node_space=Discrete(5), edge_space=None),
     ],
 )
 def test_roundtripping(space):
@@ -98,6 +99,7 @@ def test_roundtripping(space):
         ),
         Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
         Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
+        Graph(node_space=Discrete(5), edge_space=None),
     ],
 )
 def test_equality(space):
@@ -138,9 +140,7 @@ def test_equality(space):
             Graph(
                 node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)
             ),
-            Graph(
-                node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))
-            ),
+            Graph(node_space=Discrete(5), edge_space=None),
         ),
     ],
 )
@@ -208,9 +208,7 @@ def test_sample(space):
             Graph(
                 node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)
             ),
-            Graph(
-                node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))
-            ),
+            Graph(node_space=Discrete(5), edge_space=None),
         ),
     ],
 )
@@ -328,6 +326,8 @@ def test_box_dtype_check():
         ),
         Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
         Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
+        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=None),
+        Graph(node_space=Discrete(5), edge_space=None),
     ],
 )
 def test_seed_returns_list(space):
@@ -389,6 +389,8 @@ def sample_equal(sample1, sample2):
         ),
         Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
         Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
+        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=None),
+        Graph(node_space=Discrete(5), edge_space=None),
     ],
 )
 def test_seed_reproducibility(space):
@@ -431,6 +433,8 @@ def test_seed_reproducibility(space):
         ),
         Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
         Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
+        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=None),
+        Graph(node_space=Discrete(5), edge_space=None),
     ],
 )
 def test_seed_subspace_incorrelated(space):
@@ -691,6 +695,8 @@ def test_box_legacy_state_pickling():
         ),
         Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
         Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
+        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=None),
+        Graph(node_space=Discrete(5), edge_space=None),
     ],
 )
 def test_pickle(space):

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -444,7 +444,10 @@ def test_seed_subspace_incorrelated(space):
     elif isinstance(space, Dict):
         subspaces = space.spaces.values()
     elif isinstance(space, Graph):
-        subspaces = [space.node_space, space.edge_space]
+        if space.edge_space is not None:
+            subspaces = [space.node_space, space.edge_space]
+        else:
+            subspaces = [space.node_space]
 
     space.seed(0)
     states = [

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -14,7 +14,7 @@ from gym.spaces import (
     utils,
 )
 
-homogenous_spaces = [
+homogeneous_spaces = [
     Discrete(3),
     Box(low=0.0, high=np.inf, shape=(2, 2)),
     Box(low=0.0, high=np.inf, shape=(2, 2), dtype=np.float16),
@@ -49,13 +49,13 @@ graph_spaces = [
 ]
 
 
-@pytest.mark.parametrize(["space", "flatdim"], zip(homogenous_spaces, flatdims))
+@pytest.mark.parametrize(["space", "flatdim"], zip(homogeneous_spaces, flatdims))
 def test_flatdim(space, flatdim):
     dim = utils.flatdim(space)
     assert dim == flatdim, f"Expected {dim} to equal {flatdim}"
 
 
-@pytest.mark.parametrize("space", homogenous_spaces)
+@pytest.mark.parametrize("space", homogeneous_spaces)
 def test_flatten_space_boxes(space):
     flat_space = utils.flatten_space(space)
     assert isinstance(flat_space, Box), f"Expected {type(flat_space)} to equal {Box}"
@@ -64,7 +64,7 @@ def test_flatten_space_boxes(space):
     assert single_dim == flatdim, f"Expected {single_dim} to equal {flatdim}"
 
 
-@pytest.mark.parametrize("space", homogenous_spaces + graph_spaces)
+@pytest.mark.parametrize("space", homogeneous_spaces + graph_spaces)
 def test_flat_space_contains_flat_points(space):
     some_samples = [space.sample() for _ in range(10)]
     flattened_samples = [utils.flatten(space, sample) for sample in some_samples]
@@ -75,7 +75,7 @@ def test_flat_space_contains_flat_points(space):
         ), f"Expected sample #{i} {flat_sample} to be in {flat_space}"
 
 
-@pytest.mark.parametrize("space", homogenous_spaces)
+@pytest.mark.parametrize("space", homogeneous_spaces)
 def test_flatten_dim(space):
     sample = utils.flatten(space, space.sample())
     (single_dim,) = sample.shape
@@ -83,7 +83,7 @@ def test_flatten_dim(space):
     assert single_dim == flatdim, f"Expected {single_dim} to equal {flatdim}"
 
 
-@pytest.mark.parametrize("space", homogenous_spaces + graph_spaces)
+@pytest.mark.parametrize("space", homogeneous_spaces + graph_spaces)
 def test_flatten_roundtripping(space):
     some_samples = [space.sample() for _ in range(10)]
     flattened_samples = [utils.flatten(space, sample) for sample in some_samples]
@@ -146,7 +146,7 @@ expected_flattened_dtypes = [
 
 @pytest.mark.parametrize(
     ["original_space", "expected_flattened_dtype"],
-    zip(homogenous_spaces, expected_flattened_dtypes),
+    zip(homogeneous_spaces, expected_flattened_dtypes),
 )
 def test_dtypes(original_space, expected_flattened_dtype):
     flattened_space = utils.flatten_space(original_space)
@@ -227,7 +227,7 @@ expected_flattened_samples = [
 
 @pytest.mark.parametrize(
     ["space", "sample", "expected_flattened_sample"],
-    zip(homogenous_spaces, samples, expected_flattened_samples),
+    zip(homogeneous_spaces, samples, expected_flattened_samples),
 )
 def test_flatten(space, sample, expected_flattened_sample):
     assert sample in space
@@ -240,7 +240,7 @@ def test_flatten(space, sample, expected_flattened_sample):
 
 @pytest.mark.parametrize(
     ["space", "flattened_sample", "expected_sample"],
-    zip(homogenous_spaces, expected_flattened_samples, samples),
+    zip(homogeneous_spaces, expected_flattened_samples, samples),
 )
 def test_unflatten(space, flattened_sample, expected_sample):
     sample = utils.unflatten(space, flattened_sample)
@@ -272,7 +272,7 @@ expected_flattened_spaces = [
 
 @pytest.mark.parametrize(
     ["space", "expected_flattened_space"],
-    zip(homogenous_spaces, expected_flattened_spaces),
+    zip(homogeneous_spaces, expected_flattened_spaces),
 )
 def test_flatten_space(space, expected_flattened_space):
     flattened_space = utils.flatten_space(space)

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -3,9 +3,18 @@ from collections import OrderedDict
 import numpy as np
 import pytest
 
-from gym.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Tuple, utils
+from gym.spaces import (
+    Box,
+    Dict,
+    Discrete,
+    Graph,
+    MultiBinary,
+    MultiDiscrete,
+    Tuple,
+    utils,
+)
 
-spaces = [
+homogenous_spaces = [
     Discrete(3),
     Box(low=0.0, high=np.inf, shape=(2, 2)),
     Box(low=0.0, high=np.inf, shape=(2, 2), dtype=np.float16),
@@ -33,14 +42,20 @@ spaces = [
 
 flatdims = [3, 4, 4, 15, 7, 9, 14, 10, 7, 3, 8]
 
+graph_spaces = [
+    Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
+    Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
+    Graph(node_space=Discrete(5), edge_space=None),
+]
 
-@pytest.mark.parametrize(["space", "flatdim"], zip(spaces, flatdims))
+
+@pytest.mark.parametrize(["space", "flatdim"], zip(homogenous_spaces, flatdims))
 def test_flatdim(space, flatdim):
     dim = utils.flatdim(space)
     assert dim == flatdim, f"Expected {dim} to equal {flatdim}"
 
 
-@pytest.mark.parametrize("space", spaces)
+@pytest.mark.parametrize("space", homogenous_spaces)
 def test_flatten_space_boxes(space):
     flat_space = utils.flatten_space(space)
     assert isinstance(flat_space, Box), f"Expected {type(flat_space)} to equal {Box}"
@@ -49,18 +64,18 @@ def test_flatten_space_boxes(space):
     assert single_dim == flatdim, f"Expected {single_dim} to equal {flatdim}"
 
 
-@pytest.mark.parametrize("space", spaces)
+@pytest.mark.parametrize("space", homogenous_spaces + graph_spaces)
 def test_flat_space_contains_flat_points(space):
     some_samples = [space.sample() for _ in range(10)]
     flattened_samples = [utils.flatten(space, sample) for sample in some_samples]
     flat_space = utils.flatten_space(space)
     for i, flat_sample in enumerate(flattened_samples):
-        assert (
-            flat_sample in flat_space
+        assert flat_space.contains(
+            flat_sample
         ), f"Expected sample #{i} {flat_sample} to be in {flat_space}"
 
 
-@pytest.mark.parametrize("space", spaces)
+@pytest.mark.parametrize("space", homogenous_spaces)
 def test_flatten_dim(space):
     sample = utils.flatten(space, space.sample())
     (single_dim,) = sample.shape
@@ -68,7 +83,7 @@ def test_flatten_dim(space):
     assert single_dim == flatdim, f"Expected {single_dim} to equal {flatdim}"
 
 
-@pytest.mark.parametrize("space", spaces)
+@pytest.mark.parametrize("space", homogenous_spaces + graph_spaces)
 def test_flatten_roundtripping(space):
     some_samples = [space.sample() for _ in range(10)]
     flattened_samples = [utils.flatten(space, sample) for sample in some_samples]
@@ -131,7 +146,7 @@ expected_flattened_dtypes = [
 
 @pytest.mark.parametrize(
     ["original_space", "expected_flattened_dtype"],
-    zip(spaces, expected_flattened_dtypes),
+    zip(homogenous_spaces, expected_flattened_dtypes),
 )
 def test_dtypes(original_space, expected_flattened_dtype):
     flattened_space = utils.flatten_space(original_space)
@@ -212,7 +227,7 @@ expected_flattened_samples = [
 
 @pytest.mark.parametrize(
     ["space", "sample", "expected_flattened_sample"],
-    zip(spaces, samples, expected_flattened_samples),
+    zip(homogenous_spaces, samples, expected_flattened_samples),
 )
 def test_flatten(space, sample, expected_flattened_sample):
     assert sample in space
@@ -225,7 +240,7 @@ def test_flatten(space, sample, expected_flattened_sample):
 
 @pytest.mark.parametrize(
     ["space", "flattened_sample", "expected_sample"],
-    zip(spaces, expected_flattened_samples, samples),
+    zip(homogenous_spaces, expected_flattened_samples, samples),
 )
 def test_unflatten(space, flattened_sample, expected_sample):
     sample = utils.unflatten(space, flattened_sample)
@@ -256,7 +271,8 @@ expected_flattened_spaces = [
 
 
 @pytest.mark.parametrize(
-    ["space", "expected_flattened_space"], zip(spaces, expected_flattened_spaces)
+    ["space", "expected_flattened_space"],
+    zip(homogenous_spaces, expected_flattened_spaces),
 )
 def test_flatten_space(space, expected_flattened_space):
     flattened_space = utils.flatten_space(space)


### PR DESCRIPTION
# Description

This adds graph spaces to Gym.

Essentially, this PR adds support of Gym spaces to also include graph representations.
Graphs are represented using a `namedtuple`.
Graph spaces by default accept either `Discrete` or `Box` spaces as `node` or `edge` features, while the `node_list` is an `n x 2` integer only vector representing the list of nodes that each edge is connected to.

The space does not make any restrictions on amount of edges between nodes, nor does it restrict graphs from having self-connections, and further does not make any assumptions or restrictions on whether edges are unidirectional or bidirectional. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
