### PR TITLE
Fix CarRacing termination

### DIFF
--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -88,7 +88,7 @@ class FrictionDetector(contactListener):
                     and self.env.tile_visited_count / len(self.env.track)
                     > self.lap_complete_percent
                 ):
-                    self.env_new_lap = True
+                    self.env.new_lap = True
         else:
             obj.tiles.remove(tile)
 
@@ -484,6 +484,7 @@ class CarRacing(gym.Env, EzPickle):
 
         step_reward = 0
         done = False
+        info = {}
         if action is not None:  # First step without action, called from reset()
             self.reward -= 0.1
             # We actually don't want to count fuel spent, we want car to be faster.
@@ -493,13 +494,17 @@ class CarRacing(gym.Env, EzPickle):
             self.prev_reward = self.reward
             if self.tile_visited_count == len(self.track) or self.new_lap:
                 done = True
+                # Termination due to finishing lap
+                # This should not be treated as a failure
+                # but like a timeout
+                info["TimeLimit.truncated"] = True
             x, y = self.car.hull.position
             if abs(x) > PLAYFIELD or abs(y) > PLAYFIELD:
                 done = True
                 step_reward = -100
 
         self.renderer.render_step()
-        return self.state, step_reward, done, {}
+        return self.state, step_reward, done, info
 
     def render(self, mode: str = "human"):
         if self.render_mode is not None:


### PR DESCRIPTION
# Description

Fix CarRacing termination (both reaching end of lap and treating it not like a failure).

See https://github.com/openai/gym/pull/2525#discussion_r873539773

EDIT: need to be merged after https://github.com/openai/gym/pull/2888

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
