### PR TITLE
Add dict obs to passive_env_step_check

### DIFF
--- a/gym/utils/passive_env_checker.py
+++ b/gym/utils/passive_env_checker.py
@@ -270,6 +270,8 @@ def passive_env_step_check(env, action):
         )
 
     _check_obs(obs, env.observation_space, "step")
+    if isinstance(obs, dict):
+        obs = spaces.flatten(env.observation_space, obs)
     if np.any(np.isnan(obs)):
         logger.warn("Encountered NaN value in observations.")
     if np.any(np.isinf(obs)):


### PR DESCRIPTION
# Description

Some environments present dictionary observations as in [Gym Robotics](https://github.com/Farama-Foundation/Gym-Robotics). This PR includes dictionary observation check for the `passive_env_step_check` function.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
