### PR TITLE
Add reset params (with np support)

### DIFF
--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -191,9 +191,8 @@ class AcrobotEnv(core.Env):
         # Note that if you use custom reset bounds, it may lead to out-of-bound
         # state/observations.
         low, high = utils.maybe_parse_reset_bounds(
-                options,
-                -0.1,  # default low
-                0.1)  # default high
+            options, -0.1, 0.1  # default low
+        )  # default high
         self.state = self.np_random.uniform(low=low, high=high, size=(4,)).astype(
             np.float32
         )

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -188,6 +188,8 @@ class AcrobotEnv(core.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
+        # Note that if you use custom reset bounds, it may lead to out-of-bound
+        # state/observations.
         low, high = utils.maybe_parse_reset_bounds(
                 options,
                 -0.1,  # default low

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -23,6 +23,12 @@ __author__ = "Christoph Dann <cdann@cdann.de>"
 from gym.utils.renderer import Renderer
 
 
+DEFAULT_LOW = -0.1
+DEFAULT_HIGH = 0.1
+LIMIT_LOW = -1.0
+LIMIT_HIGH = 1.0
+
+
 class AcrobotEnv(core.Env):
     """
     ### Description
@@ -187,7 +193,20 @@ class AcrobotEnv(core.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        self.state = self.np_random.uniform(low=-0.1, high=0.1, size=(4,)).astype(
+        if options is None:
+            low = DEFAULT_LOW
+            high = DEFAULT_HIGH
+        else:
+          low = options.pop('low', DEFAULT_LOW)
+          high = options.pop('high', DEFAULT_HIGH)
+          # We expect only numerical inputs.
+          assert type(low) == int or float
+          assert type(high) == int or float
+          # Since the same boundaries are used for all observations, we set the
+          # limits according to the most restrictive (cos/sin): (-1., 1.).
+          low = max(low, LIMIT_LOW)
+          high = min(high, LIMIT_HIGH)
+        self.state = self.np_random.uniform(low=low, high=high, size=(4,)).astype(
             np.float32
         )
 

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -20,13 +20,8 @@ __author__ = "Christoph Dann <cdann@cdann.de>"
 
 # SOURCE:
 # https://github.com/rlpy/rlpy/blob/master/rlpy/Domains/Acrobot.py
+from gym.utils import option_parser
 from gym.utils.renderer import Renderer
-
-
-DEFAULT_LOW = -0.1
-DEFAULT_HIGH = 0.1
-LIMIT_LOW = -1.0
-LIMIT_HIGH = 1.0
 
 
 class AcrobotEnv(core.Env):
@@ -193,20 +188,14 @@ class AcrobotEnv(core.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        if options is None:
-            low = DEFAULT_LOW
-            high = DEFAULT_HIGH
-        else:
-            low = options.pop('low', DEFAULT_LOW)
-            high = options.pop('high', DEFAULT_HIGH)
-            # We expect only numerical inputs.
-            assert type(low) == int or float
-            assert type(high) == int or float
-            # Since the same boundaries are used for all observations, we set the
-            # limits according to the most restrictive (cos/sin): (-1., 1.).
-            low = max(low, LIMIT_LOW)
-            high = min(high, LIMIT_HIGH)
-            assert low < high
+        # Since the same boundaries are used for all observations, we set the
+        # limits according to the most restrictive (cos/sin): (-1., 1.).
+        low, high = option_parser.maybe_parse_reset_bounds(
+                -0.1,  # default low
+                0.1,  # default high
+                -1.0,  # limit low
+                1.0,  # limit high
+                options)
         self.state = self.np_random.uniform(low=low, high=high, size=(4,)).astype(
             np.float32
         )

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -20,7 +20,7 @@ __author__ = "Christoph Dann <cdann@cdann.de>"
 
 # SOURCE:
 # https://github.com/rlpy/rlpy/blob/master/rlpy/Domains/Acrobot.py
-from gym.utils import option_parser
+from gym.envs.classic_control import utils
 from gym.utils.renderer import Renderer
 
 
@@ -188,14 +188,10 @@ class AcrobotEnv(core.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        # Since the same boundaries are used for all observations, we set the
-        # limits according to the most restrictive (cos/sin): (-1., 1.).
-        low, high = option_parser.maybe_parse_reset_bounds(
+        low, high = utils.maybe_parse_reset_bounds(
+                options,
                 -0.1,  # default low
-                0.1,  # default high
-                -1.0,  # limit low
-                1.0,  # limit high
-                options)
+                0.1)  # default high
         self.state = self.np_random.uniform(low=low, high=high, size=(4,)).astype(
             np.float32
         )

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -197,15 +197,16 @@ class AcrobotEnv(core.Env):
             low = DEFAULT_LOW
             high = DEFAULT_HIGH
         else:
-          low = options.pop('low', DEFAULT_LOW)
-          high = options.pop('high', DEFAULT_HIGH)
-          # We expect only numerical inputs.
-          assert type(low) == int or float
-          assert type(high) == int or float
-          # Since the same boundaries are used for all observations, we set the
-          # limits according to the most restrictive (cos/sin): (-1., 1.).
-          low = max(low, LIMIT_LOW)
-          high = min(high, LIMIT_HIGH)
+            low = options.pop('low', DEFAULT_LOW)
+            high = options.pop('high', DEFAULT_HIGH)
+            # We expect only numerical inputs.
+            assert type(low) == int or float
+            assert type(high) == int or float
+            # Since the same boundaries are used for all observations, we set the
+            # limits according to the most restrictive (cos/sin): (-1., 1.).
+            low = max(low, LIMIT_LOW)
+            high = min(high, LIMIT_HIGH)
+            assert low < high
         self.state = self.np_random.uniform(low=low, high=high, size=(4,)).astype(
             np.float32
         )

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -14,6 +14,12 @@ from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
 
+DEFAULT_LOW = -0.05
+DEFAULT_HIGH = 0.05
+LIMIT_LOW = -0.2
+LIMIT_HIGH = 0.2
+
+
 class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
     """
     ### Description
@@ -194,7 +200,22 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
-        self.state = self.np_random.uniform(low=-0.05, high=0.05, size=(4,))
+        if options is None:
+            low = DEFAULT_LOW
+            high = DEFAULT_HIGH
+        else:
+          low = options.pop('low', DEFAULT_LOW)
+          high = options.pop('high', DEFAULT_HIGH)
+          # We expect only numerical inputs.
+          assert type(low) == int or float
+          assert type(high) == int or float
+          # Since the same boundaries are used for all observations, we set the
+          # limits according to the most restrictive (pole angle). As per the
+          # documentation at the top of the file, we restrict them to be within
+          # (-.2, .2).
+          low = max(low, LIMIT_LOW)
+          high = min(high, LIMIT_HIGH)
+        self.state = self.np_random.uniform(low=low, high=high, size=(4,))
         self.steps_beyond_done = None
         self.renderer.reset()
         self.renderer.render_step()

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -195,6 +195,8 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
+        # Note that if you use custom reset bounds, it may lead to out-of-bound
+        # state/observations.
         low, high = utils.maybe_parse_reset_bounds(
                 options,
                 -0.05,  # default low

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -198,9 +198,8 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         # Note that if you use custom reset bounds, it may lead to out-of-bound
         # state/observations.
         low, high = utils.maybe_parse_reset_bounds(
-                options,
-                -0.05,  # default low
-                0.05)  # default high
+            options, -0.05, 0.05  # default low
+        )  # default high
         self.state = self.np_random.uniform(low=low, high=high, size=(4,))
         self.steps_beyond_done = None
         self.renderer.reset()

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -204,17 +204,18 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
             low = DEFAULT_LOW
             high = DEFAULT_HIGH
         else:
-          low = options.pop('low', DEFAULT_LOW)
-          high = options.pop('high', DEFAULT_HIGH)
-          # We expect only numerical inputs.
-          assert type(low) == int or float
-          assert type(high) == int or float
-          # Since the same boundaries are used for all observations, we set the
-          # limits according to the most restrictive (pole angle). As per the
-          # documentation at the top of the file, we restrict them to be within
-          # (-.2, .2).
-          low = max(low, LIMIT_LOW)
-          high = min(high, LIMIT_HIGH)
+            low = options.pop('low', DEFAULT_LOW)
+            high = options.pop('high', DEFAULT_HIGH)
+            # We expect only numerical inputs.
+            assert type(low) == int or float
+            assert type(high) == int or float
+            # Since the same boundaries are used for all observations, we set the
+            # limits according to the most restrictive (pole angle). As per the
+            # documentation at the top of the file, we restrict them to be within
+            # (-.2, .2).
+            low = max(low, LIMIT_LOW)
+            high = min(high, LIMIT_HIGH)
+            assert low < high
         self.state = self.np_random.uniform(low=low, high=high, size=(4,))
         self.steps_beyond_done = None
         self.renderer.reset()

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -10,8 +10,8 @@ import numpy as np
 
 import gym
 from gym import logger, spaces
+from gym.envs.classic_control import utils
 from gym.error import DependencyNotInstalled
-from gym.utils import option_parser
 from gym.utils.renderer import Renderer
 
 
@@ -195,16 +195,10 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
-        # Since the same boundaries are used for all observations, we set the
-        # limits according to the most restrictive (pole angle). As per the
-        # documentation at the top of the file, we restrict them to be within
-        # (-.2, .2).
-        low, high = option_parser.maybe_parse_reset_bounds(
+        low, high = utils.maybe_parse_reset_bounds(
+                options,
                 -0.05,  # default low
-                0.05,  # default high
-                -0.2,  # limit low
-                0.2,  # limit high
-                options)
+                0.05)  # default high
         self.state = self.np_random.uniform(low=low, high=high, size=(4,))
         self.steps_beyond_done = None
         self.renderer.reset()

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -11,13 +11,8 @@ import numpy as np
 import gym
 from gym import logger, spaces
 from gym.error import DependencyNotInstalled
+from gym.utils import option_parser
 from gym.utils.renderer import Renderer
-
-
-DEFAULT_LOW = -0.05
-DEFAULT_HIGH = 0.05
-LIMIT_LOW = -0.2
-LIMIT_HIGH = 0.2
 
 
 class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
@@ -200,22 +195,16 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
-        if options is None:
-            low = DEFAULT_LOW
-            high = DEFAULT_HIGH
-        else:
-            low = options.pop('low', DEFAULT_LOW)
-            high = options.pop('high', DEFAULT_HIGH)
-            # We expect only numerical inputs.
-            assert type(low) == int or float
-            assert type(high) == int or float
-            # Since the same boundaries are used for all observations, we set the
-            # limits according to the most restrictive (pole angle). As per the
-            # documentation at the top of the file, we restrict them to be within
-            # (-.2, .2).
-            low = max(low, LIMIT_LOW)
-            high = min(high, LIMIT_HIGH)
-            assert low < high
+        # Since the same boundaries are used for all observations, we set the
+        # limits according to the most restrictive (pole angle). As per the
+        # documentation at the top of the file, we restrict them to be within
+        # (-.2, .2).
+        low, high = option_parser.maybe_parse_reset_bounds(
+                -0.05,  # default low
+                0.05,  # default high
+                -0.2,  # limit low
+                0.2,  # limit high
+                options)
         self.state = self.np_random.uniform(low=low, high=high, size=(4,))
         self.steps_beyond_done = None
         self.renderer.reset()

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -26,6 +26,8 @@ from gym.utils.renderer import Renderer
 
 DEFAULT_LOW = -0.6
 DEFAULT_HIGH = -0.4
+LIMIT_LOW = -1.2
+LIMIT_HIGH = 0.6
 
 
 class Continuous_MountainCarEnv(gym.Env):
@@ -188,12 +190,15 @@ class Continuous_MountainCarEnv(gym.Env):
             low = DEFAULT_LOW
             high = DEFAULT_HIGH
         else:
-          low = options.pop('low', DEFAULT_LOW)
-          high = options.pop('high', DEFAULT_HIGH)
-          # We expect only numerical inputs.
-          assert type(low) == int or float
-          assert type(high) == int or float
-          # There are no limits for mountain car initializations 🙂.
+            low = options.pop('low', DEFAULT_LOW)
+            high = options.pop('high', DEFAULT_HIGH)
+            # We expect only numerical inputs.
+            assert type(low) == int or float
+            assert type(high) == int or float
+            # MountainCar expects states to be within -1.2 and 0.6.
+            low = max(low, LIMIT_LOW)
+            high = min(high, LIMIT_HIGH)
+            assert low < high
         self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
         self.renderer.reset()
         self.renderer.render_step()

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -20,8 +20,8 @@ import numpy as np
 
 import gym
 from gym import spaces
+from gym.envs.classic_control import utils
 from gym.error import DependencyNotInstalled
-from gym.utils import option_parser
 from gym.utils.renderer import Renderer
 
 
@@ -182,12 +182,10 @@ class Continuous_MountainCarEnv(gym.Env):
     ):
         super().reset(seed=seed)
         # MountainCar expects states to be within -1.2 and 0.6.
-        low, high = option_parser.maybe_parse_reset_bounds(
+        low, high = utils.maybe_parse_reset_bounds(
+                options,
                 -0.6,  # default low
-                0.4,  # default high
-                -1.2,  # limit low
-                0.6,  # limit high
-                options)
+                0.4)  # default high
         self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
         self.renderer.reset()
         self.renderer.render_step()

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -21,13 +21,8 @@ import numpy as np
 import gym
 from gym import spaces
 from gym.error import DependencyNotInstalled
+from gym.utils import option_parser
 from gym.utils.renderer import Renderer
-
-
-DEFAULT_LOW = -0.6
-DEFAULT_HIGH = -0.4
-LIMIT_LOW = -1.2
-LIMIT_HIGH = 0.6
 
 
 class Continuous_MountainCarEnv(gym.Env):
@@ -186,19 +181,13 @@ class Continuous_MountainCarEnv(gym.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        if options is None:
-            low = DEFAULT_LOW
-            high = DEFAULT_HIGH
-        else:
-            low = options.pop('low', DEFAULT_LOW)
-            high = options.pop('high', DEFAULT_HIGH)
-            # We expect only numerical inputs.
-            assert type(low) == int or float
-            assert type(high) == int or float
-            # MountainCar expects states to be within -1.2 and 0.6.
-            low = max(low, LIMIT_LOW)
-            high = min(high, LIMIT_HIGH)
-            assert low < high
+        # MountainCar expects states to be within -1.2 and 0.6.
+        low, high = option_parser.maybe_parse_reset_bounds(
+                -0.6,  # default low
+                0.4,  # default high
+                -1.2,  # limit low
+                0.6,  # limit high
+                options)
         self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
         self.renderer.reset()
         self.renderer.render_step()

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -184,9 +184,8 @@ class Continuous_MountainCarEnv(gym.Env):
         # Note that if you use custom reset bounds, it may lead to out-of-bound
         # state/observations.
         low, high = utils.maybe_parse_reset_bounds(
-                options,
-                -0.6,  # default low
-                0.4)  # default high
+            options, -0.6, 0.4  # default low
+        )  # default high
         self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
         self.renderer.reset()
         self.renderer.render_step()

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -181,7 +181,8 @@ class Continuous_MountainCarEnv(gym.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        # MountainCar expects states to be within -1.2 and 0.6.
+        # Note that if you use custom reset bounds, it may lead to out-of-bound
+        # state/observations.
         low, high = utils.maybe_parse_reset_bounds(
                 options,
                 -0.6,  # default low

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -24,6 +24,10 @@ from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
 
+DEFAULT_LOW = -0.6
+DEFAULT_HIGH = -0.4
+
+
 class Continuous_MountainCarEnv(gym.Env):
     """
     ### Description
@@ -180,7 +184,17 @@ class Continuous_MountainCarEnv(gym.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        self.state = np.array([self.np_random.uniform(low=-0.6, high=-0.4), 0])
+        if options is None:
+            low = DEFAULT_LOW
+            high = DEFAULT_HIGH
+        else:
+          low = options.pop('low', DEFAULT_LOW)
+          high = options.pop('high', DEFAULT_HIGH)
+          # We expect only numerical inputs.
+          assert type(low) == int or float
+          assert type(high) == int or float
+          # There are no limits for mountain car initializations 🙂.
+        self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
         self.renderer.reset()
         self.renderer.render_step()
         if not return_info:

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -158,9 +158,8 @@ class MountainCarEnv(gym.Env):
         # Note that if you use custom reset bounds, it may lead to out-of-bound
         # state/observations.
         low, high = utils.maybe_parse_reset_bounds(
-                options,
-                -0.6,  # default low
-                0.4)  # default high
+            options, -0.6, 0.4  # default low
+        )  # default high
         self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
         self.renderer.reset()
         self.renderer.render_step()

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -10,13 +10,8 @@ import numpy as np
 import gym
 from gym import spaces
 from gym.error import DependencyNotInstalled
+from gym.utils import option_parser
 from gym.utils.renderer import Renderer
-
-
-DEFAULT_LOW = -0.6
-DEFAULT_HIGH = -0.4
-LIMIT_LOW = -1.2
-LIMIT_HIGH = 0.6
 
 
 class MountainCarEnv(gym.Env):
@@ -160,19 +155,13 @@ class MountainCarEnv(gym.Env):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
-        if options is None:
-            low = DEFAULT_LOW
-            high = DEFAULT_HIGH
-        else:
-            low = options.pop('low', DEFAULT_LOW)
-            high = options.pop('high', DEFAULT_HIGH)
-            # We expect only numerical inputs.
-            assert type(low) == int or float
-            assert type(high) == int or float
-            # MountainCar expects states to be within -1.2 and 0.6.
-            low = max(low, LIMIT_LOW)
-            high = min(high, LIMIT_HIGH)
-            assert low < high
+        # MountainCar expects states to be within -1.2 and 0.6.
+        low, high = option_parser.maybe_parse_reset_bounds(
+                -0.6,  # default low
+                0.4,  # default high
+                -1.2,  # limit low
+                0.6,  # limit high
+                options)
         self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
         self.renderer.reset()
         self.renderer.render_step()

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -9,8 +9,8 @@ import numpy as np
 
 import gym
 from gym import spaces
+from gym.envs.classic_control import utils
 from gym.error import DependencyNotInstalled
-from gym.utils import option_parser
 from gym.utils.renderer import Renderer
 
 
@@ -156,12 +156,10 @@ class MountainCarEnv(gym.Env):
     ):
         super().reset(seed=seed)
         # MountainCar expects states to be within -1.2 and 0.6.
-        low, high = option_parser.maybe_parse_reset_bounds(
+        low, high = utils.maybe_parse_reset_bounds(
+                options,
                 -0.6,  # default low
-                0.4,  # default high
-                -1.2,  # limit low
-                0.6,  # limit high
-                options)
+                0.4)  # default high
         self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
         self.renderer.reset()
         self.renderer.render_step()

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -155,7 +155,8 @@ class MountainCarEnv(gym.Env):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
-        # MountainCar expects states to be within -1.2 and 0.6.
+        # Note that if you use custom reset bounds, it may lead to out-of-bound
+        # state/observations.
         low, high = utils.maybe_parse_reset_bounds(
                 options,
                 -0.6,  # default low

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -15,6 +15,8 @@ from gym.utils.renderer import Renderer
 
 DEFAULT_LOW = -0.6
 DEFAULT_HIGH = -0.4
+LIMIT_LOW = -1.2
+LIMIT_HIGH = 0.6
 
 
 class MountainCarEnv(gym.Env):
@@ -162,12 +164,15 @@ class MountainCarEnv(gym.Env):
             low = DEFAULT_LOW
             high = DEFAULT_HIGH
         else:
-          low = options.pop('low', DEFAULT_LOW)
-          high = options.pop('high', DEFAULT_HIGH)
-          # We expect only numerical inputs.
-          assert type(low) == int or float
-          assert type(high) == int or float
-          # There are no limits for mountain car initializations 🙂.
+            low = options.pop('low', DEFAULT_LOW)
+            high = options.pop('high', DEFAULT_HIGH)
+            # We expect only numerical inputs.
+            assert type(low) == int or float
+            assert type(high) == int or float
+            # MountainCar expects states to be within -1.2 and 0.6.
+            low = max(low, LIMIT_LOW)
+            high = min(high, LIMIT_HIGH)
+            assert low < high
         self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
         self.renderer.reset()
         self.renderer.render_step()

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -13,6 +13,10 @@ from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
 
+DEFAULT_LOW = -0.6
+DEFAULT_HIGH = -0.4
+
+
 class MountainCarEnv(gym.Env):
     """
     ### Description
@@ -154,7 +158,17 @@ class MountainCarEnv(gym.Env):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
-        self.state = np.array([self.np_random.uniform(low=-0.6, high=-0.4), 0])
+        if options is None:
+            low = DEFAULT_LOW
+            high = DEFAULT_HIGH
+        else:
+          low = options.pop('low', DEFAULT_LOW)
+          high = options.pop('high', DEFAULT_HIGH)
+          # We expect only numerical inputs.
+          assert type(low) == int or float
+          assert type(high) == int or float
+          # There are no limits for mountain car initializations 🙂.
+        self.state = np.array([self.np_random.uniform(low=low, high=high), 0])
         self.renderer.reset()
         self.renderer.render_step()
         if not return_info:

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -11,7 +11,6 @@ from gym.envs.classic_control import utils
 from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
-
 DEFAULT_X = np.pi
 DEFAULT_Y = 1.0
 
@@ -152,8 +151,8 @@ class PendulumEnv(gym.Env):
         else:
             # Note that if you use custom reset bounds, it may lead to out-of-bound
             # state/observations.
-            x = options.get('x') if 'x' in options else DEFAULT_X
-            y = options.get('y') if 'y' in options else DEFAULT_Y
+            x = options.get("x") if "x" in options else DEFAULT_X
+            y = options.get("y") if "y" in options else DEFAULT_Y
             # We expect only numerical inputs.
             assert utils.verify_number(x)
             assert utils.verify_number(y)

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -150,6 +150,8 @@ class PendulumEnv(gym.Env):
         if options is None:
             high = np.array([DEFAULT_X, DEFAULT_Y])
         else:
+            # Note that if you use custom reset bounds, it may lead to out-of-bound
+            # state/observations.
             x = options.get('x') if 'x' in options else DEFAULT_X
             y = options.get('y') if 'y' in options else DEFAULT_Y
             # We expect only numerical inputs.

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -152,8 +152,8 @@ class PendulumEnv(gym.Env):
           x = options.pop('x', DEFAULT_X)
           y = options.pop('y', DEFAULT_Y)
           # We expect only numerical inputs.
-          assert type(tmp_low) == int or float
-          assert type(tmp_high) == int or float
+          assert type(x) == int or float
+          assert type(y) == int or float
           # Since the same boundaries are used for all observations, we set the
           # limits according to the most restrictive (sin/cos). Since these are
           # the values that will be used for the `high` variable, we enforce them

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -11,6 +11,10 @@ from gym.error import DependencyNotInstalled
 from gym.utils.renderer import Renderer
 
 
+DEFAULT_X = np.pi
+DEFAULT_Y = 1.0
+
+
 class PendulumEnv(gym.Env):
     """
        ### Description
@@ -142,8 +146,23 @@ class PendulumEnv(gym.Env):
         options: Optional[dict] = None
     ):
         super().reset(seed=seed)
-        high = np.array([np.pi, 1])
-        self.state = self.np_random.uniform(low=-high, high=high)
+        if options is None:
+            high = np.array([np.pi, 1])
+        else:
+          x = options.pop('x', DEFAULT_X)
+          y = options.pop('y', DEFAULT_Y)
+          # We expect only numerical inputs.
+          assert type(tmp_low) == int or float
+          assert type(tmp_high) == int or float
+          # Since the same boundaries are used for all observations, we set the
+          # limits according to the most restrictive (sin/cos). Since these are
+          # the values that will be used for the `high` variable, we enforce them
+          # to be non-negative: (0., 1.).
+          x = max(0.0, min(1.0, x))
+          y = max(0.0, min(1.0, y))
+          high = np.array([x, y])
+        low = -high  # We enforce symmetric limits.
+        self.state = self.np_random.uniform(low=low, high=high)
         self.last_u = None
 
         self.renderer.reset()

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -7,8 +7,8 @@ import numpy as np
 
 import gym
 from gym import spaces
+from gym.envs.classic_control import utils
 from gym.error import DependencyNotInstalled
-from gym.utils import option_parser
 from gym.utils.renderer import Renderer
 
 
@@ -148,20 +148,13 @@ class PendulumEnv(gym.Env):
     ):
         super().reset(seed=seed)
         if options is None:
-            high = np.array([np.pi, 1])
+            high = np.array([DEFAULT_X, DEFAULT_Y])
         else:
-            x = options.pop('x', DEFAULT_X)
-            y = options.pop('y', DEFAULT_Y)
+            x = options.get('x') if 'x' in options else DEFAULT_X
+            y = options.get('y') if 'y' in options else DEFAULT_Y
             # We expect only numerical inputs.
-            assert option_parser.verify_number(x)
-            assert option_parser.verify_number(y)
-            # Since the same boundaries are used for all observations, we set the
-            # limits according to the most restrictive (sin/cos). Since these are
-            # the values that will be used for the `high` variable, we enforce them
-            # to be non-negative: (0., 1.).
-            x = max(0.0, min(1.0, x))
-            y = max(0.0, min(1.0, y))
-            assert x < y
+            assert utils.verify_number(x)
+            assert utils.verify_number(y)
             high = np.array([x, y])
         low = -high  # We enforce symmetric limits.
         self.state = self.np_random.uniform(low=low, high=high)

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -8,6 +8,7 @@ import numpy as np
 import gym
 from gym import spaces
 from gym.error import DependencyNotInstalled
+from gym.utils import option_parser
 from gym.utils.renderer import Renderer
 
 
@@ -152,8 +153,8 @@ class PendulumEnv(gym.Env):
             x = options.pop('x', DEFAULT_X)
             y = options.pop('y', DEFAULT_Y)
             # We expect only numerical inputs.
-            assert type(x) == int or float
-            assert type(y) == int or float
+            assert option_parser.verify_number(x)
+            assert option_parser.verify_number(y)
             # Since the same boundaries are used for all observations, we set the
             # limits according to the most restrictive (sin/cos). Since these are
             # the values that will be used for the `high` variable, we enforce them

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -151,11 +151,10 @@ class PendulumEnv(gym.Env):
         else:
             # Note that if you use custom reset bounds, it may lead to out-of-bound
             # state/observations.
-            x = options.get("x") if "x" in options else DEFAULT_X
-            y = options.get("y") if "y" in options else DEFAULT_Y
-            # We expect only numerical inputs.
-            assert utils.verify_number(x)
-            assert utils.verify_number(y)
+            x = options.get("x_init") if "x_init" in options else DEFAULT_X
+            y = options.get("y_init") if "y_init" in options else DEFAULT_Y
+            x = utils.verify_number_and_cast(x)
+            y = utils.verify_number_and_cast(y)
             high = np.array([x, y])
         low = -high  # We enforce symmetric limits.
         self.state = self.np_random.uniform(low=low, high=high)

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -149,18 +149,19 @@ class PendulumEnv(gym.Env):
         if options is None:
             high = np.array([np.pi, 1])
         else:
-          x = options.pop('x', DEFAULT_X)
-          y = options.pop('y', DEFAULT_Y)
-          # We expect only numerical inputs.
-          assert type(x) == int or float
-          assert type(y) == int or float
-          # Since the same boundaries are used for all observations, we set the
-          # limits according to the most restrictive (sin/cos). Since these are
-          # the values that will be used for the `high` variable, we enforce them
-          # to be non-negative: (0., 1.).
-          x = max(0.0, min(1.0, x))
-          y = max(0.0, min(1.0, y))
-          high = np.array([x, y])
+            x = options.pop('x', DEFAULT_X)
+            y = options.pop('y', DEFAULT_Y)
+            # We expect only numerical inputs.
+            assert type(x) == int or float
+            assert type(y) == int or float
+            # Since the same boundaries are used for all observations, we set the
+            # limits according to the most restrictive (sin/cos). Since these are
+            # the values that will be used for the `high` variable, we enforce them
+            # to be non-negative: (0., 1.).
+            x = max(0.0, min(1.0, x))
+            y = max(0.0, min(1.0, y))
+            assert x < y
+            high = np.array([x, y])
         low = -high  # We enforce symmetric limits.
         self.state = self.np_random.uniform(low=low, high=high)
         self.last_u = None

--- a/gym/envs/classic_control/utils.py
+++ b/gym/envs/classic_control/utils.py
@@ -7,18 +7,13 @@ from typing import Optional, Union
 import numpy as np
 
 
-def verify_number(x: Union[int, float, np.ndarray]) -> bool:
-    """Verify parameter is a single number."""
-    if type(x) == int or type(x) == float:
-        # A single value that is either an int or a float.
-        return True
-    if type(x) == np.ndarray:
-        if (
-            np.issubdtype(x.dtype, np.floating) or np.issubdtype(x.dtype, np.integer)
-        ) and len(x.shape) == 0:
-            # A numpy single value that is either an int or a float.
-            return True
-    return False
+def verify_number_and_cast(x: Union[int, float, np.ndarray]) -> float:
+    """Verify parameter is a single number and cast to a float."""
+    try:
+        x = float(x)
+    except (ValueError, TypeError):
+        raise ValueError(f"Your input must support being cast to a float: {x}")
+    return x
 
 
 def maybe_parse_reset_bounds(
@@ -44,7 +39,8 @@ def maybe_parse_reset_bounds(
     low = options.get("low") if "low" in options else default_low
     high = options.get("high") if "high" in options else default_high
     # We expect only numerical inputs.
-    assert verify_number(low)
-    assert verify_number(high)
-    assert low <= high
+    low = verify_number_and_cast(low)
+    high = verify_number_and_cast(high)
+    if low > high:
+        raise ValueError("Lower bound must be lower than higher bound.")
     return low, high

--- a/gym/envs/classic_control/utils.py
+++ b/gym/envs/classic_control/utils.py
@@ -3,6 +3,7 @@ Utility functions used for classic control environments.
 """
 
 from typing import Optional, Union
+
 import numpy as np
 
 
@@ -12,17 +13,17 @@ def verify_number(x: Union[int, float, np.ndarray]) -> bool:
         # A single value that is either an int or a float.
         return True
     if type(x) == np.ndarray:
-        if ((np.issubdtype(x.dtype, np.floating) or
-             np.issubdtype(x.dtype, np.integer)) and
-            len(x.shape) == 0):
+        if (
+            np.issubdtype(x.dtype, np.floating) or np.issubdtype(x.dtype, np.integer)
+        ) and len(x.shape) == 0:
             # A numpy single value that is either an int or a float.
             return True
     return False
 
 
-def maybe_parse_reset_bounds(options: Optional[dict],
-                             default_low: float,
-                             default_high: float) -> Union[float, float]:
+def maybe_parse_reset_bounds(
+    options: Optional[dict], default_low: float, default_high: float
+) -> Union[float, float]:
     """
     This function can be called during a reset() to customize the sampling
     ranges for setting the initial state distributions.
@@ -40,8 +41,8 @@ def maybe_parse_reset_bounds(options: Optional[dict],
     if options is None:
         return default_low, default_high
 
-    low = options.get('low') if 'low' in options else default_low
-    high = options.get('high') if 'high' in options else default_high
+    low = options.get("low") if "low" in options else default_low
+    high = options.get("high") if "high" in options else default_high
     # We expect only numerical inputs.
     assert verify_number(low)
     assert verify_number(high)

--- a/gym/envs/classic_control/utils.py
+++ b/gym/envs/classic_control/utils.py
@@ -2,12 +2,10 @@
 Utility functions used for classic control environments.
 """
 
-from typing import Optional, Union
-
-import numpy as np
+from typing import Optional, SupportsFloat, Union
 
 
-def verify_number_and_cast(x: Union[int, float, np.ndarray]) -> float:
+def verify_number_and_cast(x: SupportsFloat) -> float:
     """Verify parameter is a single number and cast to a float."""
     try:
         x = float(x)

--- a/gym/envs/classic_control/utils.py
+++ b/gym/envs/classic_control/utils.py
@@ -20,21 +20,19 @@ def verify_number(x: Union[int, float, np.ndarray]) -> bool:
     return False
 
 
-def maybe_parse_reset_bounds(default_low: float,
-                             default_high: float,
-                             limit_low: float,
-                             limit_high: float,
-                             options: Optional[dict] = None) -> [float, float]:
+def maybe_parse_reset_bounds(options: Optional[dict],
+                             default_low: float,
+                             default_high: float) -> [float, float]:
     """
     This function can be called during a reset() to customize the sampling
     ranges for setting the initial state distributions.
 
     Args:
+      options: (Optional) options passed in to reset().
       default_low: Default lower limit to use, if none specified in options.
       default_high: Default upper limit to use, if none specified in options.
       limit_low: Lowest allowable value for user-specified lower limit.
       limit_high: Highest allowable value for user-specified higher limit.
-      options: (Optional) options passed in to reset().
 
     Returns:
       Lower and higher limits.
@@ -42,12 +40,10 @@ def maybe_parse_reset_bounds(default_low: float,
     if options is None:
         return default_low, default_high
 
-    low = options.pop('low', default_low)
-    high = options.pop('high', default_high)
+    low = options.get('low') if 'low' in options else default_low
+    high = options.get('high') if 'high' in options else default_high
     # We expect only numerical inputs.
     assert verify_number(low)
     assert verify_number(high)
-    low = max(low, limit_low)
-    high = min(high, limit_high)
     assert low <= high
     return low, high

--- a/gym/envs/classic_control/utils.py
+++ b/gym/envs/classic_control/utils.py
@@ -22,7 +22,7 @@ def verify_number(x: Union[int, float, np.ndarray]) -> bool:
 
 def maybe_parse_reset_bounds(options: Optional[dict],
                              default_low: float,
-                             default_high: float) -> [float, float]:
+                             default_high: float) -> Union[float, float]:
     """
     This function can be called during a reset() to customize the sampling
     ranges for setting the initial state distributions.

--- a/gym/utils/option_parser.py
+++ b/gym/utils/option_parser.py
@@ -1,0 +1,53 @@
+"""
+Utility functions used for classic control environments.
+"""
+
+from typing import Optional, Union
+import numpy as np
+
+
+def verify_number(x: Union[int, float, np.ndarray]) -> bool:
+    """Verify parameter is a single number."""
+    if type(x) == int or type(x) == float:
+        # A single value that is either an int or a float.
+        return True
+    if type(x) == np.ndarray:
+        if ((np.issubdtype(x.dtype, np.floating) or
+             np.issubdtype(x.dtype, np.integer)) and
+            len(x.shape) == 0):
+            # A numpy single value that is either an int or a float.
+            return True
+    return False
+
+
+def maybe_parse_reset_bounds(default_low: float,
+                             default_high: float,
+                             limit_low: float,
+                             limit_high: float,
+                             options: Optional[dict] = None) -> [float, float]:
+    """
+    This function can be called during a reset() to customize the sampling
+    ranges for setting the initial state distributions.
+
+    Args:
+      default_low: Default lower limit to use, if none specified in options.
+      default_high: Default upper limit to use, if none specified in options.
+      limit_low: Lowest allowable value for user-specified lower limit.
+      limit_high: Highest allowable value for user-specified higher limit.
+      options: (Optional) options passed in to reset().
+
+    Returns:
+      Lower and higher limits.
+    """
+    if options is None:
+        return default_low, default_high
+
+    low = options.pop('low', default_low)
+    high = options.pop('high', default_high)
+    # We expect only numerical inputs.
+    assert verify_number(low)
+    assert verify_number(high)
+    low = max(low, limit_low)
+    high = min(high, limit_high)
+    assert low <= high
+    return low, high

--- a/tests/envs/test_env_implementation.py
+++ b/tests/envs/test_env_implementation.py
@@ -152,7 +152,7 @@ def test_taxi_encode_decode():
     ["Acrobot-v1", "CartPole-v1", "MountainCar-v0", "MountainCarContinuous-v0"],
 )
 @pytest.mark.parametrize(
-    "low_high", [None, (-0.5, 0.5), (np.array(-0.5), np.array(0.5))]
+    "low_high", [None, (-0.4, 0.4), (np.array(-0.4), np.array(0.4))]
 )
 def test_customizable_resets(env_name: str, low_high: Optional[list]):
     env = gym.make(env_name)

--- a/tests/envs/test_env_implementation.py
+++ b/tests/envs/test_env_implementation.py
@@ -83,6 +83,27 @@ def test_frozenlake_dfs_map_generation(map_size: int):
                         frontier.append((new_row, new_col))
     raise AssertionError("No path through the frozenlake was found.")
 
+def test_taxi_action_mask():
+    env = TaxiEnv()
+
+    for state in env.P:
+        mask = env.action_mask(state)
+        for action, possible in enumerate(mask):
+            _, next_state, _, _ = env.P[state][action][0]
+            assert state != next_state if possible else state == next_state
+
+
+def test_taxi_encode_decode():
+    env = TaxiEnv()
+
+    state = env.reset()
+    for _ in range(100):
+        assert (
+            env.encode(*env.decode(state)) == state
+        ), f"state={state}, encode(decode(state))={env.encode(*env.decode(state))}"
+        state, _, _, _ = env.step(env.action_space.sample())
+
+
 @pytest.mark.parametrize(
         "env_name",
         ["Acrobot-v1", "CartPole-v1",
@@ -104,6 +125,7 @@ def test_customizable_resets(env_name: str, low_high: Optional[list]):
             action = [0] if env_name.endswith("Continuous-v0") else 0
             env.step(action)
 
+
 @pytest.mark.parametrize(
         "env_name",
         ["CartPole-v1", "MountainCar-v0", "MountainCarContinuous-v0"])
@@ -116,6 +138,7 @@ def test_customizable_out_of_bounds_resets(
     low, high = low_high
     with pytest.raises(AssertionError):
         env.reset(options={"low": low, "high": high})
+
 
 # We test Pendulum separately, as the parameters are handled differently.
 @pytest.mark.parametrize("low_high",
@@ -136,6 +159,7 @@ def test_customizable_resets(low_high: Optional[list]):
             # limit (and lower limit is just the negative of it).
             env.reset(options={"x": low, "y": high})
             env.step([0])
+
 
 @pytest.mark.parametrize(
         "env_name",

--- a/tests/envs/test_env_implementation.py
+++ b/tests/envs/test_env_implementation.py
@@ -1,11 +1,13 @@
-import pytest
 from typing import Optional
+
+import numpy as np
+import pytest
 
 import gym
 from gym.envs.box2d import BipedalWalker
 from gym.envs.box2d.lunar_lander import demo_heuristic_lander
+from gym.envs.toy_text import TaxiEnv
 from gym.envs.toy_text.frozen_lake import generate_random_map
-import numpy as np
 
 
 def test_lunar_lander_heuristics():
@@ -83,6 +85,7 @@ def test_frozenlake_dfs_map_generation(map_size: int):
                         frontier.append((new_row, new_col))
     raise AssertionError("No path through the frozenlake was found.")
 
+
 def test_taxi_action_mask():
     env = TaxiEnv()
 
@@ -105,13 +108,12 @@ def test_taxi_encode_decode():
 
 
 @pytest.mark.parametrize(
-        "env_name",
-        ["Acrobot-v1", "CartPole-v1",
-         "MountainCar-v0", "MountainCarContinuous-v0"])
-@pytest.mark.parametrize("low_high",
-                         [None,
-                          (-0.5, 0.5),
-                          (np.array(-0.5), np.array(0.5))])
+    "env_name",
+    ["Acrobot-v1", "CartPole-v1", "MountainCar-v0", "MountainCarContinuous-v0"],
+)
+@pytest.mark.parametrize(
+    "low_high", [None, (-0.5, 0.5), (np.array(-0.5), np.array(0.5))]
+)
 def test_customizable_resets(env_name: str, low_high: Optional[list]):
     env = gym.make(env_name)
     # First ensure we can do a reset.
@@ -127,13 +129,10 @@ def test_customizable_resets(env_name: str, low_high: Optional[list]):
 
 
 @pytest.mark.parametrize(
-        "env_name",
-        ["CartPole-v1", "MountainCar-v0", "MountainCarContinuous-v0"])
-@pytest.mark.parametrize("low_high",
-                         [(-10.0, -9.0),
-                          (np.array(-10.0), np.array(-9.0))])
-def test_customizable_out_of_bounds_resets(
-        env_name: str, low_high: Optional[list]):
+    "env_name", ["CartPole-v1", "MountainCar-v0", "MountainCarContinuous-v0"]
+)
+@pytest.mark.parametrize("low_high", [(-10.0, -9.0), (np.array(-10.0), np.array(-9.0))])
+def test_customizable_out_of_bounds_resets(env_name: str, low_high: Optional[list]):
     env = gym.make(env_name)
     low, high = low_high
     with pytest.raises(AssertionError):
@@ -141,12 +140,15 @@ def test_customizable_out_of_bounds_resets(
 
 
 # We test Pendulum separately, as the parameters are handled differently.
-@pytest.mark.parametrize("low_high",
-                         [None,
-                          (1.2, 1.0),
-                          (np.array(1.2), np.array(1.0)),
-                          ])
-def test_customizable_resets(low_high: Optional[list]):
+@pytest.mark.parametrize(
+    "low_high",
+    [
+        None,
+        (1.2, 1.0),
+        (np.array(1.2), np.array(1.0)),
+    ],
+)
+def test_customizable_pendulum_resets(low_high: Optional[list]):
     env = gym.make("Pendulum-v1")
     # First ensure we can do a reset and the values are within expected ranges.
     if low_high is None:
@@ -162,14 +164,13 @@ def test_customizable_resets(low_high: Optional[list]):
 
 
 @pytest.mark.parametrize(
-        "env_name",
-        ["Acrobot-v1", "CartPole-v1", "MountainCar-v0",
-         "MountainCarContinuous-v0"])
-@pytest.mark.parametrize("low_high",
-                         [("x", "y"),
-                          (10.0, 8.0),
-                          ([-1.], [1.]),
-                          (np.array([-1.]), np.array([1.]))])
+    "env_name",
+    ["Acrobot-v1", "CartPole-v1", "MountainCar-v0", "MountainCarContinuous-v0"],
+)
+@pytest.mark.parametrize(
+    "low_high",
+    [("x", "y"), (10.0, 8.0), ([-1.0], [1.0]), (np.array([-1.0]), np.array([1.0]))],
+)
 def test_invalid_customizable_resets(env_name: str, low_high: list):
     env = gym.make(env_name)
     low, high = low_high


### PR DESCRIPTION
# Description

This PR adds the ability for users to specify custom limits for the initial state distribution boundaries for classic control environments. Currently, they are hard-coded, but it can be useful for research to be able to set these to different values.

Motivating context: https://twitter.com/pcastr/status/1539368076700962817

Based on https://github.com/openai/gym/pull/2921, but now added numpy input support (and extra tests).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
# Checklist:

- [x ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes