### PR TITLE
Fixed typo in the contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Additionally, for pull requests, the project runs a number of tests for the whol
 These tests can be run locally with `pytest` in the root folder. 
 
 ## Docstrings
-Pydocstyle has been added to the pre-commit process such that all new functions follow the (google docstring style)[https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html].
+Pydocstyle has been added to the pre-commit process such that all new functions follow the [google docstring style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
 All new functions require either a short docstring, a single line explaining the purpose of a function
 or a multiline docstring that documents each argument and the return type (if there is one) of the function.
 In addition, new file and class require top docstrings that should outline the purpose of the file/class.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,5 +51,5 @@ or a multiline docstring that documents each argument and the return type (if th
 In addition, new file and class require top docstrings that should outline the purpose of the file/class.
 For classes, code block examples can be provided in the top docstring and not the constructor arguments.
 
-To check your docstrings are correct, run `pre-commit run --al-files` or `pydocstyle --source --explain --convention=google`.
+To check your docstrings are correct, run `pre-commit run --all-files` or `pydocstyle --source --explain --convention=google`.
 If all docstrings that fail, the source and reason for the failure is provided. 


### PR DESCRIPTION
# Description

1. Fixed markdown syntax for `google docstring style` hyperlink
    - Before: `(google docstring style)[https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html]`
    - After: `[google docstring style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)`
2. Fixed typo in `pre-commit run ...`
    - Before: `pre-commit run --al-files`
    - After: `pre-commit run --all-files`


## Type of change

- [x] This change requires a documentation update


### Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/17574076/185726535-a823fc67-452f-4b59-a498-30ded231b4f8.png) | ![image](https://user-images.githubusercontent.com/17574076/185726931-a853158b-068b-446b-a41b-26556a237a6e.png) |


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] My changes generate no new warnings

