### PR TITLE
Bugfix: Nan and Inf checks fail in passive_env_checker

### DIFF
--- a/gym/utils/passive_env_checker.py
+++ b/gym/utils/passive_env_checker.py
@@ -125,10 +125,6 @@ def _check_obs(obs, observation_space: spaces.Space, method_name: str):
         assert isinstance(
             obs, np.ndarray
         ), f"The observation returned by `{method_name}()` method must be a numpy array, actually {type(obs)}"
-        if np.any(np.isnan(obs)):
-            logger.warn("Encountered NaN value in observations.")
-        if np.any(np.isinf(obs)):
-            logger.warn("Encountered inf value in observations.")
     elif isinstance(observation_space, spaces.Tuple):
         assert isinstance(
             obs, tuple

--- a/gym/utils/passive_env_checker.py
+++ b/gym/utils/passive_env_checker.py
@@ -125,6 +125,10 @@ def _check_obs(obs, observation_space: spaces.Space, method_name: str):
         assert isinstance(
             obs, np.ndarray
         ), f"The observation returned by `{method_name}()` method must be a numpy array, actually {type(obs)}"
+        if np.any(np.isnan(obs)):
+            logger.warn("Encountered NaN value in observations.")
+        if np.any(np.isinf(obs)):
+            logger.warn("Encountered inf value in observations.")
     elif isinstance(observation_space, spaces.Tuple):
         assert isinstance(
             obs, tuple
@@ -281,10 +285,6 @@ def passive_env_step_check(env, action):
         )
 
     _check_obs(obs, env.observation_space, "step")
-    if np.any(np.isnan(obs)):
-        logger.warn("Encountered NaN value in observations.")
-    if np.any(np.isinf(obs)):
-        logger.warn("Encountered inf value in observations.")
 
     assert isinstance(
         reward, (float, int, np.floating, np.integer)

--- a/tests/utils/test_env_checker.py
+++ b/tests/utils/test_env_checker.py
@@ -39,3 +39,82 @@ def test_check_env_dict_action():
             str(errorinfo.value)
             == "The `step()` method must return four values: obs, reward, done, info"
         )
+
+
+def test_check_env_dict_observation():
+    """Tests passive checking for observations that are dictionaries.
+
+    The test environment returns observations that are dictionaries of different
+    types. Then three tests are performed: The first test checks if all passive
+    checks are passing. The second inserts a nan value into the observation
+    dictionary and tests for a failing passive check. Then the same test is
+    repeated by inserting an inf value into the observation dictionary.
+    """
+
+    class TestDictEnv(gym.Env):
+        def __init__(self, test_value=None):
+            self.actions = [0]
+            self.action_space = Discrete(len(self.actions))
+
+            self.observation_space = Dict(
+                {
+                    "img": Box(low=0, high=255, shape=(8, 8, 3), dtype="uint8"),
+                    "pos": Box(low=0.0, high=1.0, shape=(2,), dtype="float32"),
+                    "idx": Discrete(4),
+                }
+            )
+            self.reward_range = (0, 1)
+            self._test_value = test_value
+
+        def _get_observation(self):
+            return {
+                "img": np.zeros((8, 8, 3), dtype=np.uint8),
+                "pos": np.zeros(2, dtype=np.float32),
+                "idx": 0,
+            }
+
+        def reset(self, seed=None, return_info=None, options=None):
+            return self._get_observation()
+
+        def step(self, action):
+            observation = self._get_observation()
+            if self._test_value is not None:
+                observation["pos"][0] = self._test_value
+            return observation, 0.0, False, False, {}
+
+    from gym.wrappers.env_checker import PassiveEnvChecker
+
+    env = TestDictEnv()
+    env = PassiveEnvChecker(env)
+
+    obs = env.reset()
+    assert isinstance(obs, dict)
+    assert isinstance(obs["img"], np.ndarray)
+    assert isinstance(obs["pos"], np.ndarray)
+    assert isinstance(obs["idx"], int)
+
+    obs, rew, done, truncated, info = env.step(0)
+    assert isinstance(obs, dict)
+    assert isinstance(obs["img"], np.ndarray)
+    assert isinstance(obs["pos"], np.ndarray)
+    assert isinstance(obs["idx"], int)
+    assert isinstance(rew, float)
+    assert isinstance(done, bool)
+    assert isinstance(truncated, bool)
+    assert isinstance(info, dict)
+
+    env = TestDictEnv(test_value=np.nan)
+    env = PassiveEnvChecker(env)
+    try:
+        obs, rew, done, truncated, info = env.step(0)
+        pytest.fail()
+    except AssertionError:
+        pass
+
+    env = TestDictEnv(test_value=np.inf)
+    env = PassiveEnvChecker(env)
+    try:
+        obs, rew, done, truncated, info = env.step(0)
+        pytest.fail()
+    except AssertionError:
+        pass


### PR DESCRIPTION
# Description

In gym/utils/passive_env_checker.py:284 the observation is checked for nan or inf values with numpy. If the observation is a dictionary or tuple, this check will fail causing an error (because np.isnan cannot be called on a dictionary or tuple).

Fixes #2956

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
