### PR TITLE
Fix: add mujoco render arguments to init

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -359,6 +359,11 @@ class Wrapper(Env[ObsType, ActType]):
         self._metadata = value
 
     @property
+    def render_mode(self) -> Optional[str]:
+        """Returns the environment render_mode."""
+        return self.env.render_mode
+
+    @property
     def np_random(self) -> RandomNumberGenerator:
         """Returns the environment np_random."""
         return self.env.np_random

--- a/gym/envs/mujoco/ant.py
+++ b/gym/envs/mujoco/ant.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -9,7 +7,7 @@ from gym.envs.mujoco import mujoco_env
 class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
-            self, "ant.xml", 5, mujoco_bindings="mujoco_py",  **kwargs
+            self, "ant.xml", 5, mujoco_bindings="mujoco_py", **kwargs
         )
         utils.EzPickle.__init__(self)
 
@@ -23,7 +21,7 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         forward_reward = (xposafter - xposbefore) / self.dt
         ctrl_cost = 0.5 * np.square(a).sum()
         contact_cost = (
-                0.5 * 1e-3 * np.sum(np.square(np.clip(self.sim.data.cfrc_ext, -1, 1)))
+            0.5 * 1e-3 * np.sum(np.square(np.clip(self.sim.data.cfrc_ext, -1, 1)))
         )
         survive_reward = 1.0
         reward = forward_reward - ctrl_cost - contact_cost + survive_reward

--- a/gym/envs/mujoco/ant.py
+++ b/gym/envs/mujoco/ant.py
@@ -7,9 +7,9 @@ from gym.envs.mujoco import mujoco_env
 
 
 class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
-            self, "ant.xml", 5, render_mode=render_mode, mujoco_bindings="mujoco_py"
+            self, "ant.xml", 5, mujoco_bindings="mujoco_py",  **kwargs
         )
         utils.EzPickle.__init__(self)
 
@@ -23,7 +23,7 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         forward_reward = (xposafter - xposbefore) / self.dt
         ctrl_cost = 0.5 * np.square(a).sum()
         contact_cost = (
-            0.5 * 1e-3 * np.sum(np.square(np.clip(self.sim.data.cfrc_ext, -1, 1)))
+                0.5 * 1e-3 * np.sum(np.square(np.clip(self.sim.data.cfrc_ext, -1, 1)))
         )
         survive_reward = 1.0
         reward = forward_reward - ctrl_cost - contact_cost + survive_reward

--- a/gym/envs/mujoco/ant_v3.py
+++ b/gym/envs/mujoco/ant_v3.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -41,7 +39,9 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             exclude_current_positions_from_observation
         )
 
-        mujoco_env.MujocoEnv.__init__(self, xml_file, 5, mujoco_bindings="mujoco_py", **kwargs)
+        mujoco_env.MujocoEnv.__init__(
+            self, xml_file, 5, mujoco_bindings="mujoco_py", **kwargs
+        )
 
     @property
     def healthy_reward(self):

--- a/gym/envs/mujoco/ant_v3.py
+++ b/gym/envs/mujoco/ant_v3.py
@@ -13,7 +13,6 @@ DEFAULT_CAMERA_CONFIG = {
 class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(
         self,
-        render_mode: Optional[str] = None,
         xml_file="ant.xml",
         ctrl_cost_weight=0.5,
         contact_cost_weight=5e-4,
@@ -23,6 +22,7 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         contact_force_range=(-1.0, 1.0),
         reset_noise_scale=0.1,
         exclude_current_positions_from_observation=True,
+        **kwargs
     ):
         utils.EzPickle.__init__(**locals())
 
@@ -41,7 +41,7 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             exclude_current_positions_from_observation
         )
 
-        mujoco_env.MujocoEnv.__init__(self, xml_file, 5, mujoco_bindings="mujoco_py")
+        mujoco_env.MujocoEnv.__init__(self, xml_file, 5, mujoco_bindings="mujoco_py", **kwargs)
 
     @property
     def healthy_reward(self):

