### PR TITLE
Reduce memory consumption and hanging for Dict and Tuple spaces

### DIFF
--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -116,15 +116,13 @@ class Dict(Space[TypingDict[str, Space]], Mapping):
         elif isinstance(seed, int):
             seeds = super().seed(seed)
             subseeds = []
-            x = 0
             assert (
                 len(self.spaces) <= np.iinfo(np.int32).max
-            ), "Spaces too big to seed. Expected spaces.length <= 2147483647"
-            while x < len(self.spaces):
+            ), f"Expected spaces.length <= 2147483647, got {len(self.spaces)}"
+            while len(subseeds) < len(self.spaces):
                 subseed = self.np_random.integers(low=0, high=np.iinfo(np.int32).max)
                 if subseed not in subseeds:
                     subseeds.append(subseed)
-                    x += 1
             for subspace, subseed in zip(self.spaces.values(), subseeds):
                 seeds.append(subspace.seed(int(subseed))[0])
         elif seed is None:

--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -103,7 +103,10 @@ class Dict(Space[TypingDict[str, Space]], Mapping):
     def seed(self, seed: Optional[Union[dict, int]] = None) -> list:
         """Seed the PRNG of this space and all subspaces.
 
-        This method will generate a (mostly) unique seed for each subspace. If a truly unique seed is required use .seed(list).
+        Depending on the type of seed, the subspaces will be seeded differently
+        * None - All the subspaces will use a random initial seed
+        * Int - The integer is used to seed the `Dict` space that is used to generate seed values for each of the subspaces. Warning, this does not guarantee unique seeds for all of the subspaces.
+        * Dict - Using all the keys in the seed dictionary, the values are used to seed the subspaces. This allows the seeding of multiple composite subspaces (`Dict["space": Dict[...], ...]` with `{"space": {...}, ...}`).
 
         Args:
             seed: An optional list of ints or int to seed the (sub-)spaces.

--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -115,19 +115,16 @@ class Dict(Space[TypingDict[str, Space]], Mapping):
                 seeds += self.spaces[key].seed(seed[seed_key])
         elif isinstance(seed, int):
             seeds = super().seed(seed)
-            try:
-                subseeds = self.np_random.choice(
-                    np.iinfo(int).max,
-                    size=len(self.spaces),
-                    replace=False,  # unique subseed for each subspace
-                )
-            except ValueError:
-                subseeds = self.np_random.choice(
-                    np.iinfo(int).max,
-                    size=len(self.spaces),
-                    replace=True,  # we get more than INT_MAX subspaces
-                )
-
+            subseeds = []
+            x = 0
+            assert (
+                len(self.spaces) <= np.iinfo(np.int32).max
+            ), "Spaces too big to seed. Expected spaces.length <= 2147483647"
+            while x < len(self.spaces):
+                subseed = self.np_random.integers(low=0, high=np.iinfo(np.int32).max)
+                if subseed not in subseeds:
+                    subseeds.append(subseed)
+                    x += 1
             for subspace, subseed in zip(self.spaces.values(), subseeds):
                 seeds.append(subspace.seed(int(subseed))[0])
         elif seed is None:

--- a/gym/spaces/tuple.py
+++ b/gym/spaces/tuple.py
@@ -50,15 +50,13 @@ class Tuple(Space[tuple], Sequence):
         elif isinstance(seed, int):
             seeds = super().seed(seed)
             subseeds = []
-            x = 0
             assert (
                 len(self.spaces) <= np.iinfo(np.int32).max
-            ), "Spaces too big to seed. Expected spaces.length <= 2147483647"
-            while x < len(self.spaces):
+            ), f"Expected spaces.length <= 2147483647, got {len(self.spaces)}"
+            while len(subseeds) < len(self.spaces):
                 subseed = self.np_random.integers(low=0, high=np.iinfo(np.int32).max)
                 if subseed not in subseeds:
                     subseeds.append(subseed)
-                    x += 1
             for subspace, subseed in zip(self.spaces, subseeds):
                 seeds.append(subspace.seed(int(subseed))[0])
         elif seed is None:

--- a/gym/spaces/tuple.py
+++ b/gym/spaces/tuple.py
@@ -41,7 +41,13 @@ class Tuple(Space[tuple], Sequence):
         super().__init__(None, None, seed)  # type: ignore
 
     def seed(self, seed: Optional[Union[int, List[int]]] = None) -> list:
-        """Seed the PRNG of this space and all subspaces."""
+        """Seed the PRNG of this space and all subspaces.
+
+        This method will generate a (mostly) unique seed for each subspace. If a truly unique seed is required use .seed(list).
+
+        Args:
+            seed: An optional list of ints or int to seed the (sub-)spaces.
+        """
         seeds = []
 
         if isinstance(seed, list):
@@ -49,14 +55,9 @@ class Tuple(Space[tuple], Sequence):
                 seeds += space.seed(seed[i])
         elif isinstance(seed, int):
             seeds = super().seed(seed)
-            subseeds = []
-            assert (
-                len(self.spaces) <= np.iinfo(np.int32).max
-            ), f"Expected spaces.length <= 2147483647, got {len(self.spaces)}"
-            while len(subseeds) < len(self.spaces):
-                subseed = self.np_random.integers(low=0, high=np.iinfo(np.int32).max)
-                if subseed not in subseeds:
-                    subseeds.append(subseed)
+            subseeds = self.np_random.integers(
+                np.iinfo(np.int32).max, size=len(self.spaces)
+            )
             for subspace, subseed in zip(self.spaces, subseeds):
                 seeds.append(subspace.seed(int(subseed))[0])
         elif seed is None:

--- a/gym/spaces/tuple.py
+++ b/gym/spaces/tuple.py
@@ -43,7 +43,10 @@ class Tuple(Space[tuple], Sequence):
     def seed(self, seed: Optional[Union[int, List[int]]] = None) -> list:
         """Seed the PRNG of this space and all subspaces.
 
