### PR TITLE
Fixed `gym.vector.make` disable env checker parameter

### DIFF
--- a/gym/vector/__init__.py
+++ b/gym/vector/__init__.py
@@ -63,7 +63,6 @@ def make(
         return _make_env
 
     env_fns = [
-        create_env(env_num == 0 and disable_env_checker is False)
-        for env_num in range(num_envs)
+        create_env(disable_env_checker or env_num > 0) for env_num in range(num_envs)
     ]
     return AsyncVectorEnv(env_fns) if asynchronous else SyncVectorEnv(env_fns)


### PR DESCRIPTION
In #2864, `gym.vector.make` was upgraded to consider the `disable_env_checker` parameter in `gym.make`
The intention was that if the environment checker was enabled, i.e. `disable_env_checker=False` as default, then this would only happen for the *first* of the vector environment to prevent the user being spammed by warnings for all X number of environments. 
However, I forgot I got the new check that wrong way around meaning that only if the env checker was enabled and only on the first environment would the environment checker actually be disabled. 
This PR fixes that check by checking if the environment checker is disabled, for all environments, or if the environment number is greater than one. Meaning that for all other environments, the checker is disabled. 