--- a/gym/envs/mujoco/ant_v4.py
+++ b/gym/envs/mujoco/ant_v4.py
@@ -177,6 +177,7 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         contact_force_range=(-1.0, 1.0),
         reset_noise_scale=0.1,
         exclude_current_positions_from_observation=True,
+        **kwargs
     ):
         utils.EzPickle.__init__(**locals())
 
@@ -197,7 +198,7 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             exclude_current_positions_from_observation
         )
 
-        mujoco_env.MujocoEnv.__init__(self, xml_file, 5, render_mode=render_mode)
+        mujoco_env.MujocoEnv.__init__(self, xml_file, 5, **kwargs)
 
     @property
     def healthy_reward(self):

--- a/gym/envs/mujoco/ant_v4.py
+++ b/gym/envs/mujoco/ant_v4.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -166,7 +164,6 @@ class AntEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def __init__(
         self,
-        render_mode: Optional[str] = None,
         xml_file="ant.xml",
         ctrl_cost_weight=0.5,
         use_contact_forces=False,

--- a/gym/envs/mujoco/half_cheetah.py
+++ b/gym/envs/mujoco/half_cheetah.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -9,11 +7,7 @@ from gym.envs.mujoco import mujoco_env
 class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
-            self,
-            "half_cheetah.xml",
-            5,
-            mujoco_bindings="mujoco_py",
-            **kwargs
+            self, "half_cheetah.xml", 5, mujoco_bindings="mujoco_py", **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/half_cheetah.py
+++ b/gym/envs/mujoco/half_cheetah.py
@@ -7,13 +7,13 @@ from gym.envs.mujoco import mujoco_env
 
 
 class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
             self,
             "half_cheetah.xml",
             5,
-            render_mode=render_mode,
             mujoco_bindings="mujoco_py",
+            **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/half_cheetah_v3.py
+++ b/gym/envs/mujoco/half_cheetah_v3.py
@@ -1,7 +1,5 @@
 __credits__ = ["Rushiv Arora"]
 
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/half_cheetah_v3.py
+++ b/gym/envs/mujoco/half_cheetah_v3.py
@@ -15,12 +15,12 @@ DEFAULT_CAMERA_CONFIG = {
 class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(
         self,
-        render_mode: Optional[str] = None,
         xml_file="half_cheetah.xml",
         forward_reward_weight=1.0,
         ctrl_cost_weight=0.1,
         reset_noise_scale=0.1,
         exclude_current_positions_from_observation=True,
+        **kwargs
     ):
         utils.EzPickle.__init__(**locals())
 
@@ -35,7 +35,7 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         )
 
         mujoco_env.MujocoEnv.__init__(
-            self, xml_file, 5, render_mode=render_mode, mujoco_bindings="mujoco_py"
+            self, xml_file, 5, mujoco_bindings="mujoco_py", **kwargs
         )
 
     def control_cost(self, action):

--- a/gym/envs/mujoco/half_cheetah_v4.py
+++ b/gym/envs/mujoco/half_cheetah_v4.py
@@ -151,11 +151,11 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def __init__(
         self,
-        render_mode: Optional[str] = None,
         forward_reward_weight=1.0,
         ctrl_cost_weight=0.1,
         reset_noise_scale=0.1,
         exclude_current_positions_from_observation=True,
+        **kwargs
     ):
         utils.EzPickle.__init__(**locals())
 
@@ -170,7 +170,7 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         )
 
         mujoco_env.MujocoEnv.__init__(
-            self, "half_cheetah.xml", 5, render_mode=render_mode
+            self, "half_cheetah.xml", 5,  **kwargs
         )
 
     def control_cost(self, action):

--- a/gym/envs/mujoco/half_cheetah_v4.py
+++ b/gym/envs/mujoco/half_cheetah_v4.py
@@ -1,7 +1,5 @@
 __credits__ = ["Rushiv Arora"]
 
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -169,9 +167,7 @@ class HalfCheetahEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             exclude_current_positions_from_observation
         )
 
