### PR TITLE
Jax Blackjack Environment

### DIFF
--- a/gym/envs/__init__.py
+++ b/gym/envs/__init__.py
@@ -342,3 +342,12 @@ register(
     entry_point="gym.envs.mujoco.humanoidstandup_v4:HumanoidStandupEnv",
     max_episode_steps=1000,
 )
+
+# Jax Toy Text
+# ----------------------------------------
+
+register(
+    id="Jax-BlackJack-v0",
+    entry_point="gym.envs.jax_toy_text.jax_blackjack:JaxBlackJackEnv",
+    kwargs={"sutton_and_barto": True, "natural": False},
+)

--- a/gym/envs/jax_toy_text/__init__.py
+++ b/gym/envs/jax_toy_text/__init__.py
@@ -1,0 +1,1 @@
+from gym.envs.jax_toy_text.jax_blackjack import JaxBlackJackEnv

--- a/gym/envs/jax_toy_text/jax_blackjack.py
+++ b/gym/envs/jax_toy_text/jax_blackjack.py
@@ -1,0 +1,452 @@
+
+from functools import partial
+import math
+import os
+import time
+
+import jax.numpy as jnp
+import jax
+from jax import random, jit, pmap, vmap
+import numpy as np
+
+
+import gym
+from gym import spaces
+
+from gym.utils.renderer import Renderer
+from gym.error import DependencyNotInstalled
+
+
+
+deck = jnp.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 10, 10])
+
+
+#converts a tuple of device arrays into a tutple of ints
+def obs_from_device(obs):
+    return tuple([int(jax.device_get(obs[i])) for i in range(len(obs))])
+
+
+
+def cmp(a, b):
+    return (a > b).astype(int) - (a < b).astype(int)
+
+#gets a random card(with replacement)
+def random_card(key):
+    key = random.split(key)[0]
+    choice = random.choice(key,deck,shape=(1,))
+    
+    return choice[0].astype(int), key
+
+# draws a starting hand of two cards
+def draw_hand(key,hand):
+    new_card, key = random_card(key)
+    hand = hand.at[0].set(new_card)
+    new_card, key = random_card(key)
+    hand =  hand.at[1].set(new_card)
+    return hand, key
+
+#draws a single card
+def draw_card(key, hand, index):
+    new_card, key = random_card(key)
+    hand = hand.at[index].set(new_card)
+    return key, hand, index+1
+
+
+def usable_ace(hand):  # Does this hand have a usable ace?
+    return  jnp.logical_and((jnp.count_nonzero(hand==1) > 0 ) , (sum(hand) + 10 <= 21))
+
+# the player has decided to take a card
+def take(env_state):
+    state, key = env_state
+    dealer_hand = state[0]
+    player_hand = state[1]
+    dealer_cards = state[2] 
+    player_cards = state[3]
+    key, new_player_hand, _ = draw_card(key, player_hand,player_cards)
+    
+    return (dealer_hand,new_player_hand, dealer_cards,player_cards + 1 ),  key
+
+# the player has decided to not take a card, ending the active portion
+# of the game and turning control over to the dealer
+def notake(env_state):
+    state, key = env_state
+    dealer_hand = state[0]
+    player_hand = state[1]
+    dealer_cards = state[2] 
+    player_cards = state[3]
+
+    draw_card_wrapper = lambda val : draw_card(*val) 
+
+    key,dealer_hand, dealer_cards = jax.lax.while_loop(lambda val: sum_hand(val[1])<17, draw_card_wrapper, (key, dealer_hand, dealer_cards))
+
+    return (dealer_hand, player_hand, dealer_cards, player_cards), key
+
+# gets an observation from env state
+def _get_obsv(env_state):
+    return (sum_hand(env_state[0][1]), env_state[0][0][0], usable_ace(env_state[0][1]))
+
+def sum_hand(hand):  # Return current hand total 
+    return sum(hand) + (10 * usable_ace(hand))
+
+
+def is_bust(hand):  # Is this hand a bust?
+    return sum_hand(hand) > 21
+
+
+def score(hand):  # What is the score of this hand (0 if bust)
+    return (jnp.logical_not(is_bust(hand))) * sum_hand(hand)
+
+
+def is_natural(hand):  # Is this hand a natural blackjack?
+    return jnp.logical_and(jnp.logical_and(jnp.count_nonzero(hand) == 2 , (jnp.count_nonzero(hand==1) > 0 )) , (jnp.count_nonzero(hand==10) > 0 ))
+
+
+class JaxBlackJackEnv(gym.Env):
+
+    """
+    Blackjack is a card game where the goal is to beat the dealer by obtaining cards
+    that sum to closer to 21 (without going over 21) than the dealers cards.
+
+    ### Description
+    Card Values:
+
+    - Face cards (Jack, Queen, King) have a point value of 10.
+    - Aces can either count as 11 (called a 'usable ace') or 1.
+    - Numerical cards (2-9) have a value equal to their number.
+
+    This game is played with an infinite deck (or with replacement).
+    The game starts with the dealer having one face up and one face down card,
+    while the player has two face up cards.
+
+    The player can request additional cards (hit, action=1) until they decide to stop (stick, action=0)
+    or exceed 21 (bust, immediate loss).
+    After the player sticks, the dealer reveals their facedown card, and draws
+    until their sum is 17 or greater.  If the dealer goes bust, the player wins.
+    If neither the player nor the dealer busts, the outcome (win, lose, draw) is
+    decided by whose sum is closer to 21.
+
+    ### Action Space
+    There are two actions: stick (0), and hit (1).
+
+    ### Observation Space
+    The observation consists of a 3-tuple containing: the player's current sum,
+    the value of the dealer's one showing card (1-10 where 1 is ace),
+    and whether the player holds a usable ace (0 or 1).
+
+    This environment corresponds to the version of the blackjack problem
+    described in Example 5.1 in Reinforcement Learning: An Introduction
+    by Sutton and Barto (http://incompleteideas.net/book/the-book-2nd.html).
+
+    ### Rewards
+    - win game: +1
+    - lose game: -1
+    - draw game: 0
+    - win game with natural blackjack:
+
+        +1.5 (if <a href="#nat">natural</a> is True)
+
+        +1 (if <a href="#nat">natural</a> is False)
+
+    ### Arguments
+
+    ```
+    gym.make('Jax-Blackjack-v1', natural=False, sab=False)
+    ```
+
+    <a id="nat">`natural=False`</a>: Whether to give an additional reward for
+    starting with a natural blackjack, i.e. starting with an ace and ten (sum is 21).
+
+    <a id="sutton_and_barto">`sutton_and_barto=False`</a>: Whether to follow the exact rules outlined in the book by
+    Sutton and Barto. If `sab` is `True`, the keyword argument `natural` will be ignored.
+    If the player achieves a natural blackjack and the dealer does not, the player
+    will win (i.e. get a reward of +1). The reverse rule does not apply.
+    If both the player and the dealer get a natural, it will be a draw (i.e. reward 0).
+
+    ### Version History
+    * v1: Initial versions release (1.0.0)
+    """
+
+
+
+    metadata = {
+        "render_modes": ["human", "rgb_array", "single_rgb_array"],
+        "render_fps": 4,
+    }
+
+    def __init__(self, render_mode = None, natural = False, sutton_and_barto = False):
+        
+        self.action_space = spaces.Discrete(2)
+        self.observation_space = spaces.Tuple(
+            (spaces.Discrete(32), spaces.Discrete(11), spaces.Discrete(2))
+        )
+
+        # Flag to payout 1.5 on a "natural" blackjack win, like casino rules
+        # Ref: http://www.bicyclecards.com/how-to-play/blackjack/
+        self.natural = natural
+
+        # Flag for full agreement with the (Sutton and Barto, 2018) definition. Overrides self.natural
+        self.sutton_and_barto = sutton_and_barto
+
+        # 1 = Ace, 2-10 = Number cards, Jack/Queen/King = 10
+
+
+        self.render_mode = render_mode
+        self.renderer = Renderer(self.render_mode, self._render)
+
+    @partial(jit, static_argnums=(0,))
+    def jit_step(self, env_state, action):
+        
+
+        env_state = jax.lax.cond(action, take, notake, env_state)
+        
+
+        state, key = env_state
+        dealer_hand = state[0]
+        player_hand = state[1]
+        dealer_cards = state[2] 
+        player_cards = state[3]
+
+        # -1 reward if the player busts, otherwise +1 if better than dealer, 0 if tie, -1 if loss. 
+        reward = (is_bust(player_hand) * -1  * action) + ((jnp.logical_not(action)) * cmp(score(player_hand), score(dealer_hand)))
+        
+        #in the natural setting, if the player wins with a natural blackjack, then reward is 1.5
+        if self.natural and not self.sutton_and_barto:
+            condition = jnp.logical_and(is_natural(player_hand) , (reward == 1))
+            reward = reward * jnp.logical_not(condition) + 1.5 * condition 
+
+        # in the sutton and barto setting, if the player gets a natural blackjack and the dealer gets
+        # a non-natural blackjack, the player wins. A dealer natural blackjack and a player
+        # non-natural blackjack should result in a tie.
+        if self.sutton_and_barto:
+            condition = jnp.logical_and(is_natural(player_hand) , jnp.logical_not(is_natural(dealer_hand)))
+            reward = reward * jnp.logical_not(condition) + 1 * condition 
+        
+        # note that only a bust or player action ends the round, the player
+        # can still request another card with 21 cards
+        done = (is_bust(player_hand) * action) + ((jnp.logical_not(action)) * 1)
+
+        
+
+        new_state = (dealer_hand, player_hand, dealer_cards, player_cards), key
+
+  
+        return new_state, _get_obsv(new_state), reward, done, {}
+        
+
+    @partial(jit, static_argnums=(0,))
+    def jit_reset(self, key):
+      #env_state = self._reset(key)
+
+      player_hand = jnp.zeros(21)
+      dealer_hand =  jnp.zeros(21)
+      player_hand, key = draw_hand(key, player_hand)
+      dealer_hand, key  = draw_hand(key, dealer_hand)
+      dealer_cards = 2
+      player_cards = 2
+
+      state = (dealer_hand, player_hand, dealer_cards, player_cards)
+  
+      key = random.split(key)[0]
+      
+      env_state = (state,key)
+
+      return env_state, _get_obsv(env_state)
+
+
+    def step(self, action):
+        assert self.action_space.contains(action)
+        new_state, observation,reward,done,info = self.jit_step(self.state, action)
+        self.state = new_state
+        self.renderer.render_step()
+        return obs_from_device(observation), float(reward), bool(done), info
+
+    def reset(self, seed = 0, return_info = False):
+        key =  random.PRNGKey(seed)
+        new_state, observation = self.jit_reset(key)
+        self.state = new_state
+
+
+        _, dealer_card_value, _ = obs_from_device(_get_obsv(self.state))
+        
+        suits = ["C", "D", "H", "S"]
+        
+        self.dealer_card_suit = self.np_random.choice(suits)
+
+        if dealer_card_value == 1:
+            self.dealer_card_value_str = "A"
+        elif dealer_card_value == 10:
+            self.dealer_card_value_str = self.np_random.choice(["J", "Q", "K"])
+        else:
+            self.dealer_card_value_str = str(int(dealer_card_value))
+
+        self.renderer.reset()
+        self.renderer.render_step()
+        if not return_info:
+            return obs_from_device(observation) #, {}
+        else:
+            return obs_from_device(observation) , {}
+
+
+    def render(self, mode="human"):
+        if self.render_mode is not None:
+            return self.renderer.get_renders()
+        else:
+            return self._render(mode)
+
+
+
+    def _render(self, mode):
+        assert mode in self.metadata["render_modes"]
+
+        try:
+            import pygame
+        except ImportError:
+            raise DependencyNotInstalled(
+                "pygame is not installed, run `pip install gym[toy_text]`"
+            )
+
+        player_sum, dealer_card_value, usable_ace = _get_obsv(self.state)
+        screen_width, screen_height = 600, 500
+        card_img_height = screen_height // 3
+        card_img_width = int(card_img_height * 142 / 197)
+        spacing = screen_height // 20
+
+        bg_color = (7, 99, 36)
+        white = (255, 255, 255)
+
+        if not hasattr(self, "screen"):
+            pygame.init()
+            if mode == "human":
+                pygame.display.init()
+                self.screen = pygame.display.set_mode((screen_width, screen_height))
+            else:
+                pygame.font.init()
+                self.screen = pygame.Surface((screen_width, screen_height))
+
+        if not hasattr(self, "clock"):
+            self.clock = pygame.time.Clock()
+
+        self.screen.fill(bg_color)
+
+        def get_image(path):
+            cwd = os.path.dirname(__file__)
+            image = pygame.image.load(os.path.join(cwd, path))
+            return image
+
+        def get_font(path, size):
+            cwd = os.path.dirname(__file__)
+            font = pygame.font.Font(os.path.join(cwd, path), size)
+            return font
+
+        small_font = get_font(
+            os.path.join("..","toy_text","font", "Minecraft.ttf"), screen_height // 15
+        )
+        dealer_text = small_font.render(
+            "Dealer: " + str(dealer_card_value), True, white
+        )
+        dealer_text_rect = self.screen.blit(dealer_text, (spacing, spacing))
+
+        def scale_card_img(card_img):
+            return pygame.transform.scale(card_img, (card_img_width, card_img_height))
+
+        dealer_card_img = scale_card_img(
+            get_image(
+                os.path.join("..","toy_text","img", f"{self.dealer_card_suit}{self.dealer_card_value_str}.png")
+            )
+        )
+        dealer_card_rect = self.screen.blit(
+            dealer_card_img,
+            (
+                screen_width // 2 - card_img_width - spacing // 2,
+                dealer_text_rect.bottom + spacing,
+            ),
+        )
+
+        hidden_card_img = scale_card_img(get_image(os.path.join("..","toy_text","img", "Card.png")))
+        self.screen.blit(
+            hidden_card_img,
+            (
+                screen_width // 2 + spacing // 2,
+                dealer_text_rect.bottom + spacing,
+            ),
+        )
+
+        player_text = small_font.render("Player", True, white)
+        player_text_rect = self.screen.blit(
+            player_text, (spacing, dealer_card_rect.bottom + 1.5 * spacing)
+        )
+
+        large_font = get_font(os.path.join("..","toy_text","font", "Minecraft.ttf"), screen_height // 6)
+        player_sum_text = large_font.render(str(player_sum), True, white)
+        player_sum_text_rect = self.screen.blit(
+            player_sum_text,
+            (
+                screen_width // 2 - player_sum_text.get_width() // 2,
+                player_text_rect.bottom + spacing,
+            ),
+        )
+
+        if usable_ace:
+            usable_ace_text = small_font.render("usable ace", True, white)
+            self.screen.blit(
+                usable_ace_text,
+                (
+                    screen_width // 2 - usable_ace_text.get_width() // 2,
+                    player_sum_text_rect.bottom + spacing // 2,
+                ),
+            )
+        if mode == "human":
+            pygame.event.pump()
+            pygame.display.update()
+            self.clock.tick(self.metadata["render_fps"])
+        else:
+            return np.transpose(
+                np.array(pygame.surfarray.pixels3d(self.screen)), axes=(1, 0, 2)
+            )
+
+    def close(self):
+        if hasattr(self, "screen"):
+            import pygame
+
+            pygame.display.quit()
+            pygame.quit()
+
+
+# Pixel art from Mariia Khmelnytska (https://www.123rf.com/photo_104453049_stock-vector-pixel-art-playing-cards-standart-deck-vector-set.html)
+
+# Jax structure inspired by https://medium.com/@ngoodger_7766/writing-an-rl-environment-in-jax-9f74338898ba
+
+
+if __name__ == "__main__":
+    
+    #simple rollout testcase
+
+    
+    #with jax.disable_jit(): #enable this for debugging
+    seed = int(time.time())
+    env = JaxBlackJackEnv(render_mode = 'human', natural = False, sutton_and_barto = True)
+    obs = env.reset(seed = seed)
+    print("START ROLLOUT:")
+    done = False
+    while True:
+        print(obs)
+        env.render()
+        print("STATE:")
+        print(env.state)
+        print("OBSERVATION")
+        print(obs)
+        action = int(input("action\n"))
+        obs, reward, done, info = env.step(action)
+        print("REWARD")
+        print(reward)
+        if done:
+            print("Epsiode over")
+            print("FINAL STATE")
+            print(env.state)
+            seed = int(time.time())
+            obs = env.reset(seed = seed)
+
+
+    
+    
+  

--- a/gym/envs/jax_toy_text/jax_blackjack.py
+++ b/gym/envs/jax_toy_text/jax_blackjack.py
@@ -1,5 +1,4 @@
 import os
-import time
 from functools import partial
 from typing import Optional
 
@@ -267,13 +266,21 @@ class JaxBlackJackEnv(gym.Env):
 
     def reset(
         self,
-        seed: Optional[int] = 0,
+        seed: Optional[int] = None,
         return_info: bool = False,
         options: Optional[dict] = None,
     ):
+
         super().reset(seed=seed)
 
-        key = random.PRNGKey(seed)
+        # we pick a random 64 bit signed integer to cover the entire input space
+        # of random.PRNGkey()
+        key = random.PRNGKey(
+            self.np_random.integers(
+                np.iinfo(np.int64).min, high=np.iinfo(np.int64).max + 1, dtype=np.int64
+            )
+        )
+
         new_state, observation = self.jit_reset(key)
         self.state = new_state
 
@@ -439,8 +446,10 @@ if __name__ == "__main__":
     # simple rollout testcase
 
     # with jax.disable_jit(): #enable this for debugging
-    seed = int(time.time())
+    # seed = int(time.time())
+    seed = 0
     env = JaxBlackJackEnv(render_mode="human", natural=False, sutton_and_barto=True)
+    # env = gym.make("Blackjack-v1")
     obs = env.reset(seed=seed)
     print("START ROLLOUT:")
     done = False
@@ -448,7 +457,7 @@ if __name__ == "__main__":
         print(obs)
         env.render()
         print("STATE:")
-        print(env.state)
+        # print(env.state)
         print("OBSERVATION")
         print(obs)
         action = int(input("action\n"))
@@ -458,6 +467,7 @@ if __name__ == "__main__":
         if done:
             print("Episode over")
             print("FINAL STATE")
-            print(env.state)
-            seed = int(time.time())
-            obs = env.reset(seed=seed)
+            # print(env.state)
+            # seed = int(time.time())
+
+            obs = env.reset()

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -359,6 +359,13 @@ def make(id: Literal[
     "Ant-v2"
 ], **kwargs) -> Env[np.ndarray, np.ndarray]: ...
 
+# Toy Text
+# ----------------------------------------
+
+
+@overload
+def make(id: Literal["Jax-BlackJack-v0"], **kwargs) -> Env[np.ndarray, Union[np.ndarray, int]]: ...
+
 
 @overload
 def make(id: str, **kwargs) -> Env: ...

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ ale-py~=0.7.5
 mujoco==2.2.0
 mujoco_py<2.2,>=2.1
 imageio>=2.14.1
+jax==0.3.13
+jaxlib==0.3.10

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,3 +7,6 @@ imageio>=2.14.1
 pygame==2.1.0
 mujoco_py<2.2,>=2.1
 pytest==7.0.1
+jax==0.3.13
+jaxlib==0.3.10
+

--- a/tests/envs/test_jax_blackjack.py
+++ b/tests/envs/test_jax_blackjack.py
@@ -1,0 +1,218 @@
+
+import jax.numpy as jnp
+from jax import random
+
+import gym
+from gym.envs.jax_toy_text.jax_blackjack import JaxBlackJackEnv
+
+
+
+def test_jax_blackjack_wrapped_rollout():
+    #testing basic operation of the reset and step function wrappers
+    env = gym.make("Jax-BlackJack-v0")
+    obs = env.reset(seed=0)
+
+    assert obs == (16,10,0)
+    action = 1
+    result = env.step(action)
+    assert result == ((25, 10, 0), -1.0, True, {})
+
+    obs = env.reset(seed=0)
+    assert obs == (16,10,0)
+    action = 0
+    result = env.step(action)
+    print(result)
+    assert result == ((16, 10, 0), -1.0, True, {})
+
+
+
+
+def test_jax_blackjack_sutton_barto():
+    
+    key =  random.PRNGKey(0)
+
+    player_hand = jnp.zeros(21)
+    dealer_hand = jnp.zeros(21)
+    player_hand = player_hand.at[0].set(1)
+    player_hand = player_hand.at[1].set(10)
+    dealer_hand = dealer_hand.at[0].set(1)
+    dealer_hand = dealer_hand.at[1].set(10)
+    dealer_cards = 2
+    player_cards = 2
+    double_natural_state = (dealer_hand, player_hand, dealer_cards, player_cards) , key
+
+
+    env = gym.make("Jax-BlackJack-v0") # for Jax-BlackJack-v0, sutton_and_barto flag is active, and natural flag is inactive (default env.make)
+    _ = env.reset()
+    
+    env.unwrapped.state = double_natural_state
+    action = 0
+    obs, reward, done, info = env.step(action)
+    assert done
+    assert reward == 0
+
+
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = True, natural = False) #  sutton_and_barto flag is active, and natural flag is inactive
+    _ = env.reset()
+    
+    env.unwrapped.state = double_natural_state
+    action = 0
+    obs, reward, done, info = env.step(action)
+    assert done
+    assert reward == 0
+
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = True, natural = True) # sutton_and_barto flag is active, and natural flag is active
+    _ = env.reset()
+    
+    env.unwrapped.state = double_natural_state
+    action = 0
+    obs, reward, done, info = env.step(action)
+    assert done
+    assert reward == 0
+
+    
+    
+    key =  random.PRNGKey(6) # we pick a seed and starting state that results in the dealer getting a non-natural 21 count (7,9,5)
+
+    player_hand = jnp.zeros(21)
+    dealer_hand = jnp.zeros(21)
+    player_hand = player_hand.at[0].set(1)
+    player_hand = player_hand.at[1].set(10)
+    dealer_hand = dealer_hand.at[0].set(7)
+    dealer_hand = dealer_hand.at[1].set(9)
+    dealer_cards = 2
+    player_cards = 2
+    player_natural_dealer_not_natural = (dealer_hand, player_hand, dealer_cards, player_cards) , key
+
+
+    env = gym.make("Jax-BlackJack-v0") # for Jax-BlackJack-v0, sutton_and_barto flag is active, and natural flag is inactive (default make)
+    _ = env.reset()
+    
+    env.unwrapped.state = player_natural_dealer_not_natural
+    action = 0
+    obs, reward, done, info = env.step(action)
+    print(env.state)
+    assert done
+    assert reward == 1
+
+
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = True, natural = False) #sutton_and_barto flag is active, and natural flag is inactive
+    _ = env.reset()
+    
+    env.unwrapped.state = player_natural_dealer_not_natural
+    action = 0
+    obs, reward, done, info = env.step(action)
+    print(env.state)
+    assert done
+    assert reward == 1
+
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = True, natural = True) # sutton_and_barto flag is active, and natural flag is active
+    _ = env.reset()
+    
+    env.unwrapped.state = player_natural_dealer_not_natural
+    action = 0
+    obs, reward, done, info = env.step(action)
+    print(env.state)
+    assert done
+    assert reward == 1
+    
+    
+    key =  random.PRNGKey(6) # we pick a seed and starting state that results in the player getting a non-natural 21 count (7,9,5)
+
+    player_hand = jnp.zeros(21)
+    dealer_hand = jnp.zeros(21)
+    player_hand = player_hand.at[0].set(7)
+    player_hand = player_hand.at[1].set(9)
+    dealer_hand = dealer_hand.at[0].set(1)
+    dealer_hand = dealer_hand.at[1].set(10)
+    dealer_cards = 2
+    player_cards = 2
+    player_natural_dealer_not_natural = (dealer_hand, player_hand, dealer_cards, player_cards) , key
+
+
+    env = gym.make("Jax-BlackJack-v0") # for Jax-BlackJack-v0, sutton_and_barto flag is active, and natural flag is inactive (default make)
+    _ = env.reset()
+    
+    env.unwrapped.state = player_natural_dealer_not_natural
+    action = 1
+    obs, reward, done, info = env.step(action)
+    action = 0
+    obs, reward, done, info = env.step(action)
+    print(env.state)
+    assert done
+    assert reward == 0
+
+
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = True, natural = False) #sutton_and_barto flag is active, and natural flag is inactive
+    _ = env.reset()
+    
+    env.unwrapped.state = player_natural_dealer_not_natural
+    action = 1
+    obs, reward, done, info = env.step(action)
+    action = 0
+    obs, reward, done, info = env.step(action)
+
+    print(env.state)
+    assert done
+    assert reward == 0
+
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = True, natural = True) # sutton_and_barto flag is active, and natural flag is active
+    _ = env.reset()
+    
+    env.unwrapped.state = player_natural_dealer_not_natural
+    action = 1
+    obs, reward, done, info = env.step(action)
+    action = 0
+    obs, reward, done, info = env.step(action)
+    
+    print(env.state)
+    assert done
+    assert reward == 0
+    
+
+def test_jax_blackjack_natural():
+    key =  random.PRNGKey(6) # we pick a seed and starting state that results in the dealer getting a non-natural 21 count (7,9,5)
+
+    player_hand = jnp.zeros(21)
+    dealer_hand = jnp.zeros(21)
+    player_hand = player_hand.at[0].set(1)
+    player_hand = player_hand.at[1].set(10)
+    dealer_hand = dealer_hand.at[0].set(1)
+    dealer_hand = dealer_hand.at[1].set(10)
+    dealer_cards = 2
+    player_cards = 2
+    player_natural_dealer_not_natural = (dealer_hand, player_hand, dealer_cards, player_cards) , key
+
+
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = False, natural=True) #= sutton_and_barto flag is inactive, and natural flag is active
+    _ = env.reset()
+    
+    env.unwrapped.state = player_natural_dealer_not_natural
+    action = 0
+    obs, reward, done, info = env.step(action)
+    print(env.state)
+    assert done
+    assert reward == 0
+
+    key =  random.PRNGKey(6) # we pick a seed and starting state that results in the player getting a sub-21 count (6,6,5)
+
+    player_hand = jnp.zeros(21)
+    dealer_hand = jnp.zeros(21)
+    player_hand = player_hand.at[0].set(1)
+    player_hand = player_hand.at[1].set(10)
+    dealer_hand = dealer_hand.at[0].set(6)
+    dealer_hand = dealer_hand.at[1].set(6)
+    dealer_cards = 2
+    player_cards = 2
+    player_natural_dealer_sub_21 = (dealer_hand, player_hand, dealer_cards, player_cards) , key
+
+
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = False, natural=True)
+    _ = env.reset()
+    
+    env.unwrapped.state = player_natural_dealer_sub_21
+    action = 0
+    obs, reward, done, info = env.step(action)
+    print(env.state)
+    assert done
+    assert reward == 1.5

--- a/tests/envs/test_jax_blackjack.py
+++ b/tests/envs/test_jax_blackjack.py
@@ -9,17 +9,16 @@ def test_jax_blackjack_wrapped_rollout():
     env = gym.make("Jax-BlackJack-v0")
     obs = env.reset(seed=0)
 
-    assert obs == (16, 10, 0)
+    assert obs == (19, 10, 0)
     action = 1
     result = env.step(action)
-    assert result == ((25, 10, 0), -1.0, True, {})
+    assert result == ((29, 10, 0), -1.0, True, {})
 
     obs = env.reset(seed=0)
-    assert obs == (16, 10, 0)
+    assert obs == (19, 10, 0)
     action = 0
     result = env.step(action)
-    print(result)
-    assert result == ((16, 10, 0), -1.0, True, {})
+    assert result == ((19, 10, 0), 1.0, True, {})
 
 
 def test_jax_blackjack_sutton_barto():

--- a/tests/envs/test_jax_blackjack.py
+++ b/tests/envs/test_jax_blackjack.py
@@ -1,35 +1,30 @@
-
 import jax.numpy as jnp
 from jax import random
 
 import gym
-from gym.envs.jax_toy_text.jax_blackjack import JaxBlackJackEnv
-
 
 
 def test_jax_blackjack_wrapped_rollout():
