### PR TITLE
Fix for pickling environments

### DIFF
--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -169,7 +169,7 @@ class BipedalWalker(gym.Env, EzPickle):
     }
 
     def __init__(self, render_mode: Optional[str] = None, hardcore: bool = False):
-        EzPickle.__init__(self)
+        EzPickle.__init__(**locals())
         self.isopen = True
 
         self.world = Box2D.b2World()

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -200,13 +200,14 @@ class CarRacing(gym.Env, EzPickle):
         domain_randomize: bool = False,
         continuous: bool = True,
     ):
-        EzPickle.__init__(self)
+        EzPickle.__init__(**locals())
+
         self.continuous = continuous
         self.domain_randomize = domain_randomize
         self._init_colors()
 
-        self.world: Box2D.b2World
-        self.lap_complete_percent = lap_complete_percent
+        self.contactListener_keepref = FrictionDetector(self, lap_complete_percent)
+        self.world = Box2D.b2World((0, 0), contactListener=self.contactListener_keepref)
         self.screen: Optional[pygame.Surface] = None
         self.surf = None
         self.clock = None
@@ -480,8 +481,6 @@ class CarRacing(gym.Env, EzPickle):
     ):
         super().reset(seed=seed)
 
-        self.contactListener_keepref = FrictionDetector(self, self.lap_complete_percent)
-        self.world = Box2D.b2World((0, 0), contactListener=self.contactListener_keepref)
         self._destroy()
         self.reward = 0.0
         self.prev_reward = 0.0

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -205,8 +205,8 @@ class CarRacing(gym.Env, EzPickle):
         self.domain_randomize = domain_randomize
         self._init_colors()
 
-        self.contactListener_keepref = FrictionDetector(self, lap_complete_percent)
-        self.world = Box2D.b2World((0, 0), contactListener=self.contactListener_keepref)
+        self.world: Box2D.b2World
+        self.lap_complete_percent = lap_complete_percent
         self.screen: Optional[pygame.Surface] = None
         self.surf = None
         self.clock = None
@@ -479,6 +479,9 @@ class CarRacing(gym.Env, EzPickle):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
+
+        self.contactListener_keepref = FrictionDetector(self, self.lap_complete_percent)
+        self.world = Box2D.b2World((0, 0), contactListener=self.contactListener_keepref)
         self._destroy()
         self.reward = 0.0
         self.prev_reward = 0.0

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -192,7 +192,7 @@ class LunarLander(gym.Env, EzPickle):
         wind_power: float = 15.0,
         turbulence_power: float = 1.5,
     ):
-        EzPickle.__init__(self)
+        EzPickle.__init__(**locals())
 
         assert (
             -12.0 < gravity and gravity < 0.0

--- a/gym/envs/mujoco/ant.py
+++ b/gym/envs/mujoco/ant.py
@@ -24,7 +24,7 @@ class AntEnv(MuJocoPyEnv, utils.EzPickle):
         MuJocoPyEnv.__init__(
             self, "ant.xml", 5, observation_space=observation_space, **kwargs
         )
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
 
     def step(self, a):
         xposbefore = self.get_body_com("torso")[0]

--- a/gym/envs/mujoco/half_cheetah.py
+++ b/gym/envs/mujoco/half_cheetah.py
@@ -22,7 +22,7 @@ class HalfCheetahEnv(MuJocoPyEnv, utils.EzPickle):
         MuJocoPyEnv.__init__(
             self, "half_cheetah.xml", 5, observation_space=observation_space, **kwargs
         )
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
 
     def step(self, action):
         xposbefore = self.sim.data.qpos[0]

--- a/gym/envs/mujoco/hopper.py
+++ b/gym/envs/mujoco/hopper.py
@@ -22,7 +22,7 @@ class HopperEnv(MuJocoPyEnv, utils.EzPickle):
         MuJocoPyEnv.__init__(
             self, "hopper.xml", 4, observation_space=observation_space, **kwargs
         )
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
 
     def step(self, a):
         posbefore = self.sim.data.qpos[0]

--- a/gym/envs/mujoco/humanoid.py
+++ b/gym/envs/mujoco/humanoid.py
@@ -30,7 +30,7 @@ class HumanoidEnv(MuJocoPyEnv, utils.EzPickle):
         MuJocoPyEnv.__init__(
             self, "humanoid.xml", 5, observation_space=observation_space, **kwargs
         )
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
 
     def _get_obs(self):
         data = self.sim.data

--- a/gym/envs/mujoco/humanoidstandup.py
+++ b/gym/envs/mujoco/humanoidstandup.py
@@ -28,7 +28,7 @@ class HumanoidStandupEnv(MuJocoPyEnv, utils.EzPickle):
             observation_space=observation_space,
             **kwargs
         )
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
 
     def _get_obs(self):
         data = self.sim.data