-        mujoco_env.MujocoEnv.__init__(
-            self, "half_cheetah.xml", 5,  **kwargs
-        )
+        mujoco_env.MujocoEnv.__init__(self, "half_cheetah.xml", 5, **kwargs)
 
     def control_cost(self, action):
         control_cost = self._ctrl_cost_weight * np.sum(np.square(action))

--- a/gym/envs/mujoco/hopper.py
+++ b/gym/envs/mujoco/hopper.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/hopper.py
+++ b/gym/envs/mujoco/hopper.py
@@ -7,9 +7,9 @@ from gym.envs.mujoco import mujoco_env
 
 
 class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
-            self, "hopper.xml", 4, render_mode=render_mode, mujoco_bindings="mujoco_py"
+            self, "hopper.xml", 4, mujoco_bindings="mujoco_py", **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/hopper_v3.py
+++ b/gym/envs/mujoco/hopper_v3.py
@@ -18,7 +18,6 @@ DEFAULT_CAMERA_CONFIG = {
 class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(
         self,
-        render_mode: Optional[str] = None,
         xml_file="hopper.xml",
         forward_reward_weight=1.0,
         ctrl_cost_weight=1e-3,
@@ -29,6 +28,7 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         healthy_angle_range=(-0.2, 0.2),
         reset_noise_scale=5e-3,
         exclude_current_positions_from_observation=True,
+        **kwargs
     ):
         utils.EzPickle.__init__(**locals())
 
@@ -50,7 +50,7 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         )
 
         mujoco_env.MujocoEnv.__init__(
-            self, xml_file, 4, render_mode=render_mode, mujoco_bindings="mujoco_py"
+            self, xml_file, 4, mujoco_bindings="mujoco_py",  **kwargs
         )
 
     @property

--- a/gym/envs/mujoco/hopper_v3.py
+++ b/gym/envs/mujoco/hopper_v3.py
@@ -1,7 +1,5 @@
 __credits__ = ["Rushiv Arora"]
 
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -50,7 +48,7 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         )
 
         mujoco_env.MujocoEnv.__init__(
-            self, xml_file, 4, mujoco_bindings="mujoco_py",  **kwargs
+            self, xml_file, 4, mujoco_bindings="mujoco_py", **kwargs
         )
 
     @property

--- a/gym/envs/mujoco/hopper_v4.py
+++ b/gym/envs/mujoco/hopper_v4.py
@@ -142,7 +142,6 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def __init__(
         self,
-        render_mode: Optional[str] = None,
         forward_reward_weight=1.0,
         ctrl_cost_weight=1e-3,
         healthy_reward=1.0,
@@ -152,6 +151,7 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         healthy_angle_range=(-0.2, 0.2),
         reset_noise_scale=5e-3,
         exclude_current_positions_from_observation=True,
+        **kwargs
     ):
         utils.EzPickle.__init__(**locals())
 
@@ -172,7 +172,7 @@ class HopperEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             exclude_current_positions_from_observation
         )
 
-        mujoco_env.MujocoEnv.__init__(self, "hopper.xml", 4, render_mode=render_mode)
+        mujoco_env.MujocoEnv.__init__(self, "hopper.xml", 4, **kwargs)
 
     @property
     def healthy_reward(self):

--- a/gym/envs/mujoco/hopper_v4.py
+++ b/gym/envs/mujoco/hopper_v4.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/humanoid.py
+++ b/gym/envs/mujoco/humanoid.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -15,11 +13,7 @@ def mass_center(model, sim):
 class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
-            self,
-            "humanoid.xml",
-            5,
-            mujoco_bindings="mujoco_py",
-            **kwargs
+            self, "humanoid.xml", 5, mujoco_bindings="mujoco_py", **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/humanoid.py
+++ b/gym/envs/mujoco/humanoid.py
@@ -13,13 +13,13 @@ def mass_center(model, sim):
 
 
 class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
             self,
             "humanoid.xml",
             5,
-            render_mode=render_mode,
             mujoco_bindings="mujoco_py",