-    #testing basic operation of the reset and step function wrappers
+    # testing basic operation of the reset and step function wrappers
     env = gym.make("Jax-BlackJack-v0")
     obs = env.reset(seed=0)
 
-    assert obs == (16,10,0)
+    assert obs == (16, 10, 0)
     action = 1
     result = env.step(action)
     assert result == ((25, 10, 0), -1.0, True, {})
 
     obs = env.reset(seed=0)
-    assert obs == (16,10,0)
+    assert obs == (16, 10, 0)
     action = 0
     result = env.step(action)
     print(result)
     assert result == ((16, 10, 0), -1.0, True, {})
 
 
-
-
 def test_jax_blackjack_sutton_barto():
-    
-    key =  random.PRNGKey(0)
+
+    key = random.PRNGKey(0)
 
     player_hand = jnp.zeros(21)
     dealer_hand = jnp.zeros(21)
@@ -39,40 +34,41 @@ def test_jax_blackjack_sutton_barto():
     dealer_hand = dealer_hand.at[1].set(10)
     dealer_cards = 2
     player_cards = 2
-    double_natural_state = (dealer_hand, player_hand, dealer_cards, player_cards) , key
+    double_natural_state = (dealer_hand, player_hand, dealer_cards, player_cards), key
 
-
-    env = gym.make("Jax-BlackJack-v0") # for Jax-BlackJack-v0, sutton_and_barto flag is active, and natural flag is inactive (default env.make)
+    env = gym.make("Jax-BlackJack-v0")
+    # for Jax-BlackJack-v0, sutton_and_barto flag is active, and natural flag is inactive (default env.make)
     _ = env.reset()
-    
+
     env.unwrapped.state = double_natural_state
     action = 0
     obs, reward, done, info = env.step(action)
     assert done
     assert reward == 0
 
-
-    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = True, natural = False) #  sutton_and_barto flag is active, and natural flag is inactive
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto=True, natural=False)
+    #  sutton_and_barto flag is active, and natural flag is inactive
     _ = env.reset()
-    
+
     env.unwrapped.state = double_natural_state
     action = 0
     obs, reward, done, info = env.step(action)
     assert done
     assert reward == 0
 
-    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = True, natural = True) # sutton_and_barto flag is active, and natural flag is active
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto=True, natural=True)
+    # sutton_and_barto flag is active, and natural flag is active
     _ = env.reset()
-    
+
     env.unwrapped.state = double_natural_state
     action = 0
     obs, reward, done, info = env.step(action)
     assert done
     assert reward == 0
 
-    
-    
-    key =  random.PRNGKey(6) # we pick a seed and starting state that results in the dealer getting a non-natural 21 count (7,9,5)
+    key = random.PRNGKey(
+        6
+    )  # we pick a seed and starting state that results in the dealer getting a non-natural 21 count (7,9,5)
 
     player_hand = jnp.zeros(21)
     dealer_hand = jnp.zeros(21)
@@ -82,12 +78,17 @@ def test_jax_blackjack_sutton_barto():
     dealer_hand = dealer_hand.at[1].set(9)
     dealer_cards = 2
     player_cards = 2
-    player_natural_dealer_not_natural = (dealer_hand, player_hand, dealer_cards, player_cards) , key
+    player_natural_dealer_not_natural = (
+        dealer_hand,
+        player_hand,
+        dealer_cards,
+        player_cards,
+    ), key
 
-
-    env = gym.make("Jax-BlackJack-v0") # for Jax-BlackJack-v0, sutton_and_barto flag is active, and natural flag is inactive (default make)
+    env = gym.make("Jax-BlackJack-v0")
+    # for Jax-BlackJack-v0, sutton_and_barto flag is active, and natural flag is inactive (default make)
     _ = env.reset()
-    
+
     env.unwrapped.state = player_natural_dealer_not_natural
     action = 0
     obs, reward, done, info = env.step(action)
@@ -95,10 +96,10 @@ def test_jax_blackjack_sutton_barto():
     assert done
     assert reward == 1
 
-
-    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = True, natural = False) #sutton_and_barto flag is active, and natural flag is inactive
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto=True, natural=False)
+    # sutton_and_barto flag is active, and natural flag is inactive
     _ = env.reset()
-    
+
     env.unwrapped.state = player_natural_dealer_not_natural
     action = 0
     obs, reward, done, info = env.step(action)
@@ -106,18 +107,20 @@ def test_jax_blackjack_sutton_barto():
     assert done
     assert reward == 1
 
