### PR TITLE
backward compatibility when metadata doesn't include render mode

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -627,6 +627,7 @@ def make(
             assert isinstance(
                 env_creator.metadata, dict
             ), f"Expect the environment creator ({env_creator}) metadata to be dict, actual type: {type(env_creator.metadata)}"
+
             if "render_modes" in env_creator.metadata:
                 render_modes = env_creator.metadata["render_modes"]
 
@@ -651,12 +652,6 @@ def make(
                 # else:
                 #   we don't raise an error as the environment may have forgotten to add the "render_modes"
                 #   if the render mode is not valid for an environment, the environment should raise an error
-            else:
-                logger.warn(
-                    "Applying render_mode to environment without metadata `render_modes`."
-                )
-        else:
-            logger.warn("Applying render_mode to environment with metadata attribute.")
 
     try:
         env = env_creator(**_kwargs)

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -624,45 +624,39 @@ def make(
     # If we have access to metadata we check that "render_mode" is valid and see if the HumanRendering wrapper needs to be applied
     if mode is not None:
         if hasattr(env_creator, "metadata"):
-            if isinstance(env_creator.metadata, dict):
-                if "render_modes" in env_creator.metadata:
-                    render_modes = env_creator.metadata["render_modes"]
+            assert isinstance(
+                env_creator.metadata, dict
+            ), f"Expect the environment creator ({env_creator}) metadata to be dict, actual type: {type(env_creator.metadata)}"
+            if "render_modes" in env_creator.metadata:
+                render_modes = env_creator.metadata["render_modes"]
 
-                    # Apply the `HumanRendering` wrapper, if the mode=="human" but "human" not in render_modes
-                    if (
-                        mode == "human"
-                        and "human" not in render_modes
-                        and (
-                            "single_rgb_array" in render_modes
-                            or "rgb_array" in render_modes
-                        )
-                    ):
-                        logger.warn(
-                            "You are trying to use 'human' rendering for an environment that doesn't natively support it. "
-                            "The HumanRendering wrapper is being applied to your environment."
-                        )
-                        apply_human_rendering = True
-                        if "single_rgb_array" in render_modes:
-                            _kwargs["render_mode"] = "single_rgb_array"
-                        else:
-                            _kwargs["render_mode"] = "rgb_array"
-                    # else:
-                    #   we don't raise an error as the environment may have forgotten to add the "render_modes"
-                    #   if the render mode is not valid for an environment, the environment should raise an error
-                else:
-                    logger.warn(
-                        f"The environment {id} metadata does not include `render_modes`."
+                # Apply the `HumanRendering` wrapper, if the mode=="human" but "human" not in render_modes
+                if (
+                    mode == "human"
+                    and "human" not in render_modes
+                    and (
+                        "single_rgb_array" in render_modes
+                        or "rgb_array" in render_modes
                     )
+                ):
+                    logger.warn(
+                        "You are trying to use 'human' rendering for an environment that doesn't natively support it. "
+                        "The HumanRendering wrapper is being applied to your environment."
+                    )
+                    apply_human_rendering = True
+                    if "single_rgb_array" in render_modes:
+                        _kwargs["render_mode"] = "single_rgb_array"
+                    else:
+                        _kwargs["render_mode"] = "rgb_array"
+                # else:
+                #   we don't raise an error as the environment may have forgotten to add the "render_modes"
+                #   if the render mode is not valid for an environment, the environment should raise an error
             else:
                 logger.warn(
-                    f"The environment {id} metadata is not a dictionary, actual type: {type(env_creator.metadata)}"
+                    "Applying render_mode to environment without metadata `render_modes`."
                 )
         else:
-            logger.warn(
-                f"The environment creator for {id} does not contain metadata, this could be due to metadata being set during initialisation. Creator: {env_creator}"
-            )
-    # else:
-    #   if no mode is set then we don't run the check
+            logger.warn("Applying render_mode to environment with metadata attribute.")
 
     try:
         env = env_creator(**_kwargs)

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -622,36 +622,41 @@ def make(
     apply_human_rendering = False
 
     # If we have access to metadata we check that "render_mode" is valid and see if the HumanRendering wrapper needs to be applied
-    if mode is not None:
-        if hasattr(env_creator, "metadata"):
-            assert isinstance(
-                env_creator.metadata, dict
-            ), f"Expect the environment creator ({env_creator}) metadata to be dict, actual type: {type(env_creator.metadata)}"
+    if mode is not None and hasattr(env_creator, "metadata"):
+        assert isinstance(
+            env_creator.metadata, dict
+        ), f"Expect the environment creator ({env_creator}) metadata to be dict, actual type: {type(env_creator.metadata)}"
 
-            if "render_modes" in env_creator.metadata:
-                render_modes = env_creator.metadata["render_modes"]
+        if "render_modes" in env_creator.metadata:
+            render_modes = env_creator.metadata["render_modes"]
+            if not isinstance(render_modes, Sequence):
+                logger.warn(
+                    f"Expects the environment metadata render_modes to be a Sequence (tuple or list), actual type: {type(render_modes)}"
+                )
 
-                # Apply the `HumanRendering` wrapper, if the mode=="human" but "human" not in render_modes
-                if (
-                    mode == "human"
-                    and "human" not in render_modes
-                    and (
-                        "single_rgb_array" in render_modes
-                        or "rgb_array" in render_modes
-                    )
-                ):
-                    logger.warn(
-                        "You are trying to use 'human' rendering for an environment that doesn't natively support it. "
-                        "The HumanRendering wrapper is being applied to your environment."
-                    )
-                    apply_human_rendering = True
-                    if "single_rgb_array" in render_modes:
-                        _kwargs["render_mode"] = "single_rgb_array"
-                    else:
-                        _kwargs["render_mode"] = "rgb_array"
-                # else:
-                #   we don't raise an error as the environment may have forgotten to add the "render_modes"
-                #   if the render mode is not valid for an environment, the environment should raise an error
+            # Apply the `HumanRendering` wrapper, if the mode=="human" but "human" not in render_modes
+            if (
+                mode == "human"
+                and "human" not in render_modes
+                and ("single_rgb_array" in render_modes or "rgb_array" in render_modes)
+            ):
+                logger.warn(
+                    "You are trying to use 'human' rendering for an environment that doesn't natively support it. "
+                    "The HumanRendering wrapper is being applied to your environment."
+                )
+                apply_human_rendering = True
+                if "single_rgb_array" in render_modes:
+                    _kwargs["render_mode"] = "single_rgb_array"
+                else:
+                    _kwargs["render_mode"] = "rgb_array"
+            elif mode not in render_modes:
+                logger.warn(
+                    f"The environment is being initialised with mode ({mode}) that is not in the possible render_modes ({render_modes})."
+                )
+        else:
+            logger.warn(
+                f"The environment creator metadata doesn't include `render_modes`, contains: {list(env_creator.metadata.keys())}"
+            )
 
     try:
         env = env_creator(**_kwargs)

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -623,7 +623,7 @@ def make(
 
     # If we have access to metadata we check that "render_mode" is valid
     if hasattr(env_creator, "metadata"):
-        render_modes = env_creator.metadata["render_modes"]
+        render_modes = env_creator.metadata.get("render_modes", [])
 
         # We might be able to fall back to the HumanRendering wrapper if 'human' rendering is not supported natively
         if (

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -621,30 +621,48 @@ def make(
     mode = _kwargs.get("render_mode")
     apply_human_rendering = False
 
-    # If we have access to metadata we check that "render_mode" is valid
-    if hasattr(env_creator, "metadata"):
-        render_modes = env_creator.metadata.get("render_modes", [])
+    # If we have access to metadata we check that "render_mode" is valid and see if the HumanRendering wrapper needs to be applied
+    if mode is not None:
+        if hasattr(env_creator, "metadata"):
+            if isinstance(env_creator.metadata, dict):
+                if "render_modes" in env_creator.metadata:
+                    render_modes = env_creator.metadata["render_modes"]
 
-        # We might be able to fall back to the HumanRendering wrapper if 'human' rendering is not supported natively
-        if (
-            mode == "human"
-            and "human" not in render_modes
-            and ("single_rgb_array" in render_modes or "rgb_array" in render_modes)
-        ):
+                    # Apply the `HumanRendering` wrapper, if the mode=="human" but "human" not in render_modes
+                    if (
+                        mode == "human"
+                        and "human" not in render_modes
+                        and (
+                            "single_rgb_array" in render_modes
+                            or "rgb_array" in render_modes
+                        )
+                    ):
+                        logger.warn(
+                            "You are trying to use 'human' rendering for an environment that doesn't natively support it. "
+                            "The HumanRendering wrapper is being applied to your environment."
+                        )
+                        apply_human_rendering = True
+                        if "single_rgb_array" in render_modes:
+                            _kwargs["render_mode"] = "single_rgb_array"
+                        else:
+                            _kwargs["render_mode"] = "rgb_array"
+                    # else:
+                    #   we don't raise an error as the environment may have forgotten to add the "render_modes"
+                    #   if the render mode is not valid for an environment, the environment should raise an error
+                else:
+                    logger.warn(
+                        f"The environment {id} metadata does not include `render_modes`."
+                    )
+            else:
+                logger.warn(
+                    f"The environment {id} metadata is not a dictionary, actual type: {type(env_creator.metadata)}"
+                )
+        else:
             logger.warn(
-                "You are trying to use 'human' rendering for an environment that doesn't natively support it. "
-                "The HumanRendering wrapper is being applied to your environment."
+                f"The environment creator for {id} does not contain metadata, this could be due to metadata being set during initialisation. Creator: {env_creator}"
             )
-            _kwargs["render_mode"] = (
-                "single_rgb_array"
-                if "single_rgb_array" in env_creator.metadata["render_modes"]
-                else "rgb_array"
-            )
-            apply_human_rendering = True
-        elif mode is not None and mode not in render_modes:
-            raise error.Error(
-                f"Invalid render_mode provided: {mode}. Valid render_modes: None, {', '.join(render_modes)}"
-            )
+    # else:
+    #   if no mode is set then we don't run the check
 
     try:
         env = env_creator(**_kwargs)

--- a/tests/envs/test_make.py
+++ b/tests/envs/test_make.py
@@ -188,15 +188,6 @@ def test_make_render_mode():
     valid_render_modes = env.metadata["render_modes"]
     env.close()
 
-    assert "no mode" not in valid_render_modes
-    with pytest.raises(
-        gym.error.Error,
-        match=re.escape(
-            "Invalid render_mode provided: no mode. Valid render_modes: None, human, rgb_array, single_rgb_array"
-        ),
-    ):
-        gym.make("CartPole-v1", render_mode="no mode", disable_env_checker=True)
-
     assert len(valid_render_modes) > 0
     with pytest.warns(None) as warnings:
         env = gym.make(
@@ -244,24 +235,6 @@ def test_make_render_mode():
         ),
     ):
         gym.make("test/NoHumanOldAPI-v0", render_mode="human", disable_env_checker=True)
-
-    # Make sure that the `HumanRendering` is not applied if the environment doesn't have rgb-rendering
-    with pytest.raises(
-        gym.error.Error,
-        match=re.escape(
-            "Invalid render_mode provided: human. Valid render_modes: None, ascii"
-        ),
-    ):
-        gym.make("test/NoHumanNoRGB-v0", render_mode="human", disable_env_checker=True)
-
-    # Make sure that an error is thrown if the mode is not supported
-    with pytest.raises(
-        gym.error.Error,
-        match=re.escape(
-            "Invalid render_mode provided: ascii. Valid render_modes: None, rgb_array"
-        ),
-    ):
-        gym.make("test/NoHuman-v0", render_mode="ascii", disable_env_checker=True)
 
     # This test ensures that the additional exception "Gym tried to apply the HumanRendering wrapper but it looks like
     # your environment is using the old rendering API" is *not* triggered by a TypeError that originate from


### PR DESCRIPTION
In testing `gym-minigrid`, it used `v0.25.0`, however, this raised an error with `render_modes = env_creator.metadata["render_modes"]`  as the environment metadata does not include `"render_modes"`.

Therefore, in this PR, I have changed all of the errors to warnings and removed the respective tests 