### PR TITLE
fix: add render_mode getter to Wrapper

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -359,6 +359,11 @@ class Wrapper(Env[ObsType, ActType]):
         self._metadata = value
 
     @property
+    def render_mode(self) -> Optional[str]:
+        """Returns the environment render_mode."""
+        return self.env.render_mode
+
+    @property
     def np_random(self) -> RandomNumberGenerator:
         """Returns the environment np_random."""
         return self.env.np_random


### PR DESCRIPTION
Currently, wrapped environments don't forward correctly the attribute `render_mode`.
This PR fixes this; thanks @Markus28 for spotting this