### PR TITLE
Update frame_stack.py

### DIFF
--- a/gym/wrappers/frame_stack.py
+++ b/gym/wrappers/frame_stack.py
@@ -178,7 +178,7 @@ class FrameStack(gym.ObservationWrapper):
         )
         self.frames.append(observation)
         return step_api_compatibility(
-            (self.observation(), reward, terminated, truncated, info), self.new_step_api
+            (self.observation(None), reward, terminated, truncated, info), self.new_step_api
         )
 
     def reset(self, **kwargs):


### PR DESCRIPTION


# Description

error being - "TypeError: observation() missing 1 required positional argument: 'observation'"

missing argument for self.observation(). Previously, it was self.observation(None) and in the last commits.

Fixes # (issue)
changed it back to self.observation(None)