### PR TITLE
Parameterize initial state distributions for classic control envs.

### DIFF
--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -23,6 +23,12 @@ __author__ = "Christoph Dann <cdann@cdann.de>"
 from gym.utils.renderer import Renderer
 
 
+DEFAULT_LOW = -0.1
+DEFAULT_HIGH = 0.1
+LIMIT_LOW = -1.0
+LIMIT_HIGH = 1.0
+
+
 class AcrobotEnv(core.Env):
     """
     ### Description
@@ -187,7 +193,20 @@ class AcrobotEnv(core.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        self.state = self.np_random.uniform(low=-0.1, high=0.1, size=(4,)).astype(
+        if options is None:
+            low = DEFAULT_LOW
+            high = DEFAULT_HIGH
+        else:
+          low = options.pop('low', DEFAULT_LOW)
+          high = options.pop('high', DEFAULT_HIGH)
+          # We expect only numerical inputs.
+          assert type(low) == int or float
+          assert type(high) == int or float
+          # Since the same boundaries are used for all observations, we set the
+          # limits according to the most restrictive (cos/sin): (-1., 1.).
+          low = max(low, LIMIT_LOW)
+          high = min(high, LIMIT_HIGH)
+        self.state = self.np_random.uniform(low=low, high=high, size=(4,)).astype(
             np.float32
         )
 

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -14,6 +14,12 @@ from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
 
+DEFAULT_LOW = -0.05
+DEFAULT_HIGH = 0.05
+LIMIT_LOW = -0.2
+LIMIT_HIGH = 0.2
+
+
 class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
     """
     ### Description
@@ -194,7 +200,22 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
-        self.state = self.np_random.uniform(low=-0.05, high=0.05, size=(4,))
+        if options is None:
+            low = DEFAULT_LOW
+            high = DEFAULT_HIGH
+        else:
+          low = options.pop('low', DEFAULT_LOW)
+          high = options.pop('high', DEFAULT_HIGH)
+          # We expect only numerical inputs.
+          assert type(low) == int or float
+          assert type(high) == int or float
+          # Since the same boundaries are used for all observations, we set the
+          # limits according to the most restrictive (pole angle). As per the
+          # documentation at the top of the file, we restrict them to be within
+          # (-.2, .2).
+          low = max(low, LIMIT_LOW)
+          high = min(high, LIMIT_HIGH)
+        self.state = self.np_random.uniform(low=low, high=high, size=(4,))
         self.steps_beyond_done = None
         self.renderer.reset()
         self.renderer.render_step()

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -24,6 +24,10 @@ from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
 
+DEFAULT_LOW = -0.6
+DEFAULT_HIGH = -0.4
+
+
 class Continuous_MountainCarEnv(gym.Env):
     """
     ### Description
@@ -180,7 +184,17 @@ class Continuous_MountainCarEnv(gym.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        self.state = np.array([self.np_random.uniform(low=-0.6, high=-0.4), 0])
+        if options is None:
+            low = DEFAULT_LOW
+            high = DEFAULT_HIGH
+        else:
+          low = options.pop('low', DEFAULT_LOW)
+          high = options.pop('high', DEFAULT_HIGH)
+          # We expect only numerical inputs.
+          assert type(low) == int or float
+          assert type(high) == int or float
+          # There are no limits for mountain car initializations 🙂.
+        self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
         self.renderer.reset()
         self.renderer.render_step()
         if not return_info:

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -13,6 +13,10 @@ from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
 
+DEFAULT_LOW = -0.6
+DEFAULT_HIGH = -0.4
+
+
 class MountainCarEnv(gym.Env):
     """
     ### Description
@@ -154,7 +158,17 @@ class MountainCarEnv(gym.Env):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
-        self.state = np.array([self.np_random.uniform(low=-0.6, high=-0.4), 0])
+        if options is None:
+            low = DEFAULT_LOW
+            high = DEFAULT_HIGH
+        else:
+          low = options.pop('low', DEFAULT_LOW)
+          high = options.pop('high', DEFAULT_HIGH)
+          # We expect only numerical inputs.
+          assert type(low) == int or float
+          assert type(high) == int or float
+          # There are no limits for mountain car initializations 🙂.
+        self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
         self.renderer.reset()
         self.renderer.render_step()
         if not return_info:

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -152,8 +152,8 @@ class PendulumEnv(gym.Env):
           x = options.pop('x', DEFAULT_X)
           y = options.pop('y', DEFAULT_Y)
           # We expect only numerical inputs.
-          assert type(tmp_low) == int or float
-          assert type(tmp_high) == int or float
+          assert type(x) == int or float
+          assert type(y) == int or float
           # Since the same boundaries are used for all observations, we set the
           # limits according to the most restrictive (sin/cos). Since these are
           # the values that will be used for the `high` variable, we enforce them

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -11,6 +11,10 @@ from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
 
+DEFAULT_X = np.pi
+DEFAULT_Y = 1.0
+
+
 class PendulumEnv(gym.Env):
     """
        ### Description
@@ -142,8 +146,23 @@ class PendulumEnv(gym.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        high = np.array([np.pi, 1])
-        self.state = self.np_random.uniform(low=-high, high=high)
+        if options is None:
+            high = np.array([np.pi, 1])
+        else:
+          x = options.pop('x', DEFAULT_X)
+          y = options.pop('y', DEFAULT_Y)
+          # We expect only numerical inputs.
+          assert type(tmp_low) == int or float
+          assert type(tmp_high) == int or float
+          # Since the same boundaries are used for all observations, we set the
+          # limits according to the most restrictive (sin/cos). Since these are
+          # the values that will be used for the `high` variable, we enforce them
+          # to be non-negative: (0., 1.).
+          x = max(0.0, min(1.0, x))
+          y = max(0.0, min(1.0, y))
+          high = np.array([x, y])
+        low = -high  # We enforce symmetric limits.
+        self.state = self.np_random.uniform(low=low, high=high)
         self.last_u = None
 
         self.renderer.reset()


### PR DESCRIPTION
# Description

This PR adds the ability for users to specify custom limits for the initial state distribution boundaries for classic control environments. Currently, they are hard-coded, but it can be useful for research to be able to set these to different values.

Motivating context: https://twitter.com/pcastr/status/1539368076700962817

Fixes # (issue)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)


# Checklist:

- [x ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes