### PR TITLE
docs: Fix a few typos

### DIFF
--- a/gym/envs/mujoco/humanoidstandup_v4.py
+++ b/gym/envs/mujoco/humanoidstandup_v4.py
@@ -13,7 +13,7 @@ class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
     in ["Synthesis and stabilization of complex behaviors through online trajectory optimization"](https://ieeexplore.ieee.org/document/6386025).
     The 3D bipedal robot is designed to simulate a human. It has a torso (abdomen) with a
     pair of legs and arms. The legs each consist of two links, and so the arms (representing the
-    knees and elbows respectively). The environment starts with the humanoid layiing on the ground,
+    knees and elbows respectively). The environment starts with the humanoid laying on the ground,
     and then the goal of the environment is to make the humanoid standup and then keep it standing
     by applying torques on the various hinges.
 

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -119,7 +119,7 @@ class BaseMujocoEnv(gym.Env):
 
     def _step_mujoco_simulation(self, ctrl, n_frames):
         """
-        Step over the MuJoCo simulaion.
+        Step over the MuJoCo simulation.
         """
         raise NotImplementedError
 

--- a/gym/wrappers/vector_list_info.py
+++ b/gym/wrappers/vector_list_info.py
@@ -7,7 +7,7 @@ from gym.utils.step_api_compatibility import step_api_compatibility
 
 
 class VectorListInfo(gym.Wrapper):
-    """Converts infos of vectorized envinroments from dict to List[dict].
+    """Converts infos of vectorized environments from dict to List[dict].
 
     This wrapper converts the info format of a
     vector environment from a dictionary to a list of dictionaries.


### PR DESCRIPTION
There are small typos in:
- gym/envs/mujoco/humanoidstandup_v4.py
- gym/envs/mujoco/mujoco_env.py
- gym/wrappers/vector_list_info.py

Fixes:
- Should read `simulation` rather than `simulaion`.
- Should read `laying` rather than `layiing`.
- Should read `environments` rather than `envinroments`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md