### PR TITLE
tentative fix for render function showing changing dealer top card

### DIFF
--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -175,8 +175,17 @@ class BlackjackEnv(gym.Env):
         self.dealer = draw_hand(self.np_random)
         self.player = draw_hand(self.np_random)
 
-        self.dealer_top_card_suit = None
-        self.dealer_top_card_value_str = None
+        _, dealer_card_value, _ = self._get_obs()
+
+        suits = ["C", "D", "H", "S"]
+        self.dealer_top_card_suit = self.np_random.choice(suits)
+
+        if dealer_card_value == 1:
+            self.dealer_top_card_value_str = "A"
+        elif dealer_card_value == 10:
+            self.dealer_top_card_value_str = self.np_random.choice(["J", "Q", "K"])
+        else:
+            self.dealer_top_card_value_str = str(dealer_card_value)
 
         self.renderer.reset()
         self.renderer.render_step()
@@ -242,18 +251,6 @@ class BlackjackEnv(gym.Env):
             "Dealer: " + str(dealer_card_value), True, white
         )
         dealer_text_rect = self.screen.blit(dealer_text, (spacing, spacing))
-
-        if self.dealer_top_card_suit is None:
-            suits = ["C", "D", "H", "S"]
-            self.dealer_top_card_suit = self.np_random.choice(suits)
-
-        if dealer_card_value == 1:
-            self.dealer_top_card_value_str = "A"
-        elif dealer_card_value == 10:
-            if self.dealer_top_card_value_str is None:
-                self.dealer_top_card_value_str = self.np_random.choice(["J", "Q", "K"])
-        else:
-            self.dealer_top_card_value_str = str(dealer_card_value)
 
         def scale_card_img(card_img):
             return pygame.transform.scale(card_img, (card_img_width, card_img_height))

--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -259,7 +259,7 @@ class BlackjackEnv(gym.Env):
             get_image(
                 os.path.join(
                     "img",
-                    f"{self.dealer_top_card_suit + self.dealer_top_card_value_str + '.png'}",
+                    f"{self.dealer_top_card_suit}{self.dealer_top_card_value_str}.png",
                 )
             )
         )

--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -175,6 +175,9 @@ class BlackjackEnv(gym.Env):
         self.dealer = draw_hand(self.np_random)
         self.player = draw_hand(self.np_random)
 
+        self.dealer_top_card_suit = None
+        self.dealer_top_card_value_str = None
+
         self.renderer.reset()
         self.renderer.render_step()
 
@@ -240,22 +243,27 @@ class BlackjackEnv(gym.Env):
         )
         dealer_text_rect = self.screen.blit(dealer_text, (spacing, spacing))
 
-        suits = ["C", "D", "H", "S"]
-        dealer_card_suit = self.np_random.choice(suits)
+        if self.dealer_top_card_suit is None:
+            suits = ["C", "D", "H", "S"]
+            self.dealer_top_card_suit = self.np_random.choice(suits)
 
         if dealer_card_value == 1:
-            dealer_card_value_str = "A"
+            self.dealer_top_card_value_str = "A"
         elif dealer_card_value == 10:
-            dealer_card_value_str = self.np_random.choice(["J", "Q", "K"])
+            if self.dealer_top_card_value_str is None:
+                self.dealer_top_card_value_str = self.np_random.choice(["J", "Q", "K"])
         else:
-            dealer_card_value_str = str(dealer_card_value)
+            self.dealer_top_card_value_str = str(dealer_card_value)
 
         def scale_card_img(card_img):
             return pygame.transform.scale(card_img, (card_img_width, card_img_height))
 
         dealer_card_img = scale_card_img(
             get_image(
-                os.path.join("img", dealer_card_suit + dealer_card_value_str + ".png")
+                os.path.join(
+                    "img",
+                    self.dealer_top_card_suit + self.dealer_top_card_value_str + ".png",
+                )
             )
         )
         dealer_card_rect = self.screen.blit(

--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -259,7 +259,7 @@ class BlackjackEnv(gym.Env):
             get_image(
                 os.path.join(
                     "img",
-                    self.dealer_top_card_suit + self.dealer_top_card_value_str + ".png",
+                    f"{self.dealer_top_card_suit + self.dealer_top_card_value_str + '.png'}",
                 )
             )
         )


### PR DESCRIPTION


# Description

Changes the _render function and reset function of blackjack.py so that the suit and face card value of the dealer's top card remain stable across calls to render. All side effects moved to reset so render function should not have any side-effects.

Fixes  #2919

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->
Before
![before](https://user-images.githubusercontent.com/20377292/175180088-cde06949-7ee3-4a8d-8aa5-6040f8d6f0d4.gif)
After
![after](https://user-images.githubusercontent.com/20377292/175180095-bd386af2-f573-42dd-942a-14972e2cd31c.gif)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
