### PR TITLE
Add swig as a Box2D dependency

### DIFF
--- a/py.Dockerfile
+++ b/py.Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get -y update \
     xvfb \
     patchelf \
     ffmpeg cmake \
-    swig \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("gym/version.py") as file:
 extras = {
     "atari": ["ale-py~=0.7.5"],
     "accept-rom-license": ["autorom[accept-rom-license]~=0.4.2"],
-    "box2d": ["box2d-py==2.3.5", "pygame==2.1.0", "swig"],
+    "box2d": ["box2d-py==2.3.5", "pygame==2.1.0", "swig==4.*"],
     "classic_control": ["pygame==2.1.0"],
     "mujoco_py": ["mujoco_py<2.2,>=2.1"],
     "mujoco": ["mujoco==2.2.0", "imageio>=2.14.1"],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("gym/version.py") as file:
 extras = {
     "atari": ["ale-py~=0.7.5"],
     "accept-rom-license": ["autorom[accept-rom-license]~=0.4.2"],
-    "box2d": ["box2d-py==2.3.5", "pygame==2.1.0"],
+    "box2d": ["box2d-py==2.3.5", "pygame==2.1.0", "swig"],
     "classic_control": ["pygame==2.1.0"],
     "mujoco_py": ["mujoco_py<2.2,>=2.1"],
     "mujoco": ["mujoco==2.2.0", "imageio>=2.14.1"],


### PR DESCRIPTION
# Description

This PR adds `swig` as a dependency when installing Gym with Box2D.

Fixes https://github.com/openai/gym/issues/3005#issuecomment-1199649526.

## Type of change

- [x] Dependency change

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