--- a/gym/envs/mujoco/humanoidstandup_v4.py
+++ b/gym/envs/mujoco/humanoidstandup_v4.py
@@ -200,7 +200,7 @@ class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
             observation_space=observation_space,
             **kwargs
         )
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
 
     def _get_obs(self):
         data = self.data

--- a/gym/envs/mujoco/inverted_double_pendulum.py
+++ b/gym/envs/mujoco/inverted_double_pendulum.py
@@ -26,7 +26,7 @@ class InvertedDoublePendulumEnv(MuJocoPyEnv, utils.EzPickle):
             observation_space=observation_space,
             **kwargs
         )
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
 
     def step(self, action):
         self.do_simulation(action, self.frame_skip)

--- a/gym/envs/mujoco/inverted_double_pendulum_v4.py
+++ b/gym/envs/mujoco/inverted_double_pendulum_v4.py
@@ -132,7 +132,7 @@ class InvertedDoublePendulumEnv(MujocoEnv, utils.EzPickle):
             observation_space=observation_space,
             **kwargs
         )
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
 
     def step(self, action):
         self.do_simulation(action, self.frame_skip)

--- a/gym/envs/mujoco/inverted_pendulum.py
+++ b/gym/envs/mujoco/inverted_pendulum.py
@@ -18,7 +18,7 @@ class InvertedPendulumEnv(MuJocoPyEnv, utils.EzPickle):
     }
 
     def __init__(self, **kwargs):
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(4,), dtype=np.float64)
         MuJocoPyEnv.__init__(
             self,

--- a/gym/envs/mujoco/inverted_pendulum_v4.py
+++ b/gym/envs/mujoco/inverted_pendulum_v4.py
@@ -95,7 +95,7 @@ class InvertedPendulumEnv(MujocoEnv, utils.EzPickle):
     }
 
     def __init__(self, **kwargs):
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(4,), dtype=np.float64)
         MujocoEnv.__init__(
             self,

--- a/gym/envs/mujoco/pusher.py
+++ b/gym/envs/mujoco/pusher.py
@@ -18,7 +18,7 @@ class PusherEnv(MuJocoPyEnv, utils.EzPickle):
     }
 
     def __init__(self, **kwargs):
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(23,), dtype=np.float64)
         MuJocoPyEnv.__init__(
             self, "pusher.xml", 5, observation_space=observation_space, **kwargs

--- a/gym/envs/mujoco/pusher_v4.py
+++ b/gym/envs/mujoco/pusher_v4.py
@@ -140,7 +140,7 @@ class PusherEnv(MujocoEnv, utils.EzPickle):
     }
 
     def __init__(self, **kwargs):
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(23,), dtype=np.float64)
         MujocoEnv.__init__(
             self, "pusher.xml", 5, observation_space=observation_space, **kwargs

--- a/gym/envs/mujoco/reacher.py
+++ b/gym/envs/mujoco/reacher.py
@@ -18,7 +18,7 @@ class ReacherEnv(MuJocoPyEnv, utils.EzPickle):
     }
 
     def __init__(self, **kwargs):
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(11,), dtype=np.float64)
         MuJocoPyEnv.__init__(
             self, "reacher.xml", 2, observation_space=observation_space, **kwargs

--- a/gym/envs/mujoco/reacher_v4.py
+++ b/gym/envs/mujoco/reacher_v4.py
@@ -130,7 +130,7 @@ class ReacherEnv(MujocoEnv, utils.EzPickle):
     }
 
     def __init__(self, **kwargs):
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(11,), dtype=np.float64)
         MujocoEnv.__init__(
             self, "reacher.xml", 2, observation_space=observation_space, **kwargs

--- a/gym/envs/mujoco/swimmer.py
+++ b/gym/envs/mujoco/swimmer.py
@@ -22,7 +22,7 @@ class SwimmerEnv(MuJocoPyEnv, utils.EzPickle):
         MuJocoPyEnv.__init__(
             self, "swimmer.xml", 4, observation_space=observation_space, **kwargs
         )
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
 
     def step(self, a):
         ctrl_cost_coeff = 0.0001

--- a/gym/envs/mujoco/walker2d.py
+++ b/gym/envs/mujoco/walker2d.py
@@ -22,7 +22,7 @@ class Walker2dEnv(MuJocoPyEnv, utils.EzPickle):
         MuJocoPyEnv.__init__(
             self, "walker2d.xml", 4, observation_space=observation_space, **kwargs
         )
-        utils.EzPickle.__init__(self)
+        utils.EzPickle.__init__(self, **kwargs)
 
     def step(self, a):
         posbefore = self.sim.data.qpos[0]

--- a/gym/utils/env_checker.py
+++ b/gym/utils/env_checker.py
@@ -50,7 +50,7 @@ def data_equivalence(data_1, data_2) -> bool:
                 data_equivalence(o_1, o_2) for o_1, o_2 in zip(data_1, data_2)
             )
         elif isinstance(data_1, np.ndarray):
