### PR TITLE
Bug fix: Revert an incorrect edition on wrapper.FrameStack

### DIFF
--- a/gym/wrappers/frame_stack.py
+++ b/gym/wrappers/frame_stack.py
@@ -178,7 +178,7 @@ class FrameStack(gym.ObservationWrapper):
         )
         self.frames.append(observation)
         return step_api_compatibility(
-            (self.observation(), reward, terminated, truncated, info), self.new_step_api
+            (self.observation(None), reward, terminated, truncated, info), self.new_step_api
         )
 
     def reset(self, **kwargs):


### PR DESCRIPTION
# Description

https://github.com/openai/gym/pull/2752 incorrectly removes the obligated positional parameter of `self.observation()`, which makes the wrapper class no longer work. This bug fix corrects it.

@arjun-kg  @pseudo-rnd-thoughts  @jkterry1 

## Type of change

Please delete options that are not relevant.

- [ +] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