+            **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/humanoid_v3.py
+++ b/gym/envs/mujoco/humanoid_v3.py
@@ -22,7 +22,6 @@ def mass_center(model, sim):
 class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(
         self,
-        render_mode: Optional[str] = None,
         xml_file="humanoid.xml",
         forward_reward_weight=1.25,
         ctrl_cost_weight=0.1,
@@ -33,6 +32,7 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         healthy_z_range=(1.0, 2.0),
         reset_noise_scale=1e-2,
         exclude_current_positions_from_observation=True,
+        **kwargs
     ):
         utils.EzPickle.__init__(**locals())
 
@@ -51,7 +51,7 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         )
 
         mujoco_env.MujocoEnv.__init__(
-            self, xml_file, 5, render_mode=render_mode, mujoco_bindings="mujoco_py"
+            self, xml_file, 5, mujoco_bindings="mujoco_py", **kwargs
         )
 
     @property

--- a/gym/envs/mujoco/humanoid_v3.py
+++ b/gym/envs/mujoco/humanoid_v3.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/humanoid_v4.py
+++ b/gym/envs/mujoco/humanoid_v4.py
@@ -206,7 +206,6 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def __init__(
         self,
-        render_mode: Optional[str] = None,
         forward_reward_weight=1.25,
         ctrl_cost_weight=0.1,
         healthy_reward=5.0,
@@ -214,6 +213,7 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         healthy_z_range=(1.0, 2.0),
         reset_noise_scale=1e-2,
         exclude_current_positions_from_observation=True,
+        **kwargs
     ):
         utils.EzPickle.__init__(**locals())
 
@@ -229,7 +229,7 @@ class HumanoidEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             exclude_current_positions_from_observation
         )
 
-        mujoco_env.MujocoEnv.__init__(self, "humanoid.xml", 5, render_mode=render_mode)
+        mujoco_env.MujocoEnv.__init__(self, "humanoid.xml", 5, **kwargs)
 
     @property
     def healthy_reward(self):

--- a/gym/envs/mujoco/humanoid_v4.py
+++ b/gym/envs/mujoco/humanoid_v4.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/humanoidstandup.py
+++ b/gym/envs/mujoco/humanoidstandup.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -9,11 +7,7 @@ from gym.envs.mujoco import mujoco_env
 class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
-            self,
-            "humanoidstandup.xml",
-            5,
-            mujoco_bindings="mujoco_py",
-            **kwargs
+            self, "humanoidstandup.xml", 5, mujoco_bindings="mujoco_py", **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/humanoidstandup.py
+++ b/gym/envs/mujoco/humanoidstandup.py
@@ -7,13 +7,13 @@ from gym.envs.mujoco import mujoco_env
 
 
 class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
             self,
             "humanoidstandup.xml",
             5,
-            render_mode=render_mode,
             mujoco_bindings="mujoco_py",
+            **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/humanoidstandup_v4.py
+++ b/gym/envs/mujoco/humanoidstandup_v4.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -193,9 +191,7 @@ class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     """
 
     def __init__(self, **kwargs):
-        mujoco_env.MujocoEnv.__init__(
-            self, "humanoidstandup.xml", 5, **kwargs
-        )
+        mujoco_env.MujocoEnv.__init__(self, "humanoidstandup.xml", 5, **kwargs)
         utils.EzPickle.__init__(self)
 
     def _get_obs(self):

--- a/gym/envs/mujoco/humanoidstandup_v4.py
+++ b/gym/envs/mujoco/humanoidstandup_v4.py
@@ -192,9 +192,9 @@ class HumanoidStandupEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     """
 
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
-            self, "humanoidstandup.xml", 5, render_mode=render_mode
+            self, "humanoidstandup.xml", 5, **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/inverted_double_pendulum.py
+++ b/gym/envs/mujoco/inverted_double_pendulum.py
@@ -7,13 +7,13 @@ from gym.envs.mujoco import mujoco_env
 
 
 class InvertedDoublePendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
             self,
             "inverted_double_pendulum.xml",
             5,
-            render_mode=render_mode,
             mujoco_bindings="mujoco_py",