-    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = True, natural = True) # sutton_and_barto flag is active, and natural flag is active
+    env = gym.make(
+        "Jax-BlackJack-v0", sutton_and_barto=True, natural=True
+    )  # sutton_and_barto flag is active, and natural flag is active
     _ = env.reset()
-    
+
     env.unwrapped.state = player_natural_dealer_not_natural
     action = 0
     obs, reward, done, info = env.step(action)
     print(env.state)
     assert done
     assert reward == 1
-    
-    
-    key =  random.PRNGKey(6) # we pick a seed and starting state that results in the player getting a non-natural 21 count (7,9,5)
+
+    key = random.PRNGKey(6)
+    # we pick a seed and starting state that results in the player getting a non-natural 21 count (7,9,5)
 
     player_hand = jnp.zeros(21)
     dealer_hand = jnp.zeros(21)
@@ -127,12 +130,17 @@ def test_jax_blackjack_sutton_barto():
     dealer_hand = dealer_hand.at[1].set(10)
     dealer_cards = 2
     player_cards = 2
-    player_natural_dealer_not_natural = (dealer_hand, player_hand, dealer_cards, player_cards) , key
+    player_natural_dealer_not_natural = (
+        dealer_hand,
+        player_hand,
+        dealer_cards,
+        player_cards,
+    ), key
 
