### PR TITLE
Consider key order in `spaces.Dict.__eq__`

### DIFF
--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -81,19 +81,12 @@ class Dict(Space[TypingDict[str, Space]], Mapping):
 
         if spaces is None:
             spaces = spaces_kwargs
-        if isinstance(spaces, dict) and not isinstance(spaces, OrderedDict):
+        if isinstance(spaces, Mapping) and not isinstance(spaces, OrderedDict):
             try:
-                spaces = OrderedDict(
-                    # Add `key.__class__.__qualname__` to support sorting between
-                    # different types (e.g. `int` vs. `str`)
-                    sorted(
-                        spaces.items(),
-                        key=lambda kv: (kv[0].__class__.__qualname__, kv[0]),
-                    )
-                )
+                spaces = OrderedDict(sorted(spaces.items()))
             except TypeError:
-                # Non-sortable user-defined key types found. The keys are
-                # remaining in the insertion order.
+                # Incomparable types (e.g. `int` vs. `str`) or user-defined types found.
+                # The keys are remaining in the insertion order.
                 spaces = OrderedDict(spaces.items())
         if isinstance(spaces, Sequence):
             spaces = OrderedDict(spaces)

--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -193,14 +193,16 @@ class Dict(Space[TypingDict[str, Space]], Mapping):
 
     def __repr__(self) -> str:
         """Gives a string representation of this space."""
-        return "Dict(" + ", ".join([f"{k}: {s}" for k, s in self.spaces.items()]) + ")"
+        return (
+            "Dict(" + ", ".join([f"{k!r}: {s}" for k, s in self.spaces.items()]) + ")"
+        )
 
     def __eq__(self, other) -> bool:
         """Check whether `other` is equivalent to this instance."""
         return (
             isinstance(other, Dict)
             # Comparison of `OrderedDict`s is order-sensitive
-            and (self.spaces == other.spaces)
+            and self.spaces == other.spaces  # OrderedDict.__eq__
         )
 
     def to_jsonable(self, sample_n: list) -> dict:

--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -50,12 +50,6 @@ class Dict(Space[TypingDict[str, Space]], Mapping):
     implemented to deal with :class:`Dict` actions.
     """
 
-    # Python builtin types (hashable) that can be used as keys in a Dict space.
-    # Note: bool is a subclass of int, so it is included here. Other hashable
-    # builtin types, such as range, enumerate, frozenset, and tuple are removed
-    # here because they are rarely used as keys and may cause errors.
-    ALLOWED_KEY_TYPES = (type(None), int, float, complex, str, bytes)
-
     def __init__(
         self,
         spaces: Optional[TypingDict[str, Space]] = None,
@@ -88,16 +82,19 @@ class Dict(Space[TypingDict[str, Space]], Mapping):
         if spaces is None:
             spaces = spaces_kwargs
         if isinstance(spaces, dict) and not isinstance(spaces, OrderedDict):
-            assert all(
-                isinstance(key, self.ALLOWED_KEY_TYPES) for key in spaces
-            ), f"Dict keys must be one of the following types: {tuple(typ.__name__ for typ in self.ALLOWED_KEY_TYPES)}"
-            spaces = OrderedDict(
-                # Add `key.__class__.__qualname__` to support sorting between
-                # different types (e.g. `int` vs. `str`)
-                sorted(
-                    spaces.items(), key=lambda kv: (kv[0].__class__.__qualname__, kv[0])
+            try:
+                spaces = OrderedDict(
+                    # Add `key.__class__.__qualname__` to support sorting between
+                    # different types (e.g. `int` vs. `str`)
+                    sorted(
+                        spaces.items(),
+                        key=lambda kv: (kv[0].__class__.__qualname__, kv[0]),
+                    )
                 )
-            )
+            except TypeError:
+                # Non-sortable user-defined key types found. The keys are
+                # remaining in the insertion order.
+                spaces = OrderedDict(spaces.items())
         if isinstance(spaces, Sequence):
             spaces = OrderedDict(spaces)
 
@@ -204,6 +201,14 @@ class Dict(Space[TypingDict[str, Space]], Mapping):
     def __repr__(self) -> str:
         """Gives a string representation of this space."""
         return "Dict(" + ", ".join([f"{k}: {s}" for k, s in self.spaces.items()]) + ")"
+
+    def __eq__(self, other) -> bool:
+        """Check whether `other` is equivalent to this instance."""
+        return (
+            isinstance(other, Dict)
+            # Comparison of `OrderedDict`s is order-sensitive
+            and (self.spaces == other.spaces)
+        )
 
     def to_jsonable(self, sample_n: list) -> dict:
         """Convert a batch of samples from this space to a JSONable data type."""

--- a/gym/spaces/dict.py
+++ b/gym/spaces/dict.py
@@ -85,8 +85,8 @@ class Dict(Space[TypingDict[str, Space]], Mapping):
             try:
                 spaces = OrderedDict(sorted(spaces.items()))
             except TypeError:
-                # Incomparable types (e.g. `int` vs. `str`) or user-defined types found.
-                # The keys are remaining in the insertion order.
+                # Incomparable types (e.g. `int` vs. `str`, or user-defined types) found.
+                # The keys remain in the insertion order.
                 spaces = OrderedDict(spaces.items())
         if isinstance(spaces, Sequence):
             spaces = OrderedDict(spaces)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

~Add type check for keys in `spaces.Dict`. Only a strict set of Python builtin types are allowed to be used as keys.~

```python
# Python builtin types (hashable) that can be used as keys in a Dict space.
# Note: bool is a subclass of int, so it is included here. Other hashable
# builtin types, such as range, enumerate, frozenset, and tuple are removed
# here because they are rarely used as keys and may cause errors.
ALLOWED_KEY_TYPES = (type(None), int, float, complex, str, bytes)
```

~This makes we can have a total order of the keys. And `spaces.Dict` is always sorted in the same order.~

~1. Add `key.__class.__qualname__` to sort keys to support comparing between different types.~
2. Consider key order in `spaces.Dict.__eq__` using `OrderedDict.__eq__`.

Fixes #3023

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