+            **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/inverted_double_pendulum.py
+++ b/gym/envs/mujoco/inverted_double_pendulum.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/inverted_double_pendulum_v4.py
+++ b/gym/envs/mujoco/inverted_double_pendulum_v4.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -121,9 +119,7 @@ class InvertedDoublePendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     """
 
     def __init__(self, **kwargs):
-        mujoco_env.MujocoEnv.__init__(
-            self, "inverted_double_pendulum.xml", 5, **kwargs
-        )
+        mujoco_env.MujocoEnv.__init__(self, "inverted_double_pendulum.xml", 5, **kwargs)
         utils.EzPickle.__init__(self)
 
     def step(self, action):

--- a/gym/envs/mujoco/inverted_double_pendulum_v4.py
+++ b/gym/envs/mujoco/inverted_double_pendulum_v4.py
@@ -120,9 +120,9 @@ class InvertedDoublePendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     """
 
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
-            self, "inverted_double_pendulum.xml", 5, render_mode=render_mode
+            self, "inverted_double_pendulum.xml", 5, **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/inverted_pendulum.py
+++ b/gym/envs/mujoco/inverted_pendulum.py
@@ -7,14 +7,14 @@ from gym.envs.mujoco import mujoco_env
 
 
 class InvertedPendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         utils.EzPickle.__init__(self)
         mujoco_env.MujocoEnv.__init__(
             self,
             "inverted_pendulum.xml",
             2,
-            render_mode=render_mode,
             mujoco_bindings="mujoco_py",
+            **kwargs
         )
 
     def step(self, a):

--- a/gym/envs/mujoco/inverted_pendulum.py
+++ b/gym/envs/mujoco/inverted_pendulum.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -10,11 +8,7 @@ class InvertedPendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self, **kwargs):
         utils.EzPickle.__init__(self)
         mujoco_env.MujocoEnv.__init__(
-            self,
-            "inverted_pendulum.xml",
-            2,
-            mujoco_bindings="mujoco_py",
-            **kwargs
+            self, "inverted_pendulum.xml", 2, mujoco_bindings="mujoco_py", **kwargs
         )
 
     def step(self, a):

--- a/gym/envs/mujoco/inverted_pendulum_v4.py
+++ b/gym/envs/mujoco/inverted_pendulum_v4.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -94,9 +92,7 @@ class InvertedPendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def __init__(self, **kwargs):
         utils.EzPickle.__init__(self)
-        mujoco_env.MujocoEnv.__init__(
-            self, "inverted_pendulum.xml", 2, **kwargs
-        )
+        mujoco_env.MujocoEnv.__init__(self, "inverted_pendulum.xml", 2, **kwargs)
 
     def step(self, a):
         reward = 1.0

--- a/gym/envs/mujoco/inverted_pendulum_v4.py
+++ b/gym/envs/mujoco/inverted_pendulum_v4.py
@@ -92,10 +92,10 @@ class InvertedPendulumEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     """
 
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         utils.EzPickle.__init__(self)
         mujoco_env.MujocoEnv.__init__(
-            self, "inverted_pendulum.xml", 2, render_mode=render_mode
+            self, "inverted_pendulum.xml", 2, **kwargs
         )
 
     def step(self, a):

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from functools import partial
 from os import path
 from typing import Optional
 
@@ -39,6 +40,10 @@ class MujocoEnv(gym.Env):
         model_path,
         frame_skip,
         render_mode: Optional[str] = None,
+        width: int = DEFAULT_SIZE,
+        height: int = DEFAULT_SIZE,
+        camera_id: Optional[int] = None,
+        camera_name: Optional[str] = None,
         mujoco_bindings="mujoco",
     ):
         if model_path.startswith("/"):
@@ -107,7 +112,8 @@ class MujocoEnv(gym.Env):
 
         assert render_mode is None or render_mode in self.metadata["render_modes"]
         self.render_mode = render_mode
-        self.renderer = Renderer(self.render_mode, self._render)
+        render_frame = partial(self._render, width=width, height=height, camera_name=camera_name, camera_id=camera_id)
+        self.renderer = Renderer(self.render_mode, render_frame)
 
         action = self.action_space.sample()
         observation, _reward, done, _info = self.step(action)
@@ -208,14 +214,17 @@ class MujocoEnv(gym.Env):
     def render(
         self,
         mode="human",
-        width=DEFAULT_SIZE,
-        height=DEFAULT_SIZE,
+        width=None,
+        height=None,
         camera_id=None,
-        camera_name=None,
+        camera_name=None
     ):
         if self.render_mode is not None:
+            assert width is None and height is None and camera_id is None and camera_name is None, "Unexpected argument for render. Specify render arguments at environment initialization."
             return self.renderer.get_renders()
         else:
+            width = width if width is not None else DEFAULT_SIZE
+            height = height if height is not None else DEFAULT_SIZE
             return self._render(
                 mode=mode,
                 width=width,
@@ -230,7 +239,7 @@ class MujocoEnv(gym.Env):
         width=DEFAULT_SIZE,
         height=DEFAULT_SIZE,
         camera_id=None,
-        camera_name=None,
+        camera_name=None
     ):
         assert mode in self.metadata["render_modes"]
 

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -218,7 +218,12 @@ class MujocoEnv(gym.Env):
             self._mujoco_bindings.mj_rnePostConstraint(self.model, self.data)
 
     def render(
-        self, mode="human", width=None, height=None, camera_id=None, camera_name=None
+        self,
+        mode: str = "human",
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        camera_id: Optional[int] = None,
+        camera_name: Optional[str] = None,
     ):
         if self.render_mode is not None:
             assert (
@@ -241,11 +246,11 @@ class MujocoEnv(gym.Env):
 
     def _render(
         self,
-        mode="human",
-        width=DEFAULT_SIZE,
-        height=DEFAULT_SIZE,
-        camera_id=None,
-        camera_name=None,
+        mode: str = "human",
+        width: int = DEFAULT_SIZE,
+        height: int = DEFAULT_SIZE,
+        camera_id: Optional[int] = None,
+        camera_name: Optional[str] = None,
     ):
         assert mode in self.metadata["render_modes"]
 

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -112,7 +112,13 @@ class MujocoEnv(gym.Env):
 
         assert render_mode is None or render_mode in self.metadata["render_modes"]
         self.render_mode = render_mode
-        render_frame = partial(self._render, width=width, height=height, camera_name=camera_name, camera_id=camera_id)
+        render_frame = partial(
+            self._render,
+            width=width,
+            height=height,
+            camera_name=camera_name,
+            camera_id=camera_id,
+        )
         self.renderer = Renderer(self.render_mode, render_frame)
 
         action = self.action_space.sample()
@@ -212,15 +218,15 @@ class MujocoEnv(gym.Env):
             self._mujoco_bindings.mj_rnePostConstraint(self.model, self.data)
 
     def render(
-        self,
-        mode="human",
-        width=None,
-        height=None,
-        camera_id=None,
-        camera_name=None
+        self, mode="human", width=None, height=None, camera_id=None, camera_name=None
     ):
         if self.render_mode is not None:
-            assert width is None and height is None and camera_id is None and camera_name is None, "Unexpected argument for render. Specify render arguments at environment initialization."
+            assert (
+                width is None
+                and height is None
+                and camera_id is None
+                and camera_name is None
+            ), "Unexpected argument for render. Specify render arguments at environment initialization."
             return self.renderer.get_renders()
         else:
             width = width if width is not None else DEFAULT_SIZE
@@ -239,7 +245,7 @@ class MujocoEnv(gym.Env):
         width=DEFAULT_SIZE,
         height=DEFAULT_SIZE,
         camera_id=None,
-        camera_name=None
+        camera_name=None,
     ):
         assert mode in self.metadata["render_modes"]
 

--- a/gym/envs/mujoco/pusher.py
+++ b/gym/envs/mujoco/pusher.py
@@ -7,10 +7,10 @@ from gym.envs.mujoco import mujoco_env
 
 
 class PusherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         utils.EzPickle.__init__(self)
         mujoco_env.MujocoEnv.__init__(
-            self, "pusher.xml", 5, render_mode=render_mode, mujoco_bindings="mujoco_py"
+            self, "pusher.xml", 5, mujoco_bindings="mujoco_py", **kwargs
         )
 
     def step(self, a):

--- a/gym/envs/mujoco/pusher.py
+++ b/gym/envs/mujoco/pusher.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/pusher_v4.py
+++ b/gym/envs/mujoco/pusher_v4.py
@@ -134,9 +134,9 @@ class PusherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     """
 
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         utils.EzPickle.__init__(self)
-        mujoco_env.MujocoEnv.__init__(self, "pusher.xml", 5, render_mode=render_mode)
+        mujoco_env.MujocoEnv.__init__(self, "pusher.xml", 5, **kwargs)
 
     def step(self, a):
         vec_1 = self.get_body_com("object") - self.get_body_com("tips_arm")