-            return np.all(data_1 == data_2)
+            return np.allclose(data_1, data_2)
         else:
             return data_1 == data_2
     else:

--- a/gym/utils/ezpickle.py
+++ b/gym/utils/ezpickle.py
@@ -22,6 +22,12 @@ class EzPickle:
         self._ezpickle_args = args
         self._ezpickle_kwargs = kwargs
 
+        # If the environment has kwargs, they will be caught up the in
+        if "kwargs" in self._ezpickle_kwargs:
+            env_kwargs = kwargs.pop("kwargs")
+            for key, value in env_kwargs.items():
+                self._ezpickle_kwargs[key] = value
+
     def __getstate__(self):
         """Returns the object pickle state with args and kwargs."""
         return {

--- a/gym/utils/ezpickle.py
+++ b/gym/utils/ezpickle.py
@@ -22,7 +22,8 @@ class EzPickle:
         self._ezpickle_args = args
         self._ezpickle_kwargs = kwargs
 
-        # If the environment has kwargs, they will be caught up the in
+        # If the environment has kwargs, they will be caught up as a keyword.
+        #   This remove the kwargs and re-adds all keywords as actual keywords for pickling
         if "kwargs" in self._ezpickle_kwargs:
             env_kwargs = kwargs.pop("kwargs")
             for key, value in env_kwargs.items():

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -4,7 +4,8 @@ import pytest
 
 import gym
 from gym.envs.registration import EnvSpec
-from gym.utils.env_checker import check_env
+from gym.utils import seeding
+from gym.utils.env_checker import check_env, data_equivalence
 from tests.envs.utils import (
     all_testing_env_specs,
     all_testing_initialised_envs,
@@ -134,7 +135,13 @@ def test_render_modes(spec):
     all_testing_initialised_envs,
     ids=[env.spec.id for env in all_testing_initialised_envs],
 )
-def test_pickle_env(env):
+def test_pickle_env(env: gym.Env):
+    env.np_random, _ = seeding.np_random(0)
     pickled_env = pickle.loads(pickle.dumps(env))
-    pickled_env.reset()
-    pickled_env.step(pickled_env.action_space.sample())
+
+    data_equivalence(env.reset(), pickled_env.reset())
+
+    action = env.action_space.sample()
+    data_equivalence(env.step(action), pickled_env.step(action))
+    env.close()
+    pickled_env.close()

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -1,9 +1,16 @@
+import pickle
+
 import pytest
 
 import gym
 from gym.envs.registration import EnvSpec
 from gym.utils.env_checker import check_env
-from tests.envs.utils import all_testing_env_specs, assert_equals, gym_testing_env_specs
+from tests.envs.utils import (
+    all_testing_env_specs,
+    all_testing_initialised_envs,
+    assert_equals,
+    gym_testing_env_specs,
+)
 
 # This runs a smoketest on each official registered env. We may want
 # to try also running environments which are not officially registered envs.
@@ -120,3 +127,14 @@ def test_render_modes(spec):
             new_env.render()
             new_env.close()
     env.close()
+
+
+@pytest.mark.parametrize(
+    "env",
+    all_testing_initialised_envs,
+    ids=[env.spec.id for env in all_testing_initialised_envs],
+)
+def test_pickle_env(env):
+    pickled_env = pickle.loads(pickle.dumps(env))
+    pickled_env.reset()
+    pickled_env.step(pickled_env.action_space.sample())


### PR DESCRIPTION
Issue #3004 noted that car racing cannot be pickled. 
This PR adds a test for all gym environments to check if the environment can be pickled and reset / step can be run

The tests also found that several mujoco environments failed due to the `EzPickle` misunderstand `kwargs` as actual keyword. 

- [ ] Fix the Car Racing environment
