### PR TITLE
fix: allow mode as argument

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -387,7 +387,7 @@ class Wrapper(Env[ObsType, ActType]):
         return self.env.reset(**kwargs)
 
     def render(self, *args, **kwargs):
-        """Renders the environment with kwargs."""
+        """Renders the environment."""
         return self.env.render(*args, **kwargs)
 
     def close(self):

--- a/gym/core.py
+++ b/gym/core.py
@@ -43,7 +43,7 @@ class _EnvDecorator(type):  # TODO: remove with gym 1.0
         def render(
             self: object, *args: Tuple[Any], **kwargs: Dict[str, Any]
         ) -> render_return:
-            if "mode" in kwargs.keys():
+            if "mode" in kwargs.keys() or len(args) > 0:
                 deprecation(
                     "The argument mode in render method is deprecated; "
                     "use render_mode during environment initialization instead.\n"
@@ -386,9 +386,9 @@ class Wrapper(Env[ObsType, ActType]):
         """Resets the environment with kwargs."""
         return self.env.reset(**kwargs)
 
-    def render(self, **kwargs):
+    def render(self, *args, **kwargs):
         """Renders the environment with kwargs."""
-        return self.env.render(**kwargs)
+        return self.env.render(*args, **kwargs)
 
     def close(self):
         """Closes the environment."""

--- a/gym/utils/passive_env_checker.py
+++ b/gym/utils/passive_env_checker.py
@@ -290,7 +290,7 @@ def passive_env_step_check(env, action):
     return result
 
 
-def passive_env_render_check(env, **kwargs):
+def passive_env_render_check(env, *args, **kwargs):
     """A passive check of the `Env.render` that the declared render modes/fps in the metadata of the environment is decleared."""
     render_modes = env.metadata.get("render_modes")
     if render_modes is None:
@@ -307,4 +307,4 @@ def passive_env_render_check(env, **kwargs):
             "rendering may occur at inconsistent fps"
         )
 
-    return env.render(**kwargs)
+    return env.render(*args, **kwargs)

--- a/gym/wrappers/env_checker.py
+++ b/gym/wrappers/env_checker.py
@@ -48,10 +48,10 @@ class PassiveEnvChecker(gym.Wrapper):
         else:
             return self.env.reset(**kwargs)
 
-    def render(self, **kwargs):
+    def render(self, *args, **kwargs):
         """Renders the environment that on the first call will run the `passive_env_render_check`."""
         if self.checked_render is False:
             self.checked_render = True
-            return passive_env_render_check(self.env, **kwargs)
+            return passive_env_render_check(self.env, *args, **kwargs)
         else:
-            return self.env.render(**kwargs)
+            return self.env.render(*args, **kwargs)

--- a/gym/wrappers/order_enforcing.py
+++ b/gym/wrappers/order_enforcing.py
@@ -41,11 +41,11 @@ class OrderEnforcing(gym.Wrapper):
         self._has_reset = True
         return self.env.reset(**kwargs)
 
-    def render(self, **kwargs):
+    def render(self, *args, **kwargs):
         """Renders the environment with `kwargs`."""
         if not self._disable_render_order_enforcing and not self._has_reset:
             raise ResetNeeded(
                 "Cannot call `env.render()` before calling `env.reset()`, if this is a intended action, "
                 "set `disable_render_order_enforcing=True` on the OrderEnforcer wrapper."
             )
-        return self.env.render(**kwargs)
+        return self.env.render(*args, **kwargs)


### PR DESCRIPTION
# Description
After https://github.com/openai/gym/pull/2706, render with Wrappers doesn't work anymore with mode as argument without keyword.
For instance, the following will throw an error:
```
env = gym.make("FrozenLake-v1")
env.reset()
env.render('rgb_array')
```
This should fix this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
