### PR TITLE
Remove sys.exit(0) from mujoco renderer when closing environment 

### DIFF
--- a/gym/envs/mujoco/mujoco_rendering.py
+++ b/gym/envs/mujoco/mujoco_rendering.py
@@ -1,6 +1,5 @@
 import collections
 import os
-import sys
 import time
 from threading import Lock
 
@@ -374,8 +373,8 @@ class Viewer(RenderContext):
         if key == glfw.KEY_ESCAPE:
             print("Pressed ESC")
             print("Quitting.")
+            glfw.destroy_window(self.window)
             glfw.terminate()
-            sys.exit(0)
 
     def _cursor_pos_callback(self, window, xpos, ypos):
         if not (self._button_left_pressed or self._button_right_pressed):
@@ -495,8 +494,8 @@ class Viewer(RenderContext):
             if self.window is None:
                 return
             elif glfw.window_should_close(self.window):
+                glfw.destroy_window(self.window)
                 glfw.terminate()
-                sys.exit(0)
             self.viewport.width, self.viewport.height = glfw.get_framebuffer_size(
                 self.window
             )
@@ -556,5 +555,5 @@ class Viewer(RenderContext):
         self._markers[:] = []
 
     def close(self):
+        glfw.destroy_window(self.window)
         glfw.terminate()
-        sys.exit(0)

--- a/gym/envs/toy_text/taxi.py
+++ b/gym/envs/toy_text/taxi.py
@@ -466,5 +466,6 @@ class TaxiEnv(Env):
             pygame.display.quit()
             pygame.quit()
 
+
 # Taxi rider from https://franuka.itch.io/rpg-asset-pack
 # All other assets by Mel Tillery http://www.cyaneus.com/


### PR DESCRIPTION
destroy window mujoco rendering

remove sys.exit

# Description
Remove sys.exit(0) from mujoco renderer when closing environment.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
