### PR TITLE
Closes all rendered environments in testing

### DIFF
--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -375,14 +375,13 @@ class AcrobotEnv(core.Env):
                 np.array(pygame.surfarray.pixels3d(self.screen)), axes=(1, 0, 2)
             )
 
+    def close(self):
+        if self.screen is not None:
+            import pygame
 
-def close(self):
-    if self.screen is not None:
-        import pygame
-
-        pygame.display.quit()
-        pygame.quit()
-        self.isopen = False
+            pygame.display.quit()
+            pygame.quit()
+            self.isopen = False
 
 
 def wrap(x, m, M):

--- a/gym/wrappers/monitoring/video_recorder.py
+++ b/gym/wrappers/monitoring/video_recorder.py
@@ -221,6 +221,10 @@ class VideoRecorder:  # TODO: remove with gym 1.0
         if not self.enabled or self._closed:
             return
 
+        # First close the environment
+        self.env.close()
+
+        # Close the encoder
         if self.encoder:
             logger.debug("Closing video encoder: path=%s", self.path)
             self.encoder.close()

--- a/tests/wrappers/test_human_rendering.py
+++ b/tests/wrappers/test_human_rendering.py
@@ -21,10 +21,12 @@ def test_human_rendering():
 
         env.close()
 
+    env = gym.make("CartPole-v1", render_mode="human")
     with pytest.raises(
         AssertionError,
         match=re.escape(
             "Expected env.render_mode to be one of 'rgb_array' or 'single_rgb_array' but got 'human'"
         ),
     ):
-        HumanRendering(gym.make("CartPole-v1", render_mode="human"))
+        HumanRendering(env)
+    env.close()

--- a/tests/wrappers/test_video_recorder.py
+++ b/tests/wrappers/test_video_recorder.py
@@ -8,7 +8,7 @@ import gym
 from gym.wrappers.monitoring.video_recorder import VideoRecorder
 
 
-class BrokenRecordableEnv:
+class BrokenRecordableEnv(gym.Env):
     metadata = {"render_modes": ["rgb_array"]}
 
     def __init__(self, render_mode="rgb_array"):
@@ -18,7 +18,7 @@ class BrokenRecordableEnv:
         pass
 
 
-class UnrecordableEnv:
+class UnrecordableEnv(gym.Env):
     metadata = {"render_modes": [None]}
 
     def __init__(self, render_mode=None):


### PR DESCRIPTION
In running pytest locally, I noticed that pygame seemed to opened after the test was run, inferring that some of the rendering based tests were not closing correctly. 

In this PR, for testing, I added some code that raised an error in `__del__` if an environment had a render mode but was not closed. 
In doing this, I found 2 cases where pygame was not being closed and acrobot which its close function was in the wrong scope. 

This was inspired by #https://github.com/openai/gym/pull/2897