### PR TITLE
Properly check whether AttributeError is caused by render_mode

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -620,7 +620,7 @@ def make(
     try:
         env = env_creator(**_kwargs)
     except TypeError as e:
-        if str(e).find("got an unexpected keyword argument 'render_mode'"):
+        if str(e).find("got an unexpected keyword argument 'render_mode'") > 0:
             raise AttributeError(
                 f"You passed render_mode='human' although {id} doesn't implement human-rendering natively. "
                 "Gym tried to apply the HumanRendering wrapper but it looks like your environment is using the old "

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -620,8 +620,8 @@ def make(
     try:
         env = env_creator(**_kwargs)
     except TypeError as e:
-        if str(e).find("got an unexpected keyword argument 'render_mode'") > 0:
-            raise AttributeError(
+        if str(e).find("got an unexpected keyword argument 'render_mode'") >= 0:
+            raise error.Error(
                 f"You passed render_mode='human' although {id} doesn't implement human-rendering natively. "
                 "Gym tried to apply the HumanRendering wrapper but it looks like your environment is using the old "
                 "rendering API, which is not supported by the HumanRendering wrapper."

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -620,7 +620,10 @@ def make(
     try:
         env = env_creator(**_kwargs)
     except TypeError as e:
-        if str(e).find("got an unexpected keyword argument 'render_mode'") >= 0:
+        if (
+            str(e).find("got an unexpected keyword argument 'render_mode'") >= 0
+            and apply_human_rendering
+        ):
             raise error.Error(
                 f"You passed render_mode='human' although {id} doesn't implement human-rendering natively. "
                 "Gym tried to apply the HumanRendering wrapper but it looks like your environment is using the old "

--- a/tests/envs/test_make.py
+++ b/tests/envs/test_make.py
@@ -180,17 +180,23 @@ def test_make_render_mode():
     assert env.render_mode == "human"
     env.close()
 
-    # Make sure that `HumanRendering` is applied here
-    env = gym.make(
-        "test/NoHuman-v0", render_mode="human", disable_env_checker=True
-    )  # This environment doesn't use native rendering
-    assert has_wrapper(env, HumanRendering)
-    assert env.render_mode == "human"
-    env.close()
+    with pytest.warns(
+        Warning,
+        match=re.escape(
+            "You are trying to use 'human' rendering for an environment that doesn't natively support it. The HumanRendering wrapper is being applied to your environment."
+        ),
+    ):
+        # Make sure that `HumanRendering` is applied here
+        env = gym.make(
+            "test/NoHuman-v0", render_mode="human", disable_env_checker=True
+        )  # This environment doesn't use native rendering
+        assert has_wrapper(env, HumanRendering)
+        assert env.render_mode == "human"
+        env.close()
 
     # Make sure that an error is thrown a user tries to use the wrapper on an environment with old API
     with pytest.raises(
-        AttributeError,
+        gym.error.Error,
         match=re.escape(
             "You passed render_mode='human' although test/NoHumanOldAPI-v0 doesn't implement human-rendering natively."
         ),
@@ -214,6 +220,17 @@ def test_make_render_mode():
         ),
     ):
         gym.make("test/NoHuman-v0", render_mode="ascii", disable_env_checker=True)
+
+    # This test ensures that the additional exception "Gym tried to apply the HumanRendering wrapper but it looks like
+    # your environment is using the old rendering API" is *not* triggered by a TypeError that originate from
+    # a keyword that is not `render_mode`
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "CarRacing.__init__() got an unexpected keyword argument 'render'"
+        ),
+    ):
+        gym.make("CarRacing-v1", render="human")
 
 
 def test_make_kwargs():

--- a/tests/envs/test_make.py
+++ b/tests/envs/test_make.py
@@ -226,9 +226,7 @@ def test_make_render_mode():
     # a keyword that is not `render_mode`
     with pytest.raises(
         TypeError,
-        match=re.escape(
-            "CarRacing.__init__() got an unexpected keyword argument 'render'"
-        ),
+        match=re.escape("got an unexpected keyword argument 'render'"),
     ):
         gym.make("CarRacing-v1", render="human")
 

--- a/tests/envs/test_make.py
+++ b/tests/envs/test_make.py
@@ -194,7 +194,14 @@ def test_make_render_mode():
         assert env.render_mode == "human"
         env.close()
 
-    # Make sure that an error is thrown a user tries to use the wrapper on an environment with old API
+    with pytest.raises(
+        TypeError, match=re.escape("got an unexpected keyword argument 'render_mode'")
+    ):
+        gym.make(
+            "test/NoHumanOldAPI-v0", render_mode="rgb_array", disable_env_checker=True
+        )
+
+    # Make sure that an additional error is thrown a user tries to use the wrapper on an environment with old API
     with pytest.raises(
         gym.error.Error,
         match=re.escape(


### PR DESCRIPTION
@pseudo-rnd-thoughts 

Atm the if statement will be triggered by any attribute error, regardless of which kwarg caused it.