### PR TITLE
Fix envpool bug with missing mask key

### DIFF
--- a/gym/utils/step_api_compatibility.py
+++ b/gym/utils/step_api_compatibility.py
@@ -56,12 +56,15 @@ def step_to_new_api(
                         "TimeLimit.truncated" not in infos
                         or (
                             "TimeLimit.truncated" in infos
-                            and not infos["_TimeLimit.truncated"][i]
+                            and not infos["TimeLimit.truncated"][i]
                         )
-                    )  # vector env, dict info api, if mask is False, it's the same as TimeLimit.truncated attribute not being present for env 'i'
+                    )
+                    # vector env, dict info api, for env i, vector mask `_TimeLimit.truncated` is not considered, to be compatible with envpool
+                    # For env i, `TimeLimit.truncated` not being present is treated same as being present and set to False.
+                    # therefore, terminated=True, truncated=True simultaneously is not allowed while using compatibility functions
+                    # with vector info
                 )
             ):
-
                 terminateds.append(dones[i])
                 truncateds.append(False)
 
@@ -80,10 +83,11 @@ def step_to_new_api(
                 truncateds.append(True)
             else:
                 # This means info["TimeLimit.truncated"] exists but is False, which means the core environment had already terminated,
-                # but it also exceeded maximum timesteps at the same step.
+                # but it also exceeded maximum timesteps at the same step. However to be compatible with envpool, and to be backward compatible
+                # truncated is set to False here.
                 assert dones[i]
                 terminateds.append(True)
-                truncateds.append(True)
+                truncateds.append(False)
 
         return (
             observations,


### PR DESCRIPTION
# Description

There is a bug when using latest gym (v0.25.1) with envpool. See #3021. 

This arises since gym requires `_X` mask key to be present in infos to indicate if element `i` in `infos[X]` exists. But this is not a requirement in envpool. However as mentioned in the issue thread, for truncated, when `terminated=True`, we don't care about the value of `truncated`, therefore we can practically treat the key not existing to be the same as the key existing and being set to False. The compatibility function is changed to reflect this. `truncated` is set to False when this occurs, even in list infos (old vector infos api) for consistency. This leads to slight loss of information, but again practically should not affect anything. And this is only through compatibility functions, when using new API exclusively, this problem does not occur, `terminated=True`, `truncated=True` can occur together as these are independent events. 

Fixes #3021

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