-        This method will generate a (mostly) unique seed for each subspace. If a truly unique seed is required use .seed(list).
+        Depending on the type of seed, the subspaces will be seeded differently
+        * None - All the subspaces will use a random initial seed
+        * Int - The integer is used to seed the `Dict` space that is used to generate seed values for each of the subspaces. Warning, this does not guarantee unique seeds for all of the subspaces.
+        * Dict - Using all the keys in the seed dictionary, the values are used to seed the subspaces. This allows the seeding of multiple composite subspaces (`Dict["space": Dict[...], ...]` with `{"space": {...}, ...}`).
 
         Args:
             seed: An optional list of ints or int to seed the (sub-)spaces.

--- a/gym/spaces/tuple.py
+++ b/gym/spaces/tuple.py
@@ -45,8 +45,8 @@ class Tuple(Space[tuple], Sequence):
 
         Depending on the type of seed, the subspaces will be seeded differently
         * None - All the subspaces will use a random initial seed
-        * Int - The integer is used to seed the `Dict` space that is used to generate seed values for each of the subspaces. Warning, this does not guarantee unique seeds for all of the subspaces.
-        * Dict - Using all the keys in the seed dictionary, the values are used to seed the subspaces. This allows the seeding of multiple composite subspaces (`Dict["space": Dict[...], ...]` with `{"space": {...}, ...}`).
+        * Int - The integer is used to seed the `Tuple` space that is used to generate seed values for each of the subspaces. Warning, this does not guarantee unique seeds for all of the subspaces.
+        * List - Values used to seed the subspaces. This allows the seeding of multiple composite subspaces (`List(42, 54, ...)`).
 
         Args:
             seed: An optional list of ints or int to seed the (sub-)spaces.

--- a/gym/spaces/tuple.py
+++ b/gym/spaces/tuple.py
@@ -49,19 +49,16 @@ class Tuple(Space[tuple], Sequence):
                 seeds += space.seed(seed[i])
         elif isinstance(seed, int):
             seeds = super().seed(seed)
-            try:
-                subseeds = self.np_random.choice(
-                    np.iinfo(int).max,
-                    size=len(self.spaces),
-                    replace=False,  # unique subseed for each subspace
-                )
-            except ValueError:
-                subseeds = self.np_random.choice(
-                    np.iinfo(int).max,
-                    size=len(self.spaces),
-                    replace=True,  # we get more than INT_MAX subspaces
-                )
-
+            subseeds = []
+            x = 0
+            assert (
+                len(self.spaces) <= np.iinfo(np.int32).max
+            ), "Spaces too big to seed. Expected spaces.length <= 2147483647"
+            while x < len(self.spaces):
+                subseed = self.np_random.integers(low=0, high=np.iinfo(np.int32).max)
+                if subseed not in subseeds:
+                    subseeds.append(subseed)
+                    x += 1
             for subspace, subseed in zip(self.spaces, subseeds):
                 seeds.append(subspace.seed(int(subseed))[0])
         elif seed is None:


### PR DESCRIPTION
# Description

This PR fixes extensive memory consumption and hanging when seeding spaces.

- Iterates over length of subseeds and generates a seed from np_random.integers() instead of np_random.choice().
- Uses np.int32 instead of python int for portability.

Fixes #3010 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
