### PR TITLE
improve docker image size

### DIFF
--- a/py.Dockerfile
+++ b/py.Dockerfile
@@ -1,19 +1,32 @@
 # A Dockerfile that sets up a full Gym install with test dependencies
 ARG PYTHON_VERSION
 FROM python:$PYTHON_VERSION
-RUN apt-get -y update && apt-get install -y unzip libglu1-mesa-dev libgl1-mesa-dev libosmesa6-dev xvfb patchelf ffmpeg cmake swig
 
-# Download mujoco
-RUN mkdir /root/.mujoco && \
-    cd /root/.mujoco  && \
-    wget https://github.com/deepmind/mujoco/releases/download/2.1.0/mujoco210-linux-x86_64.tar.gz &&\
-    tar -xf mujoco210-linux-x86_64.tar.gz
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/root/.mujoco/mujoco210/bin
+RUN apt-get -y update \
+    && apt-get install --no-install-recommends -y \
+    unzip \
+    libglu1-mesa-dev \
+    libgl1-mesa-dev \
+    libosmesa6-dev \
+    xvfb \
+    patchelf \
+    ffmpeg cmake \
+    swig \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    # Download mujoco
+    && mkdir /root/.mujoco \
+    && cd /root/.mujoco \
+    && wget -qO- 'https://github.com/deepmind/mujoco/releases/download/2.1.0/mujoco210-linux-x86_64.tar.gz' | tar -xzvf -
+
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/root/.mujoco/mujoco210/bin"
 
 COPY . /usr/local/gym/
 WORKDIR /usr/local/gym/
 
-RUN if [ python:$PYTHON_VERSION = "python:3.6.15" ] ; then pip install .[box2d,classic_control,toy_text,other] pytest==7.0.1 ; else pip install .[testing] ; fi
+RUN if [ "python:${PYTHON_VERSION}" = "python:3.6.15" ] ; then pip install .[box2d,classic_control,toy_text,other] pytest=="7.0.1" --no-cache-dir; else pip install .[testing] --no-cache-dir; fi
 
 ENTRYPOINT ["/usr/local/gym/bin/docker_entrypoint"]


### PR DESCRIPTION
# Description

Improves the docker image size. Summary of various changes

* Added `--no-install-recommends`, newlined install items and removed the apt list and cache as per [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run) 
* Merged the `mujoco` RUN directive with the `apt` RUN directive to reduce layers
* Added `--no-cache-dir` to the `pip` installs since the pip cache isn't needed for a docker image
* `mujoco` is now downloaded and piped to tar to location, previously it the `mujoco210-linux-x86_64.tar.gz` was left in the docker image when it wasn't needed
* Added `SHELL ["/bin/bash", "-o", "pipefail", "-c"]` for safety
* Added quotes around various strings to ensure splitting doesn't occur

Followed rules from [hadolint](https://github.com/hadolint/hadolint) and [shellcheck](https://github.com/koalaman/shellcheck)


Running `docker build -t gym-orig --build-arg=PYTHON_VERSION=3 -f py.Dockerfile . --no-cache` with the original `Dockerfile`, the size (compressed) came out to 1.61GB and the same command with the `gym-new` tag it comes down to `1.45GB` compressed

```bash
$ docker images | grep gym
gym-new                                                                      latest          ab7f651f39f3   17 seconds ago   1.45GB
gym-orig                                                                     latest          aa7c83ec05ea   24 seconds ago   1.61GB
```

Similarly with the same build comparison but for x86 (since I'm on an M1 MacBook), i.e. ```DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -t gym-new --build-arg=PYTHON_VERSION=3 -f py.Dockerfile . --no-cache;```

```bash
$ docker images | grep gym
gym-orig                                                                     latest          9f513111ab2e   12 seconds ago   2GB
gym-new                                                                      latest          241544f82ab2   30 seconds ago   1.75GB
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
