### PR TITLE
Corrected episode end description for mujoco/ant

### DIFF
--- a/gym/envs/mujoco/ant_v4.py
+++ b/gym/envs/mujoco/ant_v4.py
@@ -133,8 +133,8 @@ class AntEnv(MujocoEnv, utils.EzPickle):
     If `terminate_when_unhealthy=True` is passed during construction (which is the default),
     the episode ends when any of the following happens:
 
-    1. Termination: The episode duration reaches a 1000 timesteps
-    2. Truncation: The ant is unhealthy
+    1. Truncation: The episode duration reaches a 1000 timesteps
+    2. Termination: The ant is unhealthy
 
     If `terminate_when_unhealthy=False` is passed, the episode is ended only when 1000 timesteps are exceeded.
 


### PR DESCRIPTION
Minor correction of episode end conditions for the ant environment as it is inconsistent with all the other mujoco environments.