### PR TITLE
fixed bipedal walker render rgb_array

### DIFF
--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -752,7 +752,7 @@ class BipedalWalker(gym.Env, EzPickle):
         elif mode in {"rgb_array", "single_rgb_array"}:
             return np.transpose(
                 np.array(pygame.surfarray.pixels3d(self.surf)), axes=(1, 0, 2)
-            )
+            )[:, -VIEWPORT_W:]
 
     def close(self):
         if self.screen is not None:


### PR DESCRIPTION
# Description

render would previously return the full surface of varying width if mode is rgb_array

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