--- a/gym/envs/mujoco/pusher_v4.py
+++ b/gym/envs/mujoco/pusher_v4.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/reacher.py
+++ b/gym/envs/mujoco/reacher.py
@@ -7,10 +7,10 @@ from gym.envs.mujoco import mujoco_env
 
 
 class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         utils.EzPickle.__init__(self)
         mujoco_env.MujocoEnv.__init__(
-            self, "reacher.xml", 2, render_mode=render_mode, mujoco_bindings="mujoco_py"
+            self, "reacher.xml", 2, mujoco_bindings="mujoco_py", **kwargs
         )
 
     def step(self, a):

--- a/gym/envs/mujoco/reacher.py
+++ b/gym/envs/mujoco/reacher.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/reacher_v4.py
+++ b/gym/envs/mujoco/reacher_v4.py
@@ -124,9 +124,9 @@ class ReacherEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     """
 
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         utils.EzPickle.__init__(self)
-        mujoco_env.MujocoEnv.__init__(self, "reacher.xml", 2, render_mode=render_mode)
+        mujoco_env.MujocoEnv.__init__(self, "reacher.xml", 2, **kwargs)
 
     def step(self, a):
         vec = self.get_body_com("fingertip") - self.get_body_com("target")

--- a/gym/envs/mujoco/reacher_v4.py
+++ b/gym/envs/mujoco/reacher_v4.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/swimmer.py
+++ b/gym/envs/mujoco/swimmer.py
@@ -7,9 +7,9 @@ from gym.envs.mujoco import mujoco_env
 
 
 class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
-            self, "swimmer.xml", 4, render_mode=render_mode, mujoco_bindings="mujoco_py"
+            self, "swimmer.xml", 4, mujoco_bindings="mujoco_py", **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/swimmer.py
+++ b/gym/envs/mujoco/swimmer.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/swimmer_v3.py
+++ b/gym/envs/mujoco/swimmer_v3.py
@@ -13,12 +13,12 @@ DEFAULT_CAMERA_CONFIG = {}
 class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(
         self,
-        render_mode: Optional[str] = None,
         xml_file="swimmer.xml",
         forward_reward_weight=1.0,
         ctrl_cost_weight=1e-4,
         reset_noise_scale=0.1,
         exclude_current_positions_from_observation=True,
+        **kwargs
     ):
         utils.EzPickle.__init__(**locals())
 
@@ -32,7 +32,7 @@ class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         )
 
         mujoco_env.MujocoEnv.__init__(
-            self, xml_file, 4, render_mode=render_mode, mujoco_bindings="mujoco_py"
+            self, xml_file, 4, mujoco_bindings="mujoco_py", **kwargs
         )
 
     def control_cost(self, action):

--- a/gym/envs/mujoco/swimmer_v3.py
+++ b/gym/envs/mujoco/swimmer_v3.py
@@ -1,7 +1,5 @@
 __credits__ = ["Rushiv Arora"]
 
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/swimmer_v4.py
+++ b/gym/envs/mujoco/swimmer_v4.py
@@ -1,7 +1,5 @@
 __credits__ = ["Rushiv Arora"]
 
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/swimmer_v4.py
+++ b/gym/envs/mujoco/swimmer_v4.py
@@ -134,11 +134,11 @@ class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def __init__(
         self,
-        render_mode: Optional[str] = None,
         forward_reward_weight=1.0,
         ctrl_cost_weight=1e-4,
         reset_noise_scale=0.1,
         exclude_current_positions_from_observation=True,
+        **kwargs
     ):
         utils.EzPickle.__init__(**locals())
 
@@ -151,7 +151,7 @@ class SwimmerEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             exclude_current_positions_from_observation
         )
 
-        mujoco_env.MujocoEnv.__init__(self, "swimmer.xml", 4, render_mode=render_mode)
+        mujoco_env.MujocoEnv.__init__(self, "swimmer.xml", 4, **kwargs)
 
     def control_cost(self, action):
         control_cost = self._ctrl_cost_weight * np.sum(np.square(action))

--- a/gym/envs/mujoco/walker2d.py
+++ b/gym/envs/mujoco/walker2d.py
@@ -7,13 +7,13 @@ from gym.envs.mujoco import mujoco_env
 
 
 class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
             self,
             "walker2d.xml",
             4,
-            render_mode=render_mode,
             mujoco_bindings="mujoco_py",
+            **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/walker2d.py
+++ b/gym/envs/mujoco/walker2d.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils
@@ -9,11 +7,7 @@ from gym.envs.mujoco import mujoco_env
 class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(self, **kwargs):
         mujoco_env.MujocoEnv.__init__(
-            self,
-            "walker2d.xml",
-            4,
-            mujoco_bindings="mujoco_py",
-            **kwargs
+            self, "walker2d.xml", 4, mujoco_bindings="mujoco_py", **kwargs
         )
         utils.EzPickle.__init__(self)
 

--- a/gym/envs/mujoco/walker2d_v3.py
+++ b/gym/envs/mujoco/walker2d_v3.py
@@ -16,7 +16,6 @@ DEFAULT_CAMERA_CONFIG = {
 class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
     def __init__(
         self,
-        render_mode: Optional[str] = None,
         xml_file="walker2d.xml",
         forward_reward_weight=1.0,
         ctrl_cost_weight=1e-3,
@@ -46,7 +45,7 @@ class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         )
 
         mujoco_env.MujocoEnv.__init__(
-            self, xml_file, 4, render_mode=render_mode, mujoco_bindings="mujoco_py"
+            self, xml_file, 4, mujoco_bindings="mujoco_py", **kwargs
         )
 
     @property

--- a/gym/envs/mujoco/walker2d_v3.py
+++ b/gym/envs/mujoco/walker2d_v3.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils

--- a/gym/envs/mujoco/walker2d_v4.py
+++ b/gym/envs/mujoco/walker2d_v4.py
@@ -160,7 +160,6 @@ class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
 
     def __init__(
         self,
-        render_mode: Optional[str] = None,
         forward_reward_weight=1.0,
         ctrl_cost_weight=1e-3,
         healthy_reward=1.0,
@@ -169,6 +168,7 @@ class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
         healthy_angle_range=(-1.0, 1.0),
         reset_noise_scale=5e-3,
         exclude_current_positions_from_observation=True,
+        **kwargs
     ):
         utils.EzPickle.__init__(**locals())
 
@@ -187,7 +187,7 @@ class Walker2dEnv(mujoco_env.MujocoEnv, utils.EzPickle):
             exclude_current_positions_from_observation
         )
 
-        mujoco_env.MujocoEnv.__init__(self, "walker2d.xml", 4, render_mode=render_mode)
+        mujoco_env.MujocoEnv.__init__(self, "walker2d.xml", 4, **kwargs)
 
     @property
     def healthy_reward(self):

--- a/gym/envs/mujoco/walker2d_v4.py
+++ b/gym/envs/mujoco/walker2d_v4.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 
 from gym import utils


### PR DESCRIPTION
Allow user to specify render arguments for Mujoco during initialization.

For example:
```
import gym

env = gym.make("Humanoid-v4", render_mode="rgb_array", height=450, width=500)
env.reset()
for _ in range(100):
    env.step(env.action_space.sample())

im = env.render()
env.close()

> im[0].shape
(450, 500, 3)
```

Thanks @wookayin for spotting this (https://github.com/openai/gym/issues/2889)