### PR TITLE
fixed env_checker.py

### DIFF
--- a/gym/wrappers/env_checker.py
+++ b/gym/wrappers/env_checker.py
@@ -22,11 +22,11 @@ class PassiveEnvChecker(gym.Wrapper):
         assert hasattr(
             env, "action_space"
         ), "You must specify a action space. https://www.gymlibrary.ml/content/environment_creation/"
-        check_observation_space(env.action_space)
+        check_observation_space(env.observation_space)
         assert hasattr(
             env, "observation_space"
         ), "You must specify an observation space. https://www.gymlibrary.ml/content/environment_creation/"
-        check_action_space(env.observation_space)
+        check_action_space(env.action_space)
 
         self.checked_reset = False
         self.checked_step = False


### PR DESCRIPTION
# Description

Minor change in `gym/wrappers/env_checker.py`. The `check_action_space()` method was being called on `env.observation_space` and the `check_observation_space()` was being called on `env.action_space`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
