### PR TITLE
Fix inversion check action and observation space

### DIFF
--- a/gym/utils/env_checker.py
+++ b/gym/utils/env_checker.py
@@ -230,11 +230,11 @@ def check_env(env: gym.Env, warn: bool = None, skip_render_check: bool = True):
     assert hasattr(
         env, "action_space"
     ), "You must specify a action space. https://www.gymlibrary.ml/content/environment_creation/"
-    check_observation_space(env.action_space)
+    check_action_space(env.action_space)
     assert hasattr(
         env, "observation_space"
     ), "You must specify an observation space. https://www.gymlibrary.ml/content/environment_creation/"
-    check_action_space(env.observation_space)
+    check_observation_space(env.observation_space)
 
     # ==== Check the reset method ====
     check_reset_seed(env)


### PR DESCRIPTION
# Description

It seems like there is an inversion in the check_env function: observation space is checked with check_action_space` and action space is checked with `check_observation_space`

Fixes #2885

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
