### PR TITLE
Add type annotations for metadata and render_mode

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -107,8 +107,9 @@ class Env(Generic[ObsType, ActType], metaclass=decorator):
     """
 
     # Set this in SOME subclasses
-    metadata = {"render_modes": []}
-    render_mode = None  # define render_mode if your environment supports rendering
+    metadata: Dict[str, Any] = {"render_modes": []}
+    # define render_mode if your environment supports rendering
+    render_mode: Optional[str] = None
     reward_range = (-float("inf"), float("inf"))
     spec: "EnvSpec" = None
 


### PR DESCRIPTION
# Description

This change adds type annotations to the `metadata` and `render_mode` attributes of `Env`. Without the type annotations, mypy infers that `metadata` is a `Dict[str, List[Any]]` which causes an error if I add a `render_fps` entry. Similarly, mypy infers that the type of `render_mode` is `None` and gives an error when setting it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A)
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A)
- [x] New and existing unit tests pass locally with my changes