### PR TITLE
Type hint mujoco_env.py and update pyright

### DIFF
--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -1,6 +1,6 @@
 from functools import partial
 from os import path
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 
@@ -318,7 +318,9 @@ class MuJocoPyEnv(BaseMujocoEnv):
         elif mode == "human":
             self._get_viewer(mode).render()
 
-    def _get_viewer(self, mode):
+    def _get_viewer(
+        self, mode
+    ) -> Union["mujoco_py.MjViewer", "mujoco_py.MjRenderContextOffscreen"]:
         self.viewer = self._viewers.get(mode)
         if self.viewer is None:
             if mode == "human":
@@ -331,9 +333,14 @@ class MuJocoPyEnv(BaseMujocoEnv):
                 "single_depth_array",
             }:
                 self.viewer = mujoco_py.MjRenderContextOffscreen(self.sim, -1)
+            else:
+                raise AttributeError(
+                    f"Unknown mode: {mode}, expected modes: {self.metadata['render_modes']}"
+                )
 
             self.viewer_setup()
             self._viewers[mode] = self.viewer
+
         return self.viewer
 
     def get_body_com(self, body_name):
@@ -447,7 +454,9 @@ class MujocoEnv(BaseMujocoEnv):
             self.viewer.close()
         super().close()
 
-    def _get_viewer(self, mode, width=DEFAULT_SIZE, height=DEFAULT_SIZE):
+    def _get_viewer(
+        self, mode, width=DEFAULT_SIZE, height=DEFAULT_SIZE
+    ) -> Union["gym.envs.mujoco.Viewer", "gym.envs.mujoco.RenderContextOffscreen"]:
         self.viewer = self._viewers.get(mode)
         if self.viewer is None:
             if mode == "human":
@@ -464,6 +473,10 @@ class MujocoEnv(BaseMujocoEnv):
 
                 self.viewer = RenderContextOffscreen(
                     width, height, self.model, self.data
+                )
+            else:
+                raise AttributeError(
+                    f"Unexpected mode: {mode}, expected modes: {self.metadata['render_modes']}"
                 )
 
             self.viewer_setup()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,6 @@ include = [
 exclude = [
     "**/node_modules",
     "**/__pycache__",
-
-    "gym/envs/mujoco/mujoco_env.py",
 ]
 
 strict = [
@@ -25,17 +23,20 @@ enableTypeIgnoreComments = true
 # This is required as the CI pre-commit does not download the module (i.e. numpy, pygame, box2d)
 #   Therefore, we have to ignore missing imports
 reportMissingImports = "none"
-
-reportUnknownMemberType = "none"
-reportUnknownParameterType = "none"
-reportUnknownVariableType = "none"
-reportUnknownArgumentType = "none"
-reportPrivateUsage = "warning"
-reportUntypedFunctionDecorator = "none"
+# Some modules are missing type stubs, which is an issue when running pyright locally
 reportMissingTypeStubs = false
-reportUnboundVariable = "warning"
-reportGeneralTypeIssues ="none"
+# For warning and error, will raise an error when
 reportInvalidTypeVarUse = "none"
+
+# reportUnknownMemberType = "warning"  # -> raises 6035 warnings
+# reportUnknownParameterType = "warning"  # -> raises 1327 warnings
+# reportUnknownVariableType = "warning"  # -> raises 2585 warnings
+# reportUnknownArgumentType = "warning"  # -> raises 2104 warnings
+reportGeneralTypeIssues ="none"  # -> commented out raises 489 errors
+
+reportPrivateUsage = "warning"
+reportUntypedFunctionDecorator = "error"
+reportUnboundVariable = "warning"
 
 [tool.pytest.ini_options]
 filterwarnings = ['ignore:.*step API.*:DeprecationWarning'] # TODO: to be removed when old step API is removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,10 @@ reportInvalidTypeVarUse = "none"
 # reportUnknownParameterType = "warning"  # -> raises 1327 warnings
 # reportUnknownVariableType = "warning"  # -> raises 2585 warnings
 # reportUnknownArgumentType = "warning"  # -> raises 2104 warnings
-reportGeneralTypeIssues ="none"  # -> commented out raises 489 errors
+reportGeneralTypeIssues = "none"  # -> commented out raises 489 errors
+reportUntypedFunctionDecorator = "none"  # -> pytest.mark.parameterize issues
 
 reportPrivateUsage = "warning"
-reportUntypedFunctionDecorator = "error"
 reportUnboundVariable = "warning"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This PR removes `mujoco_env.py` from the set of ignored files such that every gym file is tested
In addition, this PR adds comments to the pyproject.toml file for the number of warnings that each pyright disable parameter would cause. 
This should help with the type hinting of the project in the future
I have removed unnecessary pyright argument that do not raise any new warnings or errors as the original pyright argument were just copied from another project will limited investigation into their effectiveness. 