### PR TITLE
Fix the initialization of render mode set

### DIFF
--- a/gym/utils/renderer.py
+++ b/gym/utils/renderer.py
@@ -54,9 +54,9 @@ class Renderer:
 
         This method should be usually called inside environment's step and reset method.
         """
-        if self.mode is not None and self.mode not in SINGLE_RENDER:
+        if self.mode is not None and self.mode not in self.single_render:
             render_return = self.render(self.mode)
-            if self.mode not in NO_RETURNS_RENDER:
+            if self.mode not in self.no_returns_render:
                 self.render_list.append(render_return)
 
     def get_renders(self) -> Optional[List]:
@@ -64,9 +64,9 @@ class Renderer:
 
         This method should be usually called in the environment's render method to retrieve the frames collected till this time step.
         """
-        if self.mode in SINGLE_RENDER:
+        if self.mode in self.single_render:
             return self.render(self.mode)
-        elif self.mode is not None and self.mode not in NO_RETURNS_RENDER:
+        elif self.mode is not None and self.mode not in self.no_returns_render:
             renders = self.render_list
             self.render_list = []
             return renders


### PR DESCRIPTION
# Description

Currently, self-defined render mode along with `no_returns_render` and `single_render` cannot affect the `render_step` and `get_renders` methods.

This PR fixes this.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->