### PR TITLE
Fix TimeLimit wrapper and add tests

### DIFF
--- a/gym/wrappers/time_limit.py
+++ b/gym/wrappers/time_limit.py
@@ -49,7 +49,10 @@ class TimeLimit(gym.Wrapper):
         observation, reward, done, info = self.env.step(action)
         self._elapsed_steps += 1
         if self._elapsed_steps >= self._max_episode_steps:
-            info["TimeLimit.truncated"] = not done
+            # TimeLimit.truncated key may have been already set by the environment
+            # do not overwrite it
+            episode_truncated = not done or info.get("TimeLimit.truncated", False)
+            info["TimeLimit.truncated"] = episode_truncated
             done = True
         return observation, reward, done, info
 

--- a/tests/wrappers/test_time_limit.py
+++ b/tests/wrappers/test_time_limit.py
@@ -1,4 +1,7 @@
+import pytest
+
 import gym
+from gym.envs.classic_control.pendulum import PendulumEnv
 from gym.wrappers import TimeLimit
 
 
@@ -15,3 +18,47 @@ def test_time_limit_reset_info():
     obs, info = env.reset(return_info=True)
     assert ob_space.contains(obs)
     assert isinstance(info, dict)
+
+
+@pytest.mark.parametrize("double_wrap", [False, True])
+def test_time_limit_wrapper(double_wrap):
+    # The pendulum env do not terminates by default
+    # so we are sure termination is only due to timeout
+    env = PendulumEnv()
+    max_episode_length = 20
+    env = TimeLimit(env, max_episode_length)
+    if double_wrap:
+        # TimeLimit wrapper should not overwrite
+        # the TimeLimit.truncated key
+        # if it was already set
+        env = TimeLimit(env, max_episode_length)
+    env.reset()
+    done = False
+    n_steps = 0
+    info = {}
+    while not done:
+        n_steps += 1
+        _, _, done, info = env.step(env.action_space.sample())
+
+    assert n_steps == max_episode_length
+    assert "TimeLimit.truncated" in info
+    assert info["TimeLimit.truncated"] is True
+
+    # Special case: termination at the last timestep
+    # but not due to timeout
+    env = PendulumEnv()
+
+    def patched_step(_action):
+        return env.observation_space.sample(), 0.0, True, {}
+
+    env.step = patched_step
+
+    max_episode_length = 1
+    env = TimeLimit(env, max_episode_length)
+    if double_wrap:
+        env = TimeLimit(env, max_episode_length)
+    env.reset()
+    _, _, done, info = env.step(env.action_space.sample())
+    assert done is True
+    assert "TimeLimit.truncated" in info
+    assert info["TimeLimit.truncated"] is False

--- a/tests/wrappers/test_time_limit.py
+++ b/tests/wrappers/test_time_limit.py
@@ -22,7 +22,7 @@ def test_time_limit_reset_info():
 
 @pytest.mark.parametrize("double_wrap", [False, True])
 def test_time_limit_wrapper(double_wrap):
-    # The pendulum env do not terminates by default
+    # The pendulum env does not terminate by default
     # so we are sure termination is only due to timeout
     env = PendulumEnv()
     max_episode_length = 20
@@ -44,6 +44,9 @@ def test_time_limit_wrapper(double_wrap):
     assert "TimeLimit.truncated" in info
     assert info["TimeLimit.truncated"] is True
 
+
+@pytest.mark.parametrize("double_wrap", [False, True])
+def test_termination_on_last_step(double_wrap):
     # Special case: termination at the last timestep
     # but not due to timeout
     env = PendulumEnv()


### PR DESCRIPTION
# Description

Fix `TimeLimit` wrapper to allow setting the timeout key inside the env.
Add basic testing that was missing before... (I was surprised there were none :/)

Related to https://github.com/openai/gym/pull/2752

Note: this fix is needed for properly fixing the car racing env too

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: the test generate a warning but due to the passive env checker on the Pendulul env.

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
