### PR TITLE
Env Step Check allow rewards to be np int

### DIFF
--- a/gym/utils/passive_env_checker.py
+++ b/gym/utils/passive_env_checker.py
@@ -276,7 +276,7 @@ def passive_env_step_check(env, action):
         logger.warn("Encountered inf value in observations.")
 
     assert isinstance(
-        reward, (float, int, np.float32)
+        reward, (float, int, np.floating, np.integer)
     ), "The reward returned by `step()` must be a float"
     if np.any(np.isnan(reward)):
         logger.warn("Encountered NaN value in rewards.")


### PR DESCRIPTION
# Description

Changed so `passive_env_step_check` will also allow NumPy datatypes that are children of `np.integer` (ex. `np.int32`, `np.int64`, ...) and `np.floating` (ex. `np.float32`, `np.float64`, ...).

The reason is that some gym environment returns the reward in various NumPy "float" and "integer" datatypes, which is **not** incorrect behavior, thus allowing them to pass the check.

Fixes #2878

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~New feature (non-breaking change which adds functionality)~
- [ ] ~Breaking change (fix or feature that would cause existing functionality to not work as expected)~
- [ ] ~This change requires a documentation update~

### Screenshots

_not applicable_

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
