### PR TITLE
Raise `AttributeError` in `PixelObservationWrapper` if `render_mode` is None

### DIFF
--- a/gym/wrappers/pixel_observation.py
+++ b/gym/wrappers/pixel_observation.py
@@ -24,13 +24,13 @@ class PixelObservationWrapper(gym.ObservationWrapper):
 
     Example:
         >>> import gym
-        >>> env = PixelObservationWrapper(gym.make('CarRacing-v1'))
+        >>> env = PixelObservationWrapper(gym.make('CarRacing-v1', render_mode="single_rgb_array"))
         >>> obs = env.reset()
         >>> obs.keys()
         odict_keys(['pixels'])
         >>> obs['pixels'].shape
         (400, 600, 3)
-        >>> env = PixelObservationWrapper(gym.make('CarRacing-v1'), pixels_only=False)
+        >>> env = PixelObservationWrapper(gym.make('CarRacing-v1', render_mode="single_rgb_array"), pixels_only=False)
         >>> obs = env.reset()
         >>> obs.keys()
         odict_keys(['state', 'pixels'])
@@ -38,7 +38,7 @@ class PixelObservationWrapper(gym.ObservationWrapper):
         (96, 96, 3)
         >>> obs['pixels'].shape
         (400, 600, 3)
-        >>> env = PixelObservationWrapper(gym.make('CarRacing-v1'), pixel_keys=('obs',))
+        >>> env = PixelObservationWrapper(gym.make('CarRacing-v1', render_mode="single_rgb_array"), pixel_keys=('obs',))
         >>> obs = env.reset()
         >>> obs.keys()
         odict_keys(['obs'])
@@ -78,7 +78,11 @@ class PixelObservationWrapper(gym.ObservationWrapper):
             TypeError: When an unexpected pixel type is used
         """
         super().__init__(env, new_step_api=True)
-
+        if not env.render_mode:
+            raise AttributeError(
+                "env.render_mode must be specified to use PixelObservationWrapper:"
+                "`gym.make(env_name, render_mode='single_rgb_array')`."
+            )
         # Avoid side-effects that occur when render_kwargs is manipulated
         render_kwargs = copy.deepcopy(render_kwargs)
 


### PR DESCRIPTION
# Description

Rendering is broken for simple envs (e.g. Pendulum-v1) (fixes #2972)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

