### PR TITLE
fix render popping when render is called internally for Wrappers

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -325,8 +325,6 @@ class Wrapper(Env[ObsType, ActType]):
         self._metadata: Optional[dict] = None
         self.new_step_api = new_step_api
 
-        self.render_history = []
-
         if not self.new_step_api:
             deprecation(
                 "Initializing wrapper in old step API which returns one bool instead of two. It is recommended to set `new_step_api=True` to use new step API. This will be the default behaviour in future."
@@ -432,20 +430,7 @@ class Wrapper(Env[ObsType, ActType]):
         self, *args, **kwargs
     ) -> Optional[Union[RenderFrame, List[RenderFrame]]]:
         """Renders the environment."""
-        render = self.env.render(*args, **kwargs)
-        if isinstance(render, list):
-            render = self.render_history + render
-            self.render_history = []
-        return render
-
-    def _render(
-        self, *args, **kwargs
-    ) -> Optional[Union[RenderFrame, List[RenderFrame]]]:
-        """Internal call of render. Used to avoid popping frames when render is called internally."""
-        render = self.env.render(*args, **kwargs)
-        if isinstance(render, list):
-            self.render_history += render
-        return render
+        return self.env.render(*args, **kwargs)
 
     def close(self):
         """Closes the environment."""

--- a/gym/core.py
+++ b/gym/core.py
@@ -325,6 +325,8 @@ class Wrapper(Env[ObsType, ActType]):
         self._metadata: Optional[dict] = None
         self.new_step_api = new_step_api
 
+        self.render_history = []
+
         if not self.new_step_api:
             deprecation(
                 "Initializing wrapper in old step API which returns one bool instead of two. It is recommended to set `new_step_api=True` to use new step API. This will be the default behaviour in future."
@@ -426,9 +428,24 @@ class Wrapper(Env[ObsType, ActType]):
         """Resets the environment with kwargs."""
         return self.env.reset(**kwargs)
 
-    def render(self, *args, **kwargs):
+    def render(
+        self, *args, **kwargs
+    ) -> Optional[Union[RenderFrame, List[RenderFrame]]]:
         """Renders the environment."""
-        return self.env.render(*args, **kwargs)
+        render = self.env.render(*args, **kwargs)
+        if isinstance(render, list):
+            render = self.render_history + render
+            self.render_history = []
+        return render
+
+    def _render(
+        self, *args, **kwargs
+    ) -> Optional[Union[RenderFrame, List[RenderFrame]]]:
+        """Internal call of render. Used to avoid popping frames when render is called internally."""
+        render = self.env.render(*args, **kwargs)
+        if isinstance(render, list):
+            self.render_history += render
+        return render
 
     def close(self):
         """Closes the environment."""

--- a/gym/wrappers/pixel_observation.py
+++ b/gym/wrappers/pixel_observation.py
@@ -81,6 +81,7 @@ class PixelObservationWrapper(gym.ObservationWrapper):
 
         # Avoid side-effects that occur when render_kwargs is manipulated
         render_kwargs = copy.deepcopy(render_kwargs)
+        self.render_history = []
 
         if render_kwargs is None:
             render_kwargs = {}
@@ -191,3 +192,17 @@ class PixelObservationWrapper(gym.ObservationWrapper):
         observation.update(pixel_observations)
 
         return observation
+
+    def render(self, *args, **kwargs):
+        """Renders the environment."""
+        render = self.env.render(*args, **kwargs)
+        if isinstance(render, list):
+            render = self.render_history + render
+            self.render_history = []
+        return render
+
+    def _render(self, *args, **kwargs):
+        render = self.env.render(*args, **kwargs)
+        if isinstance(render, list):
+            self.render_history += render
+        return render

--- a/gym/wrappers/pixel_observation.py
+++ b/gym/wrappers/pixel_observation.py
@@ -135,7 +135,7 @@ class PixelObservationWrapper(gym.ObservationWrapper):
         self.env.reset()
         pixels_spaces = {}
         for pixel_key in pixel_keys:
-            pixels = self.env.render(**render_kwargs[pixel_key])
+            pixels = self._render(**render_kwargs[pixel_key])
             pixels: np.ndarray = pixels[-1] if isinstance(pixels, List) else pixels
 
             if not hasattr(pixels, "dtype") or not hasattr(pixels, "shape"):
@@ -184,7 +184,7 @@ class PixelObservationWrapper(gym.ObservationWrapper):
             observation[STATE_KEY] = wrapped_observation
 
         pixel_observations = {
-            pixel_key: self.env.render(**self._render_kwargs[pixel_key])
+            pixel_key: self._render(**self._render_kwargs[pixel_key])
             for pixel_key in self._pixel_keys
         }
 


### PR DESCRIPTION
Add the utility method `_render` to Wrappers. Calling `_render` save the frames, so they are added again when the user calls `render`.