### PR TITLE
Avoid metaclass conflicts when inheriting from `gym.Env`

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -31,55 +31,36 @@ ActType = TypeVar("ActType")
 RenderFrame = TypeVar("RenderFrame")
 
 
-class _EnvDecorator(type):  # TODO: remove with gym 1.0
-    """Metaclass used for adding deprecation warning to the mode kwarg in the render method."""
+# TODO: remove with gym 1.0
+def _deprecate_mode(render_func):  # type: ignore
+    """Wrapper used for adding deprecation warning to the mode kwarg in the render method."""
+    render_return = Optional[Union[RenderFrame, List[RenderFrame]]]
 
-    def __new__(cls, name, bases, attr):
-        if "render" in attr.keys():
-            attr["render"] = _EnvDecorator._deprecate_mode(attr["render"])
+    def render(
+        self: object, *args: Tuple[Any], **kwargs: Dict[str, Any]
+    ) -> render_return:
+        if "mode" in kwargs.keys() or len(args) > 0:
+            deprecation(
+                "The argument mode in render method is deprecated; "
+                "use render_mode during environment initialization instead.\n"
+                "See here for more information: https://www.gymlibrary.ml/content/api/"
+            )
+        elif self.spec is not None and "render_mode" not in self.spec.kwargs.keys():  # type: ignore
+            deprecation(
+                "You are calling render method, "
+                "but you didn't specified the argument render_mode at environment initialization. "
+                "To maintain backward compatibility, the environment will render in human mode.\n"
+                "If you want to render in human mode, initialize the environment in this way: "
+                "gym.make('EnvName', render_mode='human') and don't call the render method.\n"
+                "See here for more information: https://www.gymlibrary.ml/content/api/"
+            )
 
-        return super().__new__(cls, name, bases, attr)
+        return render_func(self, *args, **kwargs)
 
-    @staticmethod
-    def _deprecate_mode(render_func):  # type: ignore
-        render_return = Optional[Union[RenderFrame, List[RenderFrame]]]
-
-        def render(
-            self: object, *args: Tuple[Any], **kwargs: Dict[str, Any]
-        ) -> render_return:
-            if "mode" in kwargs.keys() or len(args) > 0:
-                deprecation(
-                    "The argument mode in render method is deprecated; "
-                    "use render_mode during environment initialization instead.\n"
-                    "See here for more information: https://www.gymlibrary.ml/content/api/"
-                )
-            elif self.spec is not None and "render_mode" not in self.spec.kwargs.keys():  # type: ignore
-                deprecation(
-                    "You are calling render method, "
-                    "but you didn't specified the argument render_mode at environment initialization. "
-                    "To maintain backward compatibility, the environment will render in human mode.\n"
-                    "If you want to render in human mode, initialize the environment in this way: "
-                    "gym.make('EnvName', render_mode='human') and don't call the render method.\n"
-                    "See here for more information: https://www.gymlibrary.ml/content/api/"
-                )
-
-            return render_func(self, *args, **kwargs)
-
-        return render
+    return render
 
 
-decorator = _EnvDecorator
-if sys.version_info[0:2] == (3, 6):
-    # needed for https://github.com/python/typing/issues/449
-    from typing import GenericMeta
-
-    class _GenericEnvDecorator(GenericMeta, _EnvDecorator):
-        pass
-
-    decorator = _GenericEnvDecorator
-
-
-class Env(Generic[ObsType, ActType], metaclass=decorator):
+class Env(Generic[ObsType, ActType]):
     r"""The main OpenAI Gym class.
 
     It encapsulates an environment with arbitrary behind-the-scenes dynamics.
@@ -105,6 +86,12 @@ class Env(Generic[ObsType, ActType], metaclass=decorator):
 
     Note: a default reward range set to :math:`(-\infty,+\infty)` already exists. Set it if you want a narrower range.
     """
+
+    def __init_subclass__(cls) -> None:
+        """Hook used for wrapping render method."""
+        super().__init_subclass__()
+        if "render" in vars(cls):
+            cls.render = _deprecate_mode(vars(cls)["render"])
 
     # Set this in SOME subclasses
     metadata = {"render_modes": []}


### PR DESCRIPTION
# Description

Using `__init_subclass__` instead of metaclass, suggested by [PEP 487](https://peps.python.org/pep-0487/)(introduced in python3.6).
As a result, downstream package can safely inherit from `gym.Env` and `abc.ABC`/`Protocol`/...(classes with metaclass != `type`), or set their own metaclass without making a intermediate metaclass inherited from custom metaclass and `type(gym.Env)`.

For example, https://github.com/rlworkgroup/metaworld use `abc.ABC`/`abc.ABCMeta`, thus it was broken by the metaclass introduced in `gym-0.25.0`.
https://github.com/rlworkgroup/metaworld/blob/18118a28c06893da0f363786696cc792457b062b/metaworld/envs/mujoco/mujoco_env.py#L31
https://github.com/rlworkgroup/metaworld/blob/18118a28c06893da0f363786696cc792457b062b/metaworld/envs/mujoco/sawyer_xyz/sawyer_xyz_env.py#L14

```python
import abc, gym
class SomeAbstractEnvUseABCMeta(gym.Env, metaclass=abc.ABCMeta): pass
class SomeAbstractEnvUseABC(gym.Env, abc.ABC): pass
``` 
Above code works on `gym<0.25.0`, but crashs on `gym==0.25.0`
![image](https://user-images.githubusercontent.com/83971976/181503144-043d537a-f88c-4a6a-9e1f-7c8c8d157fc6.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

If user-code/downstream library doesn't depend on `type(gym.Env)`, it should not be a breaking change, but there is a rare case that workaround for metaclass introduced in `gym-0.25.0` is used:
```python
import abc, gym
class AbstractEnvMeta(type(gym.Env), abc.ABCMeta): pass
class SomeAbstractEnv(gym.Env, metaclass=AbstractEnvMeta): pass
``` 
Above code will crash if `issubclass(abc.ABCMeta, type(gym.Env))`, which is true without decorator metaclass introduced in `gym-0.25.0` since `type(gym.Env) is type`, because of [MRO conflict](https://stackoverflow.com/a/42567588/16613821). i.e., above code will crash on `gym<0.25.0` and after this change.
I want to note that following code won't crash on any version of `gym` or after this change:
```python
import abc, gym
class AbstractEnvMeta(abc.ABCMeta, type(gym.Env)): pass
class SomeAbstractEnv(gym.Env, metaclass=AbstractEnvMeta): pass
```


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