-
-    env = gym.make("Jax-BlackJack-v0") # for Jax-BlackJack-v0, sutton_and_barto flag is active, and natural flag is inactive (default make)
+    env = gym.make("Jax-BlackJack-v0")
+    # for Jax-BlackJack-v0, sutton_and_barto flag is active, and natural flag is inactive (default make)
     _ = env.reset()
-    
+
     env.unwrapped.state = player_natural_dealer_not_natural
     action = 1
     obs, reward, done, info = env.step(action)
@@ -142,10 +150,10 @@ def test_jax_blackjack_sutton_barto():
     assert done
     assert reward == 0
 
-
-    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = True, natural = False) #sutton_and_barto flag is active, and natural flag is inactive
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto=True, natural=False)
+    # sutton_and_barto flag is active, and natural flag is inactive
     _ = env.reset()
-    
+
     env.unwrapped.state = player_natural_dealer_not_natural
     action = 1
     obs, reward, done, info = env.step(action)
@@ -156,22 +164,24 @@ def test_jax_blackjack_sutton_barto():
     assert done
     assert reward == 0
 
-    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = True, natural = True) # sutton_and_barto flag is active, and natural flag is active
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto=True, natural=True)
+    # sutton_and_barto flag is active, and natural flag is active
     _ = env.reset()
-    
+
     env.unwrapped.state = player_natural_dealer_not_natural
     action = 1
     obs, reward, done, info = env.step(action)
     action = 0
     obs, reward, done, info = env.step(action)
-    
+
     print(env.state)
     assert done
     assert reward == 0
-    
+
 
 def test_jax_blackjack_natural():
-    key =  random.PRNGKey(6) # we pick a seed and starting state that results in the dealer getting a non-natural 21 count (7,9,5)
+    key = random.PRNGKey(6)
+    # we pick a seed and starting state that results in the dealer getting a non-natural 21 count (7,9,5)
 
     player_hand = jnp.zeros(21)
     dealer_hand = jnp.zeros(21)
@@ -181,12 +191,17 @@ def test_jax_blackjack_natural():
     dealer_hand = dealer_hand.at[1].set(10)
     dealer_cards = 2
     player_cards = 2
-    player_natural_dealer_not_natural = (dealer_hand, player_hand, dealer_cards, player_cards) , key
+    player_natural_dealer_not_natural = (
+        dealer_hand,
+        player_hand,
+        dealer_cards,
+        player_cards,
+    ), key
 
-
-    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = False, natural=True) #= sutton_and_barto flag is inactive, and natural flag is active
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto=False, natural=True)
+    # = sutton_and_barto flag is inactive, and natural flag is active
     _ = env.reset()
-    
+
     env.unwrapped.state = player_natural_dealer_not_natural
     action = 0
     obs, reward, done, info = env.step(action)
@@ -194,7 +209,8 @@ def test_jax_blackjack_natural():
     assert done
     assert reward == 0
 
-    key =  random.PRNGKey(6) # we pick a seed and starting state that results in the player getting a sub-21 count (6,6,5)
+    key = random.PRNGKey(6)
+    # we pick a seed and starting state that results in the player getting a sub-21 count (6,6,5)
 
     player_hand = jnp.zeros(21)
     dealer_hand = jnp.zeros(21)
@@ -204,12 +220,16 @@ def test_jax_blackjack_natural():
     dealer_hand = dealer_hand.at[1].set(6)
     dealer_cards = 2
     player_cards = 2
-    player_natural_dealer_sub_21 = (dealer_hand, player_hand, dealer_cards, player_cards) , key
+    player_natural_dealer_sub_21 = (
+        dealer_hand,
+        player_hand,
+        dealer_cards,
+        player_cards,
+    ), key
 
-
-    env = gym.make("Jax-BlackJack-v0", sutton_and_barto = False, natural=True)
+    env = gym.make("Jax-BlackJack-v0", sutton_and_barto=False, natural=True)
     _ = env.reset()
-    
+
     env.unwrapped.state = player_natural_dealer_sub_21
     action = 0
     obs, reward, done, info = env.step(action)


### PR DESCRIPTION
# Description

This includes a blackjack environment which relies on just in time compilable functions for the step and reset logic, which can also offer the standard gym API. The plan is that this is the first of a series of Jax implementations for all of the toytext environments. This was heavily inspired by https://medium.com/@ngoodger_7766/writing-an-rl-environment-in-jax-9f74338898ba but for now the autoreset capabilities are removed. This may need to be edited for compliance with whatever finalized api we decide on for jax environments. I temporarilly added a main function to jax_blackjack.py so you can test out the environment for yourself easily by calling jax_blackjack.py

## Notes For Reviewers
Here is a non-exhaustive list of areas which I think need reviewer attention:


### `self.state`
Right now all non-rendering related state is contained in `self.state` so for all non-rendering purposes, you can set state by assigning `self.state` to a new state. `self.step` and `self.reset` use `self.state` to give inputs to and to record the output of the side-effect free `self.jit_reset` and `self.jit_step` functions.  

### Pseudorandom

~~Currently, this uses Jax pseudorandom for all non-rendering related side-effects, there is a warning because seed defaults to zero instead of `None`. Also, the render state initialization to decide on dealer top card suit/face card value used in the reset function uses the standard  np_random. Curious if this seems acceptable, or what would be best here.~~

Should behave correctly now.

### Profling
No profiling yet to confirm that this is faster than normal blackjack after JITing. Profiling report will go here, probably will require jit_autoreset to make a fair comparison. 

### Autoreset

We will probably want to implement a JIT autoreset so we can use this with a compiled for loop for collecting rollouts, like is used here: https://medium.com/@ngoodger_7766/writing-an-rl-environment-in-jax-9f74338898ba
If we do that, the last obs will needs to be returned somehow.



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

