### PR TITLE
Fix typo

### DIFF
--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -45,7 +45,7 @@ class Dict(Space[TypingDict[str, Space]], Mapping):
         ... )
 
     It can be convenient to use :class:`Dict` spaces if you want to make complex observations or actions more human-readable.
-    Usually, it will be not be possible to use elements of this space directly in learning code. However, you can easily
+    Usually, it will not be possible to use elements of this space directly in learning code. However, you can easily
     convert `Dict` observations to flat arrays by using a :class:`gym.wrappers.FlattenObservation` wrapper. Similar wrappers can be
     implemented to deal with :class:`Dict` actions.
     """


### PR DESCRIPTION
# Description

This PR fixes a typo in `gym/spaces/dict.py`.
