### PR TITLE
Revert "Parameterize initial state distributions for classic control envs."

### DIFF
--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -23,12 +23,6 @@ __author__ = "Christoph Dann <cdann@cdann.de>"
 from gym.utils.renderer import Renderer
 
 
-DEFAULT_LOW = -0.1
-DEFAULT_HIGH = 0.1
-LIMIT_LOW = -1.0
-LIMIT_HIGH = 1.0
-
-
 class AcrobotEnv(core.Env):
     """
     ### Description
@@ -193,21 +187,7 @@ class AcrobotEnv(core.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        if options is None:
-            low = DEFAULT_LOW
-            high = DEFAULT_HIGH
-        else:
-            low = options.pop('low', DEFAULT_LOW)
-            high = options.pop('high', DEFAULT_HIGH)
-            # We expect only numerical inputs.
-            assert type(low) == int or float
-            assert type(high) == int or float
-            # Since the same boundaries are used for all observations, we set the
-            # limits according to the most restrictive (cos/sin): (-1., 1.).
-            low = max(low, LIMIT_LOW)
-            high = min(high, LIMIT_HIGH)
-            assert low < high
-        self.state = self.np_random.uniform(low=low, high=high, size=(4,)).astype(
+        self.state = self.np_random.uniform(low=-0.1, high=0.1, size=(4,)).astype(
             np.float32
         )
 

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -14,12 +14,6 @@ from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
 
-DEFAULT_LOW = -0.05
-DEFAULT_HIGH = 0.05
-LIMIT_LOW = -0.2
-LIMIT_HIGH = 0.2
-
-
 class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
     """
     ### Description
@@ -200,23 +194,7 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
-        if options is None:
-            low = DEFAULT_LOW
-            high = DEFAULT_HIGH
-        else:
-            low = options.pop('low', DEFAULT_LOW)
-            high = options.pop('high', DEFAULT_HIGH)
-            # We expect only numerical inputs.
-            assert type(low) == int or float
-            assert type(high) == int or float
-            # Since the same boundaries are used for all observations, we set the
-            # limits according to the most restrictive (pole angle). As per the
-            # documentation at the top of the file, we restrict them to be within
-            # (-.2, .2).
-            low = max(low, LIMIT_LOW)
-            high = min(high, LIMIT_HIGH)
-            assert low < high
-        self.state = self.np_random.uniform(low=low, high=high, size=(4,))
+        self.state = self.np_random.uniform(low=-0.05, high=0.05, size=(4,))
         self.steps_beyond_done = None
         self.renderer.reset()
         self.renderer.render_step()

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -24,12 +24,6 @@ from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
 
-DEFAULT_LOW = -0.6
-DEFAULT_HIGH = -0.4
-LIMIT_LOW = -1.2
-LIMIT_HIGH = 0.6
-
-
 class Continuous_MountainCarEnv(gym.Env):
     """
     ### Description
@@ -186,20 +180,7 @@ class Continuous_MountainCarEnv(gym.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        if options is None:
-            low = DEFAULT_LOW
-            high = DEFAULT_HIGH
-        else:
-            low = options.pop('low', DEFAULT_LOW)
-            high = options.pop('high', DEFAULT_HIGH)
-            # We expect only numerical inputs.
-            assert type(low) == int or float
-            assert type(high) == int or float
-            # MountainCar expects states to be within -1.2 and 0.6.
-            low = max(low, LIMIT_LOW)
-            high = min(high, LIMIT_HIGH)
-            assert low < high
-        self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
+        self.state = np.array([self.np_random.uniform(low=-0.6, high=-0.4), 0])
         self.renderer.reset()
         self.renderer.render_step()
         if not return_info:

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -13,12 +13,6 @@ from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
 
-DEFAULT_LOW = -0.6
-DEFAULT_HIGH = -0.4
-LIMIT_LOW = -1.2
-LIMIT_HIGH = 0.6
-
-
 class MountainCarEnv(gym.Env):
     """
     ### Description
@@ -160,20 +154,7 @@ class MountainCarEnv(gym.Env):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
-        if options is None:
-            low = DEFAULT_LOW
-            high = DEFAULT_HIGH
-        else:
-            low = options.pop('low', DEFAULT_LOW)
-            high = options.pop('high', DEFAULT_HIGH)
-            # We expect only numerical inputs.
-            assert type(low) == int or float
-            assert type(high) == int or float
-            # MountainCar expects states to be within -1.2 and 0.6.
-            low = max(low, LIMIT_LOW)
-            high = min(high, LIMIT_HIGH)
-            assert low < high
-        self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
+        self.state = np.array([self.np_random.uniform(low=-0.6, high=-0.4), 0])
         self.renderer.reset()
         self.renderer.render_step()
         if not return_info:

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -11,10 +11,6 @@ from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
 
-DEFAULT_X = np.pi
-DEFAULT_Y = 1.0
-
-
 class PendulumEnv(gym.Env):
     """
        ### Description
@@ -146,24 +142,8 @@ class PendulumEnv(gym.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        if options is None:
-            high = np.array([np.pi, 1])
-        else:
-            x = options.pop('x', DEFAULT_X)
-            y = options.pop('y', DEFAULT_Y)
-            # We expect only numerical inputs.
-            assert type(x) == int or float
-            assert type(y) == int or float
-            # Since the same boundaries are used for all observations, we set the
-            # limits according to the most restrictive (sin/cos). Since these are
-            # the values that will be used for the `high` variable, we enforce them
-            # to be non-negative: (0., 1.).
-            x = max(0.0, min(1.0, x))
-            y = max(0.0, min(1.0, y))
-            assert x < y
-            high = np.array([x, y])
-        low = -high  # We enforce symmetric limits.
-        self.state = self.np_random.uniform(low=low, high=high)
+        high = np.array([np.pi, 1])
+        self.state = self.np_random.uniform(low=-high, high=high)
         self.last_u = None
 
         self.renderer.reset()

--- a/tests/envs/test_env_implementation.py
+++ b/tests/envs/test_env_implementation.py
@@ -1,11 +1,9 @@
 import pytest
-from typing import Optional
 
 import gym
 from gym.envs.box2d import BipedalWalker
 from gym.envs.box2d.lunar_lander import demo_heuristic_lander
 from gym.envs.toy_text.frozen_lake import generate_random_map
-import numpy as np
 
 
 def test_lunar_lander_heuristics():
@@ -82,34 +80,3 @@ def test_frozenlake_dfs_map_generation(map_size: int):
                     if new_frozenlake[new_row][new_col] not in "#H":
                         frontier.append((new_row, new_col))
     raise AssertionError("No path through the frozenlake was found.")
-
-
-@pytest.mark.parametrize("low_high", [None, (-1.0, 1.0), (0., 2.), (-2., 1.)])
-def test_customizable_resets(low_high: Optional[list]):
-    envs = {
-        'acrobot': gym.make('Acrobot-v1'),
-        'cartpole': gym.make('CartPole-v1'),
-        'mountaincar': gym.make('MountainCar-v0'),
-        'mountaincar_continuous': gym.make('MountainCarContinuous-v0'),
-        'pendulum': gym.make('Pendulum-v1'),
-    }
-    for env in envs:
-        # For each environment, make sure we can reset and step without out-of-bound
-        # errors.
-        if low_high is None:
-            envs[env].reset()
-        else:
-            low, high = low_high
-            for i in range(15):
-                if env == 'pendulum':
-                    # Pendulum is initialized a little differently, where we specify the
-                    # x and y values for the upper limit (and lower limit is just the
-                    # negative of it).
-                    envs[env].reset(options={'x': low, 'y': high})
-                else:
-                    envs[env].reset(options={'low': low, 'high': high})
-                    assert np.all((envs[env].state >= low) & (envs[env].state <+ high))
-                if env.endswith('continuous') or env == 'pendulum':
-                    envs[env].step([0])
-                else:
-                    envs[env].step(0)


### PR DESCRIPTION
@jkterry1 This really needs to be reverted. I don't think it breaks anything too strongly, but it certainly doesn't *work*, and frankenstein-reviewing this PR and the PR that's fixing it is hard enough that I'd have no guarantees that it'd actually work after the review.