### PR TITLE
Add testing for Fundamental spaces with full coverage

### DIFF
--- a/gym/spaces/discrete.py
+++ b/gym/spaces/discrete.py
@@ -85,18 +85,19 @@ class Discrete(Space[int]):
         if isinstance(x, int):
             as_int = x
         elif isinstance(x, (np.generic, np.ndarray)) and (
-            x.dtype.char in np.typecodes["AllInteger"] and x.shape == ()
+            np.issubdtype(x.dtype, np.integer) and x.shape == ()
         ):
             as_int = int(x)  # type: ignore
         else:
             return False
+
         return self.start <= as_int < self.start + self.n
 
     def __repr__(self) -> str:
         """Gives a string representation of this space."""
         if self.start != 0:
-            return "Discrete(%d, start=%d)" % (self.n, self.start)
-        return "Discrete(%d)" % self.n
+            return f"Discrete({self.n}, start={self.start})"
+        return f"Discrete({self.n})"
 
     def __eq__(self, other) -> bool:
         """Check whether ``other`` is equivalent to this instance."""
@@ -114,8 +115,6 @@ class Discrete(Space[int]):
         Args:
             state: The new state
         """
-        super().__setstate__(state)
-
         # Don't mutate the original state
         state = dict(state)
 
@@ -124,5 +123,4 @@ class Discrete(Space[int]):
         if "start" not in state:
             state["start"] = 0
 
-        # Update our state
-        self.__dict__.update(state)
+        super().__setstate__(state)

--- a/gym/spaces/graph.py
+++ b/gym/spaces/graph.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from gym.spaces.box import Box
 from gym.spaces.discrete import Discrete
-from gym.spaces.multi_discrete import SAMPLE_MASK_TYPE, MultiDiscrete
+from gym.spaces.multi_discrete import MultiDiscrete
 from gym.spaces.space import Space
 
 
@@ -97,8 +97,8 @@ class Graph(Space):
         self,
         mask: Optional[
             Tuple[
-                Optional[Union[np.ndarray, SAMPLE_MASK_TYPE]],
-                Optional[Union[np.ndarray, SAMPLE_MASK_TYPE]],
+                Optional[Union[np.ndarray, tuple]],
+                Optional[Union[np.ndarray, tuple]],
             ]
         ] = None,
         num_nodes: int = 10,

--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -79,12 +79,10 @@ class MultiBinary(Space[np.ndarray]):
                 mask.shape == self.shape
             ), f"The expected shape of the mask is {self.shape}, actual shape: {mask.shape}"
             assert np.all(
-                np.logical_or(mask == 0, mask == 1)
-            ), f"All values of a mask should be 0 or 1, actual values: {mask}"
+                mask == 0 | mask == 1 | mask == 2
+            ), f"All values of a mask should be 0, 1 or 2, actual values: {mask}"
 
-            return mask * self.np_random.integers(
-                low=0, high=2, size=self.n, dtype=self.dtype
-            )
+            return np.where(mask == 2, self.np_random.integers(low=0, high=2, size=self.n, dtype=self.dtype), mask.astype(self.dtype))
 
         return self.np_random.integers(low=0, high=2, size=self.n, dtype=self.dtype)
 

--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -62,7 +62,8 @@ class MultiBinary(Space[np.ndarray]):
 
         Args:
             mask: An optional np.ndarray to mask samples with expected shape of ``space.shape``.
-                Where mask == 0 then the samples will be 0.
+                For mask == 0 then the samples will be 0 and mask == 1 then random samples will be generated.
+                The expected mask shape is the space shape and mask dtype is `np.int8`.
 
         Returns:
             Sampled values from space
@@ -91,9 +92,12 @@ class MultiBinary(Space[np.ndarray]):
         """Return boolean specifying if x is a valid member of this space."""
         if isinstance(x, Sequence):
             x = np.array(x)  # Promote list to array for contains check
-        if self.shape != x.shape:
-            return False
-        return ((x == 0) | (x == 1)).all()
+
+        return bool(
+            isinstance(x, np.ndarray)
+            and self.shape == x.shape
+            and np.all((x == 0) | (x == 1))
+        )
 
     def to_jsonable(self, sample_n) -> list:
         """Convert a batch of samples from this space to a JSONable data type."""
@@ -101,7 +105,7 @@ class MultiBinary(Space[np.ndarray]):
 
     def from_jsonable(self, sample_n) -> list:
         """Convert a JSONable data type to a batch of samples from this space."""
-        return [np.asarray(sample) for sample in sample_n]
+        return [np.asarray(sample, self.dtype) for sample in sample_n]
 
     def __repr__(self) -> str:
         """Gives a string representation of this space."""

--- a/gym/spaces/multi_binary.py
+++ b/gym/spaces/multi_binary.py
@@ -79,10 +79,14 @@ class MultiBinary(Space[np.ndarray]):
                 mask.shape == self.shape
             ), f"The expected shape of the mask is {self.shape}, actual shape: {mask.shape}"
             assert np.all(
-                mask == 0 | mask == 1 | mask == 2
+                (mask == 0) | (mask == 1) | (mask == 2)
             ), f"All values of a mask should be 0, 1 or 2, actual values: {mask}"
 
-            return np.where(mask == 2, self.np_random.integers(low=0, high=2, size=self.n, dtype=self.dtype), mask.astype(self.dtype))
+            return np.where(
+                mask == 2,
+                self.np_random.integers(low=0, high=2, size=self.n, dtype=self.dtype),
+                mask.astype(self.dtype),
+            )
 
         return self.np_random.integers(low=0, high=2, size=self.n, dtype=self.dtype)
 

--- a/gym/spaces/multi_discrete.py
+++ b/gym/spaces/multi_discrete.py
@@ -83,18 +83,21 @@ class MultiDiscrete(Space[np.ndarray]):
                 sub_mask: Union[np.ndarray, tuple],
                 sub_nvec: Union[np.ndarray, np.integer],
             ) -> Union[int, List[int]]:
-                # TODO: consider a special case where the mask can be a single np.ndarray, i.e MD([2, 2])
                 if isinstance(sub_nvec, np.ndarray):
-                    assert isinstance(
-                        sub_mask, tuple
-                    ), f"Expects the mask to be a tuple for sub_nvec ({sub_nvec}), actual type: {type(sub_mask)}"
-                    assert len(sub_mask) == len(
-                        sub_nvec
-                    ), f"Expects the mask length to be equal to the number of actions, mask length: {len(sub_mask)}, nvec length: {len(sub_nvec)}"
-                    return [
-                        _apply_mask(new_mask, new_nvec)
-                        for new_mask, new_nvec in zip(sub_mask, sub_nvec)
-                    ]
+                    if np.all(sub_mask.shape == sub_nvec):
+                        # todo - test
+                        return self.np_random.choice(sub_mask, axis=-1)
+                    else:
+                        assert isinstance(
+                            sub_mask, tuple
+                        ), f"Expects the mask to be a tuple for sub_nvec ({sub_nvec}), actual type: {type(sub_mask)}"
+                        assert len(sub_mask) == len(
+                            sub_nvec
+                        ), f"Expects the mask length to be equal to the number of actions, mask length: {len(sub_mask)}, nvec length: {len(sub_nvec)}"
+                        return [
+                            _apply_mask(new_mask, new_nvec)
+                            for new_mask, new_nvec in zip(sub_mask, sub_nvec)
+                        ]
                 else:
                     assert np.issubdtype(
                         type(sub_nvec), np.integer

--- a/gym/spaces/multi_discrete.py
+++ b/gym/spaces/multi_discrete.py
@@ -84,20 +84,16 @@ class MultiDiscrete(Space[np.ndarray]):
                 sub_nvec: Union[np.ndarray, np.integer],
             ) -> Union[int, List[int]]:
                 if isinstance(sub_nvec, np.ndarray):
-                    if np.all(sub_mask.shape == sub_nvec):
-                        # todo - test
-                        return self.np_random.choice(sub_mask, axis=-1)
-                    else:
-                        assert isinstance(
-                            sub_mask, tuple
-                        ), f"Expects the mask to be a tuple for sub_nvec ({sub_nvec}), actual type: {type(sub_mask)}"
-                        assert len(sub_mask) == len(
-                            sub_nvec
-                        ), f"Expects the mask length to be equal to the number of actions, mask length: {len(sub_mask)}, nvec length: {len(sub_nvec)}"
-                        return [
-                            _apply_mask(new_mask, new_nvec)
-                            for new_mask, new_nvec in zip(sub_mask, sub_nvec)
-                        ]
+                    assert isinstance(
+                        sub_mask, tuple
+                    ), f"Expects the mask to be a tuple for sub_nvec ({sub_nvec}), actual type: {type(sub_mask)}"
+                    assert len(sub_mask) == len(
+                        sub_nvec
+                    ), f"Expects the mask length to be equal to the number of actions, mask length: {len(sub_mask)}, nvec length: {len(sub_nvec)}"
+                    return [
+                        _apply_mask(new_mask, new_nvec)
+                        for new_mask, new_nvec in zip(sub_mask, sub_nvec)
+                    ]
                 else:
                     assert np.issubdtype(
                         type(sub_nvec), np.integer

--- a/gym/spaces/sequence.py
+++ b/gym/spaces/sequence.py
@@ -4,7 +4,6 @@ from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 
-import gym
 from gym.spaces.space import Space
 from gym.utils import seeding
 
@@ -26,7 +25,7 @@ class Sequence(Space[Tuple]):
     def __init__(
         self,
         space: Space,
-        seed: Optional[Union[int, seeding.RandomNumberGenerator]] = None,
+        seed: Optional[Union[int, List[int], seeding.RandomNumberGenerator]] = None,
     ):
         """Constructor of the :class:`Sequence` space.
 
@@ -34,9 +33,6 @@ class Sequence(Space[Tuple]):
             space: Elements in the sequences this space represent must belong to this space.
             seed: Optionally, you can use this argument to seed the RNG that is used to sample from the space.
         """
-        assert isinstance(
-            space, gym.Space
-        ), f"Expects the feature space to be instance of a gym Space, actual type: {type(space)}"
         self.feature_space = space
         super().__init__(
             None, None, seed  # type: ignore
@@ -54,8 +50,7 @@ class Sequence(Space[Tuple]):
         return False
 
     def sample(
-        self,
-        mask: Optional[Tuple[Optional[Union[np.ndarray, int]], Optional[Any]]] = None,
+        self, mask: Optional[Tuple[Optional[np.ndarray], Any]] = None
     ) -> Tuple[Any]:
         """Generates a single random sample from this space.
 
@@ -73,24 +68,9 @@ class Sequence(Space[Tuple]):
         if mask is not None:
             length_mask, feature_mask = mask
         else:
-            length_mask, feature_mask = None, None
-
+            length_mask = None
+            feature_mask = None
         if length_mask is not None:
-            if np.issubdtype(type(length_mask), np.integer):
-                assert (
-                    0 <= length_mask
-                ), f"Expects the length mask to be greater than zero, actual value: {length_mask}"
-            elif isinstance(length_mask, np.ndarray):
-                assert (
-                    len(length_mask.shape) == 1
-                ), f"Expects the shape of the length mask to be 1-dimensional, actual shape: {length_mask.shape}"
-                assert np.all(
-                    0 <= length_mask
-                ), f"Expects all values in the length_mask to be greater than zero, actual values: {length_mask}"
-            else:
-                raise TypeError(
-                    f"Expects the type of length_mask to an integer or a np.ndarray, actual type: {type(length_mask)}"
-                )
             length = self.np_random.choice(length_mask)
         else:
             length = self.np_random.geometric(0.25)

--- a/gym/spaces/text.py
+++ b/gym/spaces/text.py
@@ -127,7 +127,9 @@ class Text(Space[str]):
                     string = ""
                 else:
                     # Otherwise the string will not be contained in the space
-                    raise ValueError(f"Trying to sample with a minimum length > 0 ({self.min_length}) but the character mask is all zero meaning that no character could be sampled.")
+                    raise ValueError(
+                        f"Trying to sample with a minimum length > 0 ({self.min_length}) but the character mask is all zero meaning that no character could be sampled."
+                    )
             else:
                 string = "".join(
                     self.character_list[index]

--- a/gym/spaces/text.py
+++ b/gym/spaces/text.py
@@ -89,6 +89,7 @@ class Text(Space[str]):
                 len(mask) == 2
             ), f"Expects the mask length to be two, actual length: {len(mask)}"
             length, charlist_mask = mask
+
             if length is not None:
                 assert np.issubdtype(
                     type(length), np.integer
@@ -122,7 +123,11 @@ class Text(Space[str]):
             valid_mask = charlist_mask == 1
             valid_indexes = np.where(valid_mask)[0]
             if len(valid_indexes) == 0:
-                string = ""
+                if self.min_length == 0:
+                    string = ""
+                else:
+                    # Otherwise the string will not be contained in the space
+                    raise ValueError(f"Trying to sample with a minimum length > 0 ({self.min_length}) but the character mask is all zero meaning that no character could be sampled.")
             else:
                 string = "".join(
                     self.character_list[index]

--- a/gym/spaces/text.py
+++ b/gym/spaces/text.py
@@ -1,5 +1,5 @@
 """Implementation of a space that represents textual strings."""
-from typing import Any, FrozenSet, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, FrozenSet, Optional, Set, Tuple, Union
 
 import numpy as np
 
@@ -27,7 +27,7 @@ class Text(Space[str]):
         self,
         max_length: int,
         *,
-        min_length: int = 0,
+        min_length: int = 1,
         charset: Union[Set[str], str] = alphanumeric,
         seed: Optional[Union[int, np.random.Generator]] = None,
     ):
@@ -36,9 +36,9 @@ class Text(Space[str]):
         Both bounds for text length are inclusive.
 
         Args:
-            min_length (int): Minimum text length (in characters).
+            min_length (int): Minimum text length (in characters). Defaults to 1 to prevent empty strings.
             max_length (int): Maximum text length (in characters).
-            charset (Union[set, SupportsIndex]): Character set, defaults to the lower and upper english alphabet plus latin digits.
+            charset (Union[set], str): Character set, defaults to the lower and upper english alphabet plus latin digits.
             seed: The seed for sampling from the space.
         """
         assert np.issubdtype(
@@ -56,9 +56,13 @@ class Text(Space[str]):
 
         self.min_length: int = int(min_length)
         self.max_length: int = int(max_length)
-        self.charset: FrozenSet[str] = frozenset(charset)
-        self._charlist: List[str] = list(charset)
-        self._charset_str: str = "".join(sorted(self._charlist))
+
+        self._char_set: FrozenSet[str] = frozenset(charset)
+        self._char_list: Tuple[str, ...] = tuple(charset)
+        self._char_index: Dict[str, np.int32] = {
+            val: np.int32(i) for i, val in enumerate(tuple(charset))
+        }
+        self._char_str: str = "".join(sorted(tuple(charset)))
 
         # As the shape is dynamic (between min_length and max_length) then None
         super().__init__(dtype=str, seed=seed)
@@ -71,20 +75,41 @@ class Text(Space[str]):
         Args:
             mask: An optional tuples of length and mask for the text.
                 The length is expected to be between the `min_length` and `max_length` otherwise a random integer between `min_length` and `max_length` is selected.
-                For the mask, we expect a numpy array of length of the charset passed with dtype == np.int8
+                For the mask, we expect a numpy array of length of the charset passed with `dtype == np.int8`.
+                If the charlist mask is all zero then an empty string is returned no matter the `min_length`
 
         Returns:
             A sampled string from the space
         """
         if mask is not None:
+            assert isinstance(
+                mask, tuple
+            ), f"Expects the mask type to be a tuple, actual type: {type(mask)}"
+            assert (
+                len(mask) == 2
+            ), f"Expects the mask length to be two, actual length: {len(mask)}"
             length, charlist_mask = mask
             if length is not None:
-                assert self.min_length <= length <= self.max_length
+                assert np.issubdtype(
+                    type(length), np.integer
+                ), f"Expects the Text sample length to be an integer, actual type: {type(length)}"
+                assert (
+                    self.min_length <= length <= self.max_length
+                ), f"Expects the Text sample length be between {self.min_length} and {self.max_length}, actual length: {length}"
 
             if charlist_mask is not None:
-                assert isinstance(charlist_mask, np.ndarray)
-                assert charlist_mask.dtype is np.int8
-                assert charlist_mask.shape == (len(self._charlist),)
+                assert isinstance(
+                    charlist_mask, np.ndarray
+                ), f"Expects the Text sample mask to be an np.ndarray, actual type: {type(charlist_mask)}"
+                assert (
+                    charlist_mask.dtype == np.int8
+                ), f"Expects the Text sample mask to be an np.ndarray, actual dtype: {charlist_mask.dtype}"
+                assert charlist_mask.shape == (
+                    len(self.character_set),
+                ), f"expects the Text sample mask to be {(len(self.character_set),)}, actual shape: {charlist_mask.shape}"
+                assert np.all(
+                    np.logical_or(charlist_mask == 0, charlist_mask == 1)
+                ), f"Expects all masks values to 0 or 1, actual values: {charlist_mask}"
         else:
             length, charlist_mask = None, None
 
@@ -92,10 +117,17 @@ class Text(Space[str]):
             length = self.np_random.integers(self.min_length, self.max_length + 1)
 
         if charlist_mask is None:
-            string = self.np_random.choice(self._charlist, size=length)
+            string = self.np_random.choice(self.character_list, size=length)
         else:
-            masked_charlist = self._charlist[np.where(mask)[0]]
-            string = self.np_random.choice(masked_charlist, size=length)
+            valid_mask = charlist_mask == 1
+            valid_indexes = np.where(valid_mask)[0]
+            if len(valid_indexes) == 0:
+                string = ""
+            else:
+                string = "".join(
+                    self.character_list[index]
+                    for index in self.np_random.choice(valid_indexes, size=length)
+                )
 
         return "".join(string)
 
@@ -103,13 +135,13 @@ class Text(Space[str]):
         """Return boolean specifying if x is a valid member of this space."""
         if isinstance(x, str):
             if self.min_length <= len(x) <= self.max_length:
-                return all(c in self.charset for c in x)
+                return all(c in self.character_set for c in x)
         return False
 
     def __repr__(self) -> str:
         """Gives a string representation of this space."""
         return (
-            f"Text({self.min_length}, {self.max_length}, charset={self._charset_str})"
+            f"Text({self.min_length}, {self.max_length}, characters={self.characters})"
         )
 
     def __eq__(self, other) -> bool:
@@ -118,5 +150,29 @@ class Text(Space[str]):
             isinstance(other, Text)
             and self.min_length == other.min_length
             and self.max_length == other.max_length
-            and self.charset == other.charset
+            and self.character_set == other.character_set
         )
+
+    @property
+    def character_set(self) -> FrozenSet[str]:
+        """Returns the character set for the space."""
+        return self._char_set
+
+    @property
+    def character_list(self) -> Tuple[str, ...]:
+        """Returns a tuple of characters in the space."""
+        return self._char_list
+
+    def character_index(self, char: str) -> np.int32:
+        """Returns a unique index for each character in the space's character set."""
+        return self._char_index[char]
+
+    @property
+    def characters(self) -> str:
+        """Returns a string with all Text characters."""
+        return self._char_str
+
+    @property
+    def is_np_flattenable(self) -> bool:
+        """The flattened version is an integer array for each character, padded to the max character length."""
+        return True

--- a/gym/utils/env_checker.py
+++ b/gym/utils/env_checker.py
@@ -50,7 +50,9 @@ def data_equivalence(data_1, data_2) -> bool:
                 data_equivalence(o_1, o_2) for o_1, o_2 in zip(data_1, data_2)
             )
         elif isinstance(data_1, np.ndarray):
-            return np.all(data_1 == data_2)
+            return data_1.shape == data_2.shape and np.allclose(
+                data_1, data_2, atol=0.00001
+            )
         else:
             return data_1 == data_2
     else:

--- a/tests/spaces/test_box.py
+++ b/tests/spaces/test_box.py
@@ -60,11 +60,15 @@ def test_low_high_values(value, valid: bool):
     if valid:
         with warnings.catch_warnings(record=True) as caught_warnings:
             Box(low=value, high=value)
-        assert len(caught_warnings) == 0, tuple(warning.message for warning in caught_warnings)
+        assert len(caught_warnings) == 0, tuple(
+            warning.message for warning in caught_warnings
+        )
     else:
         with pytest.raises(
             ValueError,
-            match=r"expect their types to be np\.ndarray, an integer or a float",
+            match=re.escape(
+                "expect their types to be np.ndarray, an integer or a float"
+            ),
         ):
             Box(low=value, high=value)
 

--- a/tests/spaces/test_box.py
+++ b/tests/spaces/test_box.py
@@ -285,22 +285,32 @@ def test_legacy_state_pickling():
 
 def test_get_inf():
     """Tests that get inf function works as expected, primarily for coverage."""
-    assert get_inf(np.float32, '+') == np.inf
+    assert get_inf(np.float32, "+") == np.inf
     assert get_inf(np.float16, "-") == -np.inf
-    with pytest.raises(TypeError, match=re.escape("Unknown sign *, use either '+' or '-'")):
+    with pytest.raises(
+        TypeError, match=re.escape("Unknown sign *, use either '+' or '-'")
+    ):
         get_inf(np.float32, "*")
 
     assert get_inf(np.int16, "+") == 32765
     assert get_inf(np.int8, "-") == -126
-    with pytest.raises(TypeError, match=re.escape("Unknown sign *, use either '+' or '-'")):
-        get_inf(np.int32, '*')
+    with pytest.raises(
+        TypeError, match=re.escape("Unknown sign *, use either '+' or '-'")
+    ):
+        get_inf(np.int32, "*")
 
-    with pytest.raises(ValueError, match=re.escape("Unknown dtype <class 'numpy.complex128'> for infinite bounds")):
-        get_inf(np.complex_, '+')
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Unknown dtype <class 'numpy.complex128'> for infinite bounds"),
+    ):
+        get_inf(np.complex_, "+")
 
 
 def test_sample_mask():
-    """Boxs cannot have a mask applied."""
+    """Box cannot have a mask applied."""
     space = Box(0, 1)
-    with pytest.raises(gym.error.Error, match=re.escape("Box.sample cannot be provided a mask, actual value: ")):
+    with pytest.raises(
+        gym.error.Error,
+        match=re.escape("Box.sample cannot be provided a mask, actual value: "),
+    ):
         space.sample(mask=np.array([0, 1, 0], dtype=np.int8))

--- a/tests/spaces/test_box.py
+++ b/tests/spaces/test_box.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 import numpy as np
 import pytest
@@ -57,9 +58,9 @@ def test_shape_inference(box, expected_shape):
 def test_low_high_values(value, valid: bool):
     """Test what `low` and `high` values are valid for `Box` space."""
     if valid:
-        with pytest.warns() as warnings:
+        with warnings.catch_warnings(record=True) as caught_warnings:
             Box(low=value, high=value)
-        assert len(warnings) == 0, tuple(warning.message for warning in warnings)
+        assert len(caught_warnings) == 0, tuple(warning.message for warning in caught_warnings)
     else:
         with pytest.raises(
             ValueError,

--- a/tests/spaces/test_box.py
+++ b/tests/spaces/test_box.py
@@ -5,24 +5,22 @@ import pytest
 
 from gym.spaces import Box
 
-# Todo, move Box unique tests from test_spaces.py to test_box.py
-
 
 @pytest.mark.parametrize(
     "box,expected_shape",
     [
-        (
-            Box(low=np.zeros(2), high=np.ones(2)),
+        (  # Test with same 1-dim low and high shape
+            Box(low=np.zeros(2), high=np.ones(2), dtype=np.int32),
             (2,),
-        ),  # Test with same 1-dim low and high shape
-        (
-            Box(low=np.zeros((2, 1)), high=np.ones((2, 1))),
+        ),
+        (  # Test with same multi-dim low and high shape
+            Box(low=np.zeros((2, 1)), high=np.ones((2, 1)), dtype=np.int32),
             (2, 1),
-        ),  # Test with same multi-dim low and high shape
-        (
+        ),
+        (  # Test with scalar low high and different shape
             Box(low=0, high=1, shape=(5, 2)),
             (5, 2),
-        ),  # Test with scalar low high and different shape
+        ),
         (Box(low=0, high=1), (1,)),  # Test with int and int
         (Box(low=0.0, high=1.0), (1,)),  # Test with float and float
         (Box(low=np.zeros(1)[0], high=np.ones(1)[0]), (1,)),
@@ -32,7 +30,8 @@ from gym.spaces import Box
         (Box(low=np.zeros(3), high=1.0), (3,)),  # Test with array and scalar
     ],
 )
-def test_box_shape_inference(box, expected_shape):
+def test_shape_inference(box, expected_shape):
+    """Test that the shape inference is as expected."""
     assert box.shape == expected_shape
     assert box.sample().shape == expected_shape
 
@@ -47,7 +46,7 @@ def test_box_shape_inference(box, expected_shape):
         (np.zeros(2, dtype=np.float32), True),
         (np.zeros((2, 2), dtype=np.float32), True),
         (np.inf, True),
-        (np.nan, True),  # This is a weird side
+        (np.nan, True),  # This is a weird case that we allow
         (True, False),
         (np.bool8(True), False),
         (1 + 1j, False),
@@ -55,11 +54,12 @@ def test_box_shape_inference(box, expected_shape):
         ("string", False),
     ],
 )
-def test_box_values(value, valid):
+def test_low_high_values(value, valid: bool):
+    """Test what `low` and `high` values are valid for `Box` space."""
     if valid:
-        with pytest.warns(None) as warnings:
+        with pytest.warns() as warnings:
             Box(low=value, high=value)
-        assert len(warnings.list) == 0, tuple(warning.message for warning in warnings)
+        assert len(warnings) == 0, tuple(warning.message for warning in warnings)
     else:
         with pytest.raises(
             ValueError,
@@ -132,6 +132,145 @@ def test_box_values(value, valid):
         ),
     ],
 )
-def test_box_errors(low, high, kwargs, error, message):
+def test_init_errors(low, high, kwargs, error, message):
+    """Test all constructor errors."""
     with pytest.raises(error, match=f"^{re.escape(message)}$"):
         Box(low=low, high=high, **kwargs)
+
+
+def test_dtype_check():
+    """Tests the Box contains function with different dtypes."""
+    # Related Issues:
+    # https://github.com/openai/gym/issues/2357
+    # https://github.com/openai/gym/issues/2298
+
+    space = Box(0, 1, (), dtype=np.float32)
+
+    # casting will match the correct type
+    assert np.array(0.5, dtype=np.float32) in space
+
+    # float16 is in float32 space
+    assert np.array(0.5, dtype=np.float16) in space
+
+    # float64 is not in float32 space
+    assert np.array(0.5, dtype=np.float64) not in space
+
+
+@pytest.mark.parametrize(
+    "space",
+    [
+        Box(low=0, high=np.inf, shape=(2,), dtype=np.int32),
+        Box(low=0, high=np.inf, shape=(2,), dtype=np.float32),
+        Box(low=0, high=np.inf, shape=(2,), dtype=np.int64),
+        Box(low=0, high=np.inf, shape=(2,), dtype=np.float64),
+        Box(low=-np.inf, high=0, shape=(2,), dtype=np.int32),
+        Box(low=-np.inf, high=0, shape=(2,), dtype=np.float32),
+        Box(low=-np.inf, high=0, shape=(2,), dtype=np.int64),
+        Box(low=-np.inf, high=0, shape=(2,), dtype=np.float64),
+        Box(low=-np.inf, high=np.inf, shape=(2,), dtype=np.int32),
+        Box(low=-np.inf, high=np.inf, shape=(2,), dtype=np.float32),
+        Box(low=-np.inf, high=np.inf, shape=(2,), dtype=np.int64),
+        Box(low=-np.inf, high=np.inf, shape=(2,), dtype=np.float64),
+        Box(low=0, high=np.inf, shape=(2, 3), dtype=np.int32),
+        Box(low=0, high=np.inf, shape=(2, 3), dtype=np.float32),
+        Box(low=0, high=np.inf, shape=(2, 3), dtype=np.int64),
+        Box(low=0, high=np.inf, shape=(2, 3), dtype=np.float64),
+        Box(low=-np.inf, high=0, shape=(2, 3), dtype=np.int32),
+        Box(low=-np.inf, high=0, shape=(2, 3), dtype=np.float32),
+        Box(low=-np.inf, high=0, shape=(2, 3), dtype=np.int64),
+        Box(low=-np.inf, high=0, shape=(2, 3), dtype=np.float64),
+        Box(low=-np.inf, high=np.inf, shape=(2, 3), dtype=np.int32),
+        Box(low=-np.inf, high=np.inf, shape=(2, 3), dtype=np.float32),
+        Box(low=-np.inf, high=np.inf, shape=(2, 3), dtype=np.int64),
+        Box(low=-np.inf, high=np.inf, shape=(2, 3), dtype=np.float64),
+        Box(low=np.array([-np.inf, 0]), high=np.array([0.0, np.inf]), dtype=np.int32),
+        Box(low=np.array([-np.inf, 0]), high=np.array([0.0, np.inf]), dtype=np.float32),
+        Box(low=np.array([-np.inf, 0]), high=np.array([0.0, np.inf]), dtype=np.int64),
+        Box(low=np.array([-np.inf, 0]), high=np.array([0.0, np.inf]), dtype=np.float64),
+    ],
+)
+def test_infinite_space(space):
+    """
+    To test spaces that are passed in have only 0 or infinite bounds because `space.high` and `space.low`
+     are both modified within the init, we check for infinite when we know it's not 0
+    """
+
+    assert np.all(
+        space.low < space.high
+    ), f"Box low bound ({space.low}) is not lower than the high bound ({space.high})"
+
+    space.seed(0)
+    sample = space.sample()
+
+    # check if space contains sample
+    assert (
+        sample in space
+    ), f"Sample ({sample}) not inside space according to `space.contains()`"
+
+    # manually check that the sign of the sample is within the bounds
+    assert np.all(
+        np.sign(sample) <= np.sign(space.high)
+    ), f"Sign of sample ({sample}) is less than space upper bound ({space.high})"
+    assert np.all(
+        np.sign(space.low) <= np.sign(sample)
+    ), f"Sign of sample ({sample}) is more than space lower bound ({space.low})"
+
+    # check that int bounds are bounded for everything
+    # but floats are unbounded for infinite
+    if np.any(space.high != 0):
+        assert (
+            space.is_bounded("above") is False
+        ), "inf upper bound supposed to be unbounded"
+    else:
+        assert (
+            space.is_bounded("above") is True
+        ), "non-inf upper bound supposed to be bounded"
+
+    if np.any(space.low != 0):
+        assert (
+            space.is_bounded("below") is False
+        ), "inf lower bound supposed to be unbounded"
+    else:
+        assert (
+            space.is_bounded("below") is True
+        ), "non-inf lower bound supposed to be bounded"
+
+    if np.any(space.low != 0) or np.any(space.high != 0):
+        assert space.is_bounded("both") is False
+    else:
+        assert space.is_bounded("both") is True
+
+    # check for dtype
+    assert (
+        space.high.dtype == space.dtype
+    ), f"High's dtype {space.high.dtype} doesn't match `space.dtype`'"
+    assert (
+        space.low.dtype == space.dtype
+    ), f"Low's dtype {space.high.dtype} doesn't match `space.dtype`'"
+
+    with pytest.raises(
+        ValueError, match="manner is not in {'below', 'above', 'both'}, actual value:"
+    ):
+        space.is_bounded("test")
+
+
+def test_legacy_state_pickling():
+    legacy_state = {
+        "dtype": np.dtype("float32"),
+        "_shape": (5,),
+        "low": np.array([0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32),
+        "high": np.array([1.0, 1.0, 1.0, 1.0, 1.0], dtype=np.float32),
+        "bounded_below": np.array([True, True, True, True, True]),
+        "bounded_above": np.array([True, True, True, True, True]),
+        "_np_random": None,
+    }
+
+    b = Box(-1, 1, ())
+    assert "low_repr" in b.__dict__ and "high_repr" in b.__dict__
+    del b.__dict__["low_repr"]
+    del b.__dict__["high_repr"]
+    assert "low_repr" not in b.__dict__ and "high_repr" not in b.__dict__
+
+    b.__setstate__(legacy_state)
+    assert b.low_repr == "0.0"
+    assert b.high_repr == "1.0"

--- a/tests/spaces/test_discrete.py
+++ b/tests/spaces/test_discrete.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from gym.spaces import Discrete
+
+
+def test_space_legacy_pickling():
+    """Test the legacy pickle of Discrete that is missing the `start` parameter."""
+    legacy_state = {
+        "shape": (
+            1,
+            2,
+            3,
+        ),
+        "dtype": np.int64,
+        "np_random": np.random.default_rng(),
+        "n": 3,
+    }
+    space = Discrete(1)
+    space.__setstate__(legacy_state)
+
+    assert space.shape == legacy_state["shape"]
+    assert space.np_random == legacy_state["np_random"]
+    assert space.n == 3
+    assert space.dtype == legacy_state["dtype"]
+
+    # Test that start is missing
+    assert "start" in space.__dict__
+    del space.__dict__["start"]  # legacy did not include start param
+    assert "start" not in space.__dict__
+
+    space.__setstate__(legacy_state)
+    assert space.start == 0

--- a/tests/spaces/test_discrete.py
+++ b/tests/spaces/test_discrete.py
@@ -30,3 +30,11 @@ def test_space_legacy_pickling():
 
     space.__setstate__(legacy_state)
     assert space.start == 0
+
+
+def test_sample_mask():
+    space = Discrete(4, start=2)
+    assert 2 <= space.sample() < 6
+    assert space.sample(mask=np.array([0, 1, 0, 0], dtype=np.int8)) == 3
+    assert space.sample(mask=np.array([0, 0, 0, 0], dtype=np.int8)) == 2
+    assert space.sample(mask=np.array([0, 1, 0, 1], dtype=np.int8)) in [3, 5]

--- a/tests/spaces/test_multibinary.py
+++ b/tests/spaces/test_multibinary.py
@@ -1,0 +1,5 @@
+
+
+def test_sample():
+    # todo
+    pass

--- a/tests/spaces/test_multibinary.py
+++ b/tests/spaces/test_multibinary.py
@@ -1,5 +1,3 @@
-
-
 def test_sample():
     # todo
     pass

--- a/tests/spaces/test_multidiscrete.py
+++ b/tests/spaces/test_multidiscrete.py
@@ -59,5 +59,8 @@ def test_multidiscrete_length():
     assert len(space) == 3
 
     space = MultiDiscrete(nvec=[[2, 3], [3, 2]])
-    with pytest.warns(UserWarning, match="Getting the length of a multi-dimensional MultiDiscrete space."):
+    with pytest.warns(
+        UserWarning,
+        match="Getting the length of a multi-dimensional MultiDiscrete space.",
+    ):
         assert len(space) == 2

--- a/tests/spaces/test_multidiscrete.py
+++ b/tests/spaces/test_multidiscrete.py
@@ -1,3 +1,5 @@
+import pytest
+
 from gym.spaces import Discrete, MultiDiscrete
 from gym.utils.env_checker import data_equivalence
 
@@ -50,3 +52,12 @@ def test_multidiscrete_subspace_reproducibility():
     assert data_equivalence(space[:].sample(), space[:].sample())
     assert data_equivalence(space[:, :].sample(), space[:, :].sample())
     assert data_equivalence(space[:, :].sample(), space.sample())
+
+
+def test_multidiscrete_length():
+    space = MultiDiscrete(nvec=[3, 2, 4])
+    assert len(space) == 3
+
+    space = MultiDiscrete(nvec=[[2, 3], [3, 2]])
+    with pytest.warns(UserWarning, match="Getting the length of a multi-dimensional MultiDiscrete space."):
+        assert len(space) == 2

--- a/tests/spaces/test_multidiscrete.py
+++ b/tests/spaces/test_multidiscrete.py
@@ -1,0 +1,52 @@
+from gym.spaces import Discrete, MultiDiscrete
+from gym.utils.env_checker import data_equivalence
+
+
+def test_multidiscrete_as_tuple():
+    # 1D multi-discrete
+    space = MultiDiscrete([3, 4, 5])
+
+    assert space.shape == (3,)
+    assert space[0] == Discrete(3)
+    assert space[0:1] == MultiDiscrete([3])
+    assert space[0:2] == MultiDiscrete([3, 4])
+    assert space[:] == space and space[:] is not space
+
+    # 2D multi-discrete
+    space = MultiDiscrete([[3, 4, 5], [6, 7, 8]])
+
+    assert space.shape == (2, 3)
+    assert space[0, 1] == Discrete(4)
+    assert space[0] == MultiDiscrete([3, 4, 5])
+    assert space[0:1] == MultiDiscrete([[3, 4, 5]])
+    assert space[0:2, :] == MultiDiscrete([[3, 4, 5], [6, 7, 8]])
+    assert space[:, 0:1] == MultiDiscrete([[3], [6]])
+    assert space[0:2, 0:2] == MultiDiscrete([[3, 4], [6, 7]])
+    assert space[:] == space and space[:] is not space
+    assert space[:, :] == space and space[:, :] is not space
+
+
+def test_multidiscrete_subspace_reproducibility():
+    # 1D multi-discrete
+    space = MultiDiscrete([100, 200, 300])
+    space.seed()
+
+    assert data_equivalence(space[0].sample(), space[0].sample())
+    assert data_equivalence(space[0:1].sample(), space[0:1].sample())
+    assert data_equivalence(space[0:2].sample(), space[0:2].sample())
+    assert data_equivalence(space[:].sample(), space[:].sample())
+    assert data_equivalence(space[:].sample(), space.sample())
+
+    # 2D multi-discrete
+    space = MultiDiscrete([[300, 400, 500], [600, 700, 800]])
+    space.seed()
+
+    assert data_equivalence(space[0, 1].sample(), space[0, 1].sample())
+    assert data_equivalence(space[0].sample(), space[0].sample())
+    assert data_equivalence(space[0:1].sample(), space[0:1].sample())
+    assert data_equivalence(space[0:2, :].sample(), space[0:2, :].sample())
+    assert data_equivalence(space[:, 0:1].sample(), space[:, 0:1].sample())
+    assert data_equivalence(space[0:2, 0:2].sample(), space[0:2, 0:2].sample())
+    assert data_equivalence(space[:].sample(), space[:].sample())
+    assert data_equivalence(space[:, :].sample(), space[:, :].sample())
+    assert data_equivalence(space[:, :].sample(), space.sample())

--- a/tests/spaces/test_space.py
+++ b/tests/spaces/test_space.py
@@ -1,0 +1,24 @@
+from functools import partial
+
+import pytest
+
+from gym import Space
+from gym.spaces import utils
+
+TESTING_SPACE = Space()
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        TESTING_SPACE.sample,
+        partial(TESTING_SPACE.contains, None),
+        partial(utils.flatdim, TESTING_SPACE),
+        partial(utils.flatten, TESTING_SPACE, None),
+        partial(utils.flatten_space, TESTING_SPACE),
+        partial(utils.unflatten, TESTING_SPACE, None),
+    ],
+)
+def test_not_implemented_errors(func):
+    with pytest.raises(NotImplementedError):
+        func()

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -406,10 +406,10 @@ SPACE_KWARGS = [
     {"nvec": [3, 2]},  # MultiDiscrete
     {"n": 2},  # MultiBinary
     {"max_length": 5},  # Text
-    {"spaces": (Discrete(3), Discrete(2))},  # Tuple
-    {"spaces": {"a": Discrete(3), "b": Discrete(2)}},  # Dict
-    {"node_space": Discrete(4), "edge_space": Discrete(3)},  # Graph
-    {"space": Discrete(4)},  # Sequence
+    # {"spaces": (Discrete(3), Discrete(2))},  # Tuple
+    # {"spaces": {"a": Discrete(3), "b": Discrete(2)}},  # Dict
+    # {"node_space": Discrete(4), "edge_space": Discrete(3)},  # Graph
+    # {"space": Discrete(4)},  # Sequence
 ]
 assert len(SPACE_CLS) == len(SPACE_KWARGS)
 

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -1,182 +1,70 @@
 import copy
+import itertools
 import json  # note: ujson fails this test due to float equality
 import pickle
-import string
 import tempfile
 from typing import List, Union
 
 import numpy as np
 import pytest
 
-from gym.spaces import (
-    Box,
-    Dict,
-    Discrete,
-    Graph,
-    MultiBinary,
-    MultiDiscrete,
-    Sequence,
-    Space,
-    Text,
-    Tuple,
+from gym.spaces import Box, Discrete, MultiBinary, MultiDiscrete, Space, Text
+from gym.utils import seeding
+from gym.utils.env_checker import data_equivalence
+from tests.spaces.utils import (
+    TESTING_FUNDAMENTAL_SPACES,
+    TESTING_FUNDAMENTAL_SPACES_IDS,
+    TESTING_SPACES,
+    TESTING_SPACES_IDS,
+)
+
+# Due to this test taking a 1ms each then we don't mind generating so many tests
+# This generates all pairs of spaces of the same type in TESTING_SPACES
+TESTING_SPACES_PERMUTATIONS = list(
+    itertools.chain(
+        *[
+            list(itertools.permutations(list(group), r=2))
+            for key, group in itertools.groupby(
+                TESTING_SPACES, key=lambda space: type(space)
+            )
+        ]
+    )
 )
 
 
-@pytest.mark.parametrize(
-    "space",
-    [
-        Discrete(3),
-        Discrete(5, start=-2),
-        Box(low=0.0, high=np.inf, shape=(2, 2)),
-        Tuple([Discrete(5), Discrete(10)]),
-        Tuple(
-            [
-                Discrete(5),
-                Box(
-                    low=np.array([0.0, 0.0]),
-                    high=np.array([1.0, 5.0]),
-                    dtype=np.float64,
-                ),
-            ]
-        ),
-        Tuple((Discrete(5), Discrete(2), Discrete(2))),
-        Tuple((Discrete(5), Discrete(2, start=6), Discrete(2, start=-4))),
-        MultiDiscrete([2, 2, 100]),
-        MultiBinary(10),
-        Dict(
-            {
-                "position": Discrete(5),
-                "velocity": Box(
-                    low=np.array([0.0, 0.0]),
-                    high=np.array([1.0, 5.0]),
-                    dtype=np.float64,
-                ),
-            }
-        ),
-        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
-        Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
-        Graph(node_space=Discrete(5), edge_space=None),
-        Sequence(Discrete(4)),
-        Sequence(Dict({"feature": Box(0, 1, (3,))})),
-        Text(5),
-        Text(min_length=1, max_length=10, charset=string.digits),
-    ],
-)
-def test_roundtripping(space):
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+def test_roundtripping(space: Space):
+    """Tests if space samples passed to `to_jsonable` and `from_jsonable` produce the original samples."""
     sample_1 = space.sample()
     sample_2 = space.sample()
-    assert space.contains(sample_1)
-    assert space.contains(sample_2)
-    json_rep = space.to_jsonable([sample_1, sample_2])
 
-    json_roundtripped = json.loads(json.dumps(json_rep))
+    # Convert the samples to json, dump + load json and convert back to python
+    sample_json = space.to_jsonable([sample_1, sample_2])
+    sample_roundtripped = json.loads(json.dumps(sample_json))
+    sample_1_prime, sample_2_prime = space.from_jsonable(sample_roundtripped)
 
-    samples_after_roundtrip = space.from_jsonable(json_roundtripped)
-    sample_1_prime, sample_2_prime = samples_after_roundtrip
-
-    s1 = space.to_jsonable([sample_1])
-    s1p = space.to_jsonable([sample_1_prime])
-    s2 = space.to_jsonable([sample_2])
-    s2p = space.to_jsonable([sample_2_prime])
-    assert s1 == s1p, f"Expected {s1} to equal {s1p}"
-    assert s2 == s2p, f"Expected {s2} to equal {s2p}"
+    # Check if the samples are equivalent
+    assert data_equivalence(
+        sample_1, sample_1_prime
+    ), f"sample 1: {sample_1}, prime: {sample_1_prime}"
+    assert data_equivalence(
+        sample_2, sample_2_prime
+    ), f"sample 2: {sample_2}, prime: {sample_2_prime}"
 
 
 @pytest.mark.parametrize(
-    "space",
-    [
-        Discrete(3),
-        Discrete(5, start=-2),
-        Box(low=np.array([-10.0, 0.0]), high=np.array([10.0, 10.0]), dtype=np.float64),
-        Box(low=-np.inf, high=np.inf, shape=(1, 3)),
-        Tuple([Discrete(5), Discrete(10)]),
-        Tuple(
-            [
-                Discrete(5),
-                Box(
-                    low=np.array([0.0, 0.0]),
-                    high=np.array([1.0, 5.0]),
-                    dtype=np.float64,
-                ),
-            ]
-        ),
-        Tuple((Discrete(5), Discrete(2), Discrete(2))),
-        Tuple((Discrete(5), Discrete(2), Discrete(2, start=-6))),
-        MultiDiscrete([2, 2, 100]),
-        MultiBinary(6),
-        Dict(
-            {
-                "position": Discrete(5),
-                "velocity": Box(
-                    low=np.array([0.0, 0.0]),
-                    high=np.array([1.0, 5.0]),
-                    dtype=np.float64,
-                ),
-            }
-        ),
-        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
-        Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
-        Graph(node_space=Discrete(5), edge_space=None),
-        Sequence(Discrete(4)),
-        Sequence(Dict({"feature": Box(0, 1, (3,))})),
-        Text(5),
-        Text(min_length=1, max_length=10, charset=string.digits),
-    ],
+    "space_1,space_2",
+    TESTING_SPACES_PERMUTATIONS,
+    ids=[f"({s1}, {s2})" for s1, s2 in TESTING_SPACES_PERMUTATIONS],
 )
-def test_equality(space):
-    space1 = space
-    space2 = copy.deepcopy(space)
-    assert space1 == space2, f"Expected {space1} to equal {space2}"
+def test_space_equality(space_1, space_2):
+    """Check that `space.__eq__` works.
 
-
-@pytest.mark.parametrize(
-    "spaces",
-    [
-        (Discrete(3), Discrete(4)),
-        (Discrete(3), Discrete(3, start=-1)),
-        (MultiDiscrete([2, 2, 100]), MultiDiscrete([2, 2, 8])),
-        (MultiBinary(8), MultiBinary(7)),
-        (
-            Box(
-                low=np.array([-10.0, 0.0]),
-                high=np.array([10.0, 10.0]),
-                dtype=np.float64,
-            ),
-            Box(
-                low=np.array([-10.0, 0.0]), high=np.array([10.0, 9.0]), dtype=np.float64
-            ),
-        ),
-        (
-            Box(low=-np.inf, high=0.0, shape=(2, 1)),
-            Box(low=0.0, high=np.inf, shape=(2, 1)),
-        ),
-        (Tuple([Discrete(5), Discrete(10)]), Tuple([Discrete(1), Discrete(10)])),
-        (
-            Tuple([Discrete(5), Discrete(10)]),
-            Tuple([Discrete(5, start=7), Discrete(10)]),
-        ),
-        (Dict({"position": Discrete(5)}), Dict({"position": Discrete(4)})),
-        (Dict({"position": Discrete(5)}), Dict({"speed": Discrete(5)})),
-        (
-            Graph(
-                node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)
-            ),
-            Graph(node_space=Discrete(5), edge_space=None),
-        ),
-        (
-            Sequence(Discrete(4)),
-            Sequence(Dict({"feature": Box(0, 1, (3,))})),
-        ),
-        (Sequence(Discrete(4)), Sequence(Discrete(4, start=-1))),
-        (
-            Text(5),
-            Text(min_length=1, max_length=10, charset=string.digits),
-        ),
-    ],
-)
-def test_inequality(spaces):
-    space1, space2 = spaces
-    assert space1 != space2, f"Expected {space1} != {space2}"
+    Testing spaces permutations contains all combinations of testing spaces of the same type.
+    """
+    assert space_1 == space_1
+    assert space_2 == space_2
+    assert space_1 != space_2
 
 
 # The expected sum of variance for an alpha of 0.05
@@ -198,38 +86,27 @@ CHI_SQUARED = np.array(
 
 
 @pytest.mark.parametrize(
-    "space",
-    [
-        Discrete(1),
-        Discrete(5),
-        Discrete(8, start=-20),
-        Box(low=0, high=255, shape=(2,), dtype=np.uint8),
-        Box(low=-np.inf, high=np.inf, shape=(3,)),
-        Box(low=1.0, high=np.inf, shape=(3,)),
-        Box(low=-np.inf, high=2.0, shape=(3,)),
-        Box(low=np.array([0, 2]), high=np.array([10, 4])),
-        MultiDiscrete([3, 5]),
-        MultiDiscrete(np.array([[3, 5], [2, 1]])),
-        MultiBinary([2, 4]),
-    ],
+    "space", TESTING_FUNDAMENTAL_SPACES, ids=TESTING_FUNDAMENTAL_SPACES_IDS
 )
 def test_sample(space: Space, n_trials: int = 1_000):
     """Test the space sample has the expected distribution with the chi-squared test and KS test.
 
-    Example code with scipy.stats.chisquared
+    Example code with scipy.stats.chisquared that should have the same
 
-    import scipy.stats
-    variance = np.sum(np.square(observed_frequency - expected_frequency) / expected_frequency)
-    f'X2 at alpha=0.05 = {scipy.stats.chi2.isf(0.05, df=4)}'
-    f'p-value = {scipy.stats.chi2.sf(variance, df=4)}'
-    scipy.stats.chisquare(f_obs=observed_frequency)
+    >>> import scipy.stats
+    >>> variance = np.sum(np.square(observed_frequency - expected_frequency) / expected_frequency)
+    >>> f'X2 at alpha=0.05 = {scipy.stats.chi2.isf(0.05, df=4)}'
+    >>> f'p-value = {scipy.stats.chi2.sf(variance, df=4)}'
+    >>> scipy.stats.chisquare(f_obs=observed_frequency)
     """
     space.seed(0)
     samples = np.array([space.sample() for _ in range(n_trials)])
     assert len(samples) == n_trials
 
-    # todo add Box space test
-    if isinstance(space, Discrete):
+    if isinstance(space, Box):
+        # TODO: Add KS testing for continuous uniform distribution
+        pass
+    elif isinstance(space, Discrete):
         expected_frequency = np.ones(space.n) * n_trials / space.n
         observed_frequency = np.zeros(space.n)
         for sample in samples:
@@ -292,40 +169,79 @@ def test_sample(space: Space, n_trials: int = 1_000):
                 assert _variance < CHI_SQUARED[_degrees_of_freedom]
 
         _chi_squared_test(space.nvec, expected_frequency, observed_frequency)
+    elif isinstance(space, Text):
+        expected_frequency = (
+            np.ones(len(space.character_set))
+            * n_trials
+            * (space.min_length + (space.max_length - space.min_length) / 2)
+            / len(space.character_set)
+        )
+        observed_frequency = np.zeros(len(space.character_set))
+        for sample in samples:
+            for x in sample:
+                observed_frequency[space.character_index(x)] += 1
+        degrees_of_freedom = len(space.character_set) - 1
+
+        assert observed_frequency.shape == expected_frequency.shape
+        assert np.sum(observed_frequency) == sum(len(sample) for sample in samples)
+
+        variance = np.sum(
+            np.square(expected_frequency - observed_frequency) / expected_frequency
+        )
+        if degrees_of_freedom == 61:
+            # scipy.stats.chi2.isf(0.05, df=61)
+            assert variance < 80.23209784876272
+        else:
+            assert variance < CHI_SQUARED[degrees_of_freedom]
+    else:
+        raise NotImplementedError(f"Unknown sample testing for {type(space)}")
+
+
+SAMPLE_MASK_RNG, _ = seeding.np_random(1)
 
 
 @pytest.mark.parametrize(
     "space,mask",
-    [
-        (Discrete(5), np.array([0, 1, 1, 0, 1], dtype=np.int8)),
-        (Discrete(4, start=-20), np.array([1, 1, 0, 1], dtype=np.int8)),
-        (Discrete(4, start=1), np.array([0, 0, 0, 0], dtype=np.int8)),
-        (MultiBinary([3, 2]), np.array([[0, 1], [1, 1], [0, 0]], dtype=np.int8)),
-        (
-            MultiDiscrete([5, 3]),
+    itertools.zip_longest(
+        TESTING_FUNDAMENTAL_SPACES,
+        [
+            # Discrete
+            np.array([1, 1, 0], dtype=np.int8),
+            np.array([0, 1, 0], dtype=np.int8),
+            # Box
+            None,
+            None,
+            None,
+            None,
+            None,
+            # Multi-discrete
+            (np.array([1, 1], dtype=np.int8), np.array([0, 0], dtype=np.int8)),
             (
-                np.array([0, 1, 1, 0, 1], dtype=np.int8),
-                np.array([0, 1, 1], dtype=np.int8),
+                (np.array([1, 0], dtype=np.int8), np.array([0, 1, 1], dtype=np.int8)),
+                (np.array([1, 1, 0], dtype=np.int8), np.array([0, 1], dtype=np.int8)),
             ),
-        ),
-        (
-            MultiDiscrete(np.array([4, 2])),
-            (np.array([0, 0, 0, 0], dtype=np.int8), np.array([1, 1], dtype=np.int8)),
-        ),
-        (
-            MultiDiscrete(np.array([[2, 2], [4, 3]])),
-            (
-                (np.array([0, 1], dtype=np.int8), np.array([1, 1], dtype=np.int8)),
-                (
-                    np.array([0, 1, 1, 0], dtype=np.int8),
-                    np.array([1, 0, 0], dtype=np.int8),
-                ),
-            ),
-        ),
-    ],
+            # Multi-binary
+            np.array([0, 1, 1, 1, 0, 0, 1, 1], dtype=np.int8),
+            np.array([[0, 1, 1], [0, 0, 1]], dtype=np.int8),
+            # Text
+            (None, SAMPLE_MASK_RNG.integers(low=0, high=2, size=62, dtype=np.int8)),
+            (4, SAMPLE_MASK_RNG.integers(low=0, high=2, size=62, dtype=np.int8)),
+            (None, np.array([1, 1, 0, 1, 0, 0], dtype=np.int8)),
+        ],
+    ),
+    ids=TESTING_FUNDAMENTAL_SPACES_IDS,
 )
-def test_space_sample_mask(space, mask, n_trials: int = 100):
-    """Test the space sample with mask works using the pearson chi-squared test."""
+def test_space_sample_mask(space: Space, mask, n_trials: int = 100):
+    """Tests that the sampling a space with a mask has the expected distribution.
+
+    The implemented code is similar to the `test_space_sample` that considers the mask applied.
+    """
+    if isinstance(space, Box):
+        # The box space can't have a sample mask
+        assert mask is None
+        return
+    assert mask is not None
+
     space.seed(1)
     samples = np.array([space.sample(mask) for _ in range(n_trials)])
 
@@ -415,621 +331,147 @@ def test_space_sample_mask(space, mask, n_trials: int = 100):
                 assert _variance < CHI_SQUARED[_degrees_of_freedom]
 
         _chi_squared_test(space.nvec, mask, expected_frequency, observed_frequency)
+    elif isinstance(space, Text):
+        length, charlist_mask = mask
+
+        if length is None:
+            expected_length = (
+                space.min_length + (space.max_length - space.min_length) / 2
+            )
+        else:
+            expected_length = length
+
+        if np.any(charlist_mask == 1):
+            expected_frequency = (
+                np.ones(len(space.character_set))
+                * n_trials
+                * expected_length
+                / np.sum(charlist_mask)
+                * charlist_mask
+            )
+        else:
+            expected_frequency = np.zeros(len(space.character_set))
+
+        observed_frequency = np.zeros(len(space.character_set))
+        for sample in samples:
+            for char in sample:
+                observed_frequency[space.character_index(char)] += 1
+
+        degrees_of_freedom = max(np.sum(charlist_mask) - 1, 0)
+
+        assert observed_frequency.shape == expected_frequency.shape
+        assert np.sum(observed_frequency) == sum(len(sample) for sample in samples)
+
+        variance = np.sum(
+            np.square(expected_frequency - observed_frequency)
+            / np.clip(expected_frequency, 1, None)
+        )
+        if degrees_of_freedom == 26:
+            # scipy.stats.chi2.isf(0.05, df=29)
+            assert variance < 38.88513865983007
+        elif degrees_of_freedom == 31:
+            # scipy.stats.chi2.isf(0.05, df=31)
+            assert variance < 44.985343280365136
+        else:
+            assert variance < CHI_SQUARED[degrees_of_freedom]
     else:
         raise NotImplementedError()
 
 
-@pytest.mark.parametrize(
-    "space,mask",
-    [
-        (
-            Dict(a=Discrete(2), b=MultiDiscrete([2, 4])),
-            {
-                "a": np.array([0, 1], dtype=np.int8),
-                "b": (
-                    np.array([0, 1], dtype=np.int8),
-                    np.array([1, 1, 0, 0], dtype=np.int8),
-                ),
-            },
-        ),
-        (
-            Tuple([Box(0, 1, ()), Discrete(3), MultiBinary([2, 1])]),
-            (
-                None,
-                np.array([0, 1, 0], dtype=np.int8),
-                np.array([[0], [1]], dtype=np.int8),
-            ),
-        ),
-        (
-            Dict(a=Tuple([Box(0, 1, ()), Discrete(3)]), b=Discrete(3)),
-            {
-                "a": (None, np.array([1, 0, 0], dtype=np.int8)),
-                "b": np.array([0, 1, 1], dtype=np.int8),
-            },
-        ),
-        (Graph(node_space=Discrete(5), edge_space=Discrete(3)), None),
-        (
-            Graph(node_space=Discrete(3), edge_space=Box(low=0, high=1, shape=(5,))),
-            None,
-        ),
-        (
-            Graph(
-                node_space=Box(low=-100, high=100, shape=(3,)), edge_space=Discrete(3)
-            ),
-            None,
-        ),
-        (Sequence(Discrete(2)), (None, np.array([0, 1], dtype=np.int8))),
-        (
-            Sequence(Discrete(2)),
-            (np.array([2, 3, 4], dtype=np.int8), np.array([0, 1], dtype=np.int8)),
-        ),
-        (Sequence(Discrete(2)), (np.array([2, 3, 4], dtype=np.int8), None)),
-        (Sequence(Discrete(2)), (None, None)),
-        (Sequence(Discrete(2)), None),
-    ],
-)
-def test_composite_space_sample_mask(space, mask):
-    """Test that composite space samples use the mask correctly."""
-    space.sample(mask)
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+def test_seed_reproducibility(space):
+    """Test that the set the space seed will reproduce the same samples."""
+    space_1 = space
+    space_2 = copy.deepcopy(space)
 
-
-@pytest.mark.parametrize(
-    "spaces",
-    [
-        (Discrete(5), MultiBinary(5)),
-        (
-            Box(
-                low=np.array([-10.0, 0.0]),
-                high=np.array([10.0, 10.0]),
-                dtype=np.float64,
-            ),
-            MultiDiscrete([2, 2, 8]),
-        ),
-        (
-            Box(low=0, high=255, shape=(64, 64, 3), dtype=np.uint8),
-            Box(low=0, high=255, shape=(32, 32, 3), dtype=np.uint8),
-        ),
-        (Dict({"position": Discrete(5)}), Tuple([Discrete(5)])),
-        (Dict({"position": Discrete(5)}), Discrete(5)),
-        (Tuple((Discrete(5),)), Discrete(5)),
-        (
-            Box(low=np.array([-np.inf, 0.0]), high=np.array([0.0, np.inf])),
-            Box(low=np.array([-np.inf, 1.0]), high=np.array([0.0, np.inf])),
-        ),
-        (
-            Graph(
-                node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)
-            ),
-            Graph(node_space=Discrete(5), edge_space=None),
-        ),
-        (Sequence(Discrete(4)), Sequence(Discrete(3))),
-        (
-            Text(5),
-            Text(min_length=1, max_length=10, charset=string.digits),
-        ),
-    ],
-)
-def test_class_inequality(spaces):
-    assert spaces[0] == spaces[0]
-    assert spaces[1] == spaces[1]
-    assert spaces[0] != spaces[1]
-    assert spaces[1] != spaces[0]
-
-
-@pytest.mark.parametrize(
-    "space_fn",
-    [
-        lambda: Dict(space1="abc"),
-        lambda: Dict({"space1": "abc"}),
-        lambda: Tuple(["abc"]),
-    ],
-)
-def test_bad_space_calls(space_fn):
-    with pytest.raises(AssertionError):
-        space_fn()
-
-
-def test_seed_Dict():
-    test_space = Dict(
-        {
-            "a": Box(low=0, high=1, shape=(3, 3)),
-            "b": Dict(
-                {
-                    "b_1": Box(low=-100, high=100, shape=(2,)),
-                    "b_2": Box(low=-1, high=1, shape=(2,)),
-                }
-            ),
-            "c": Discrete(5),
-        }
-    )
-
-    seed_dict = {
-        "a": 0,
-        "b": {
-            "b_1": 1,
-            "b_2": 2,
-        },
-        "c": 3,
-    }
-
-    test_space.seed(seed_dict)
-
-    # "Unpack" the dict sub-spaces into individual spaces
-    a = Box(low=0, high=1, shape=(3, 3))
-    a.seed(0)
-    b_1 = Box(low=-100, high=100, shape=(2,))
-    b_1.seed(1)
-    b_2 = Box(low=-1, high=1, shape=(2,))
-    b_2.seed(2)
-    c = Discrete(5)
-    c.seed(3)
-
-    for i in range(10):
-        test_s = test_space.sample()
-        a_s = a.sample()
-        assert (test_s["a"] == a_s).all()
-        b_1_s = b_1.sample()
-        assert (test_s["b"]["b_1"] == b_1_s).all()
-        b_2_s = b_2.sample()
-        assert (test_s["b"]["b_2"] == b_2_s).all()
-        c_s = c.sample()
-        assert test_s["c"] == c_s
-
-
-def test_box_dtype_check():
-    # Related Issues:
-    # https://github.com/openai/gym/issues/2357
-    # https://github.com/openai/gym/issues/2298
-
-    space = Box(0, 2, tuple(), dtype=np.float32)
-
-    # casting will match the correct type
-    assert space.contains(np.array(0.5, dtype=np.float32))
-
-    # float64 is not in float32 space
-    assert not space.contains(np.array(0.5))
-    assert not space.contains(np.array(1))
-
-
-@pytest.mark.parametrize(
-    "space",
-    [
-        Discrete(3),
-        Discrete(3, start=-4),
-        Box(low=0.0, high=np.inf, shape=(2, 2)),
-        Tuple([Discrete(5), Discrete(10)]),
-        Tuple(
-            [
-                Discrete(5),
-                Box(
-                    low=np.array([0.0, 0.0]),
-                    high=np.array([1.0, 5.0]),
-                    dtype=np.float64,
-                ),
-            ]
-        ),
-        Tuple((Discrete(5), Discrete(2), Discrete(2))),
-        MultiDiscrete([2, 2, 100]),
-        MultiBinary(10),
-        Dict(
-            {
-                "position": Discrete(5),
-                "velocity": Box(
-                    low=np.array([0.0, 0.0]),
-                    high=np.array([1.0, 5.0]),
-                    dtype=np.float64,
-                ),
-            }
-        ),
-        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
-        Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
-        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=None),
-        Graph(node_space=Discrete(5), edge_space=None),
-        Sequence(Discrete(4)),
-        Sequence(Dict({"a": Box(0, 1), "b": Discrete(3)})),
-        Text(5),
-        Text(min_length=1, max_length=10, charset=string.digits),
-    ],
-)
-def test_seed_returns_list(space):
-    def assert_integer_list(seed):
-        assert isinstance(seed, list)
-        assert len(seed) >= 1
-        assert all([isinstance(s, int) for s in seed])
-
-    assert_integer_list(space.seed(None))
-    assert_integer_list(space.seed(0))
-
-
-def convert_sample_hashable(sample):
-    if isinstance(sample, np.ndarray):
-        return tuple(sample.tolist())
-    if isinstance(sample, (list, tuple)):
-        return tuple(convert_sample_hashable(s) for s in sample)
-    if isinstance(sample, dict):
-        return tuple(
-            (key, convert_sample_hashable(value)) for key, value in sample.items()
+    for seed in range(5):
+        assert space_1.seed(seed) == space_2.seed(seed)
+        # With the same seed, the two spaces should be identical
+        assert all(
+            data_equivalence(space_1.sample(), space_2.sample()) for _ in range(10)
         )
 
-    return sample
+    assert space_1.seed(123) != space_2.seed(456)
+    # Due to randomness, it is difficult to test that random seeds produce different answers
+    #   Therefore, taking 10 samples and checking that they are not all the same.
+    assert not all(
+        data_equivalence(space_1.sample(), space_2.sample()) for _ in range(10)
+    )
 
 
-def sample_equal(sample1, sample2):
-    return convert_sample_hashable(sample1) == convert_sample_hashable(sample2)
-
-
-@pytest.mark.parametrize(
-    "space",
-    [
-        Discrete(3),
-        Discrete(3, start=-4),
-        Box(low=0.0, high=np.inf, shape=(2, 2)),
-        Tuple([Discrete(5), Discrete(10)]),
-        Tuple(
-            [
-                Discrete(5),
-                Box(
-                    low=np.array([0.0, 0.0]),
-                    high=np.array([1.0, 5.0]),
-                    dtype=np.float64,
-                ),
-            ]
-        ),
-        Tuple((Discrete(5), Discrete(2), Discrete(2))),
-        MultiDiscrete([2, 2, 100]),
-        MultiBinary(10),
-        Dict(
-            {
-                "position": Discrete(5),
-                "velocity": Box(
-                    low=np.array([0.0, 0.0]),
-                    high=np.array([1.0, 5.0]),
-                    dtype=np.float64,
-                ),
-            }
-        ),
-        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
-        Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
-        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=None),
-        Graph(node_space=Discrete(5), edge_space=None),
-        Sequence(Discrete(4)),
-        Sequence(Dict({"a": Box(0, 1), "b": Discrete(3)})),
-        Text(5),
-        Text(min_length=1, max_length=10, charset=string.digits),
-    ],
-)
-def test_seed_reproducibility(space):
-    space1 = space
-    space2 = copy.deepcopy(space)
-
-    space1.seed(None)
-    space2.seed(None)
-
-    assert space1.seed(0) == space2.seed(0)
-    assert sample_equal(space1.sample(), space2.sample())
+SPACE_CLS = list(dict.fromkeys(type(space) for space in TESTING_SPACES))
+SPACE_KWARGS = [
+    {"n": 3},  # Discrete
+    {"low": 1, "high": 10},  # Box
+    {"nvec": [3, 2]},  # MultiDiscrete
+    {"n": 2},  # MultiBinary
+    {"max_length": 5},  # Text
+    {"spaces": (Discrete(3), Discrete(2))},  # Tuple
+    {"spaces": {"a": Discrete(3), "b": Discrete(2)}},  # Dict
+    {"node_space": Discrete(4), "edge_space": Discrete(3)},  # Graph
+    {"space": Discrete(4)},  # Sequence
+]
+assert len(SPACE_CLS) == len(SPACE_KWARGS)
 
 
 @pytest.mark.parametrize(
-    "space",
-    [
-        Tuple([Discrete(100), Discrete(100)]),
-        Tuple([Discrete(5), Discrete(10)]),
-        Tuple([Discrete(5), Discrete(5, start=10)]),
-        Tuple(
-            [
-                Discrete(5),
-                Box(
-                    low=np.array([0.0, 0.0]),
-                    high=np.array([1.0, 5.0]),
-                    dtype=np.float64,
-                ),
-            ]
-        ),
-        Tuple((Discrete(5), Discrete(2), Discrete(2))),
-        Dict(
-            {
-                "position": Discrete(5),
-                "velocity": Box(
-                    low=np.array([0.0, 0.0]),
-                    high=np.array([1.0, 5.0]),
-                    dtype=np.float64,
-                ),
-            }
-        ),
-        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
-        Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
-        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=None),
-        Graph(node_space=Discrete(5), edge_space=None),
-        Text(5),
-        Text(min_length=1, max_length=10, charset=string.digits),
-    ],
+    "space_cls,kwarg",
+    list(zip(SPACE_CLS, SPACE_KWARGS)),
+    ids=[f"{space_cls}" for space_cls in SPACE_CLS],
 )
-def test_seed_subspace_incorrelated(space):
-    subspaces = []
-    if isinstance(space, Tuple):
-        subspaces = space.spaces
-    elif isinstance(space, Dict):
-        subspaces = space.spaces.values()
-    elif isinstance(space, Graph):
-        if space.edge_space is not None:
-            subspaces = [space.node_space, space.edge_space]
-        else:
-            subspaces = [space.node_space]
+def test_seed_np_random(space_cls, kwarg):
+    """During initialisation of a space, a rng instance can be passed to the space.
 
+    Test that the space's `np_random` is the rng instance
+    """
+    rng, _ = seeding.np_random(123)
+
+    space = space_cls(seed=rng, **kwarg)
+    assert space.np_random is rng
+
+
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+def test_sample_contains(space):
+    """Test that samples are contained within the space.
+
+    Then test that for all other spaces, we test that an error is not raise with a sample and a bool is returned.
+    As other spaces can be contained with this space, we cannot test that the contains is always true or false.
+    """
+    for _ in range(10):
+        sample = space.sample()
+        assert sample in space
+        assert space.contains(sample)
+
+    for other_space in TESTING_SPACES:
+        assert isinstance(space.contains(other_space.sample()), bool)
+
+
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+def test_repr(space):
+    assert isinstance(str(space), str)
+
+
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+def test_space_pickling(space):
+    """Tests the spaces can be pickled with the unpickled version being equivalent to the original."""
     space.seed(0)
-    states = [
-        convert_sample_hashable(subspace.np_random.bit_generator.state)
-        for subspace in subspaces
-    ]
-
-    assert len(states) == len(set(states))
-
-
-def test_tuple():
-    spaces = [Discrete(5), Discrete(10), Discrete(5)]
-    space_tuple = Tuple(spaces)
-
-    assert len(space_tuple) == len(spaces)
-    assert space_tuple.count(Discrete(5)) == 2
-    assert space_tuple.count(MultiBinary(2)) == 0
-    for i, space in enumerate(space_tuple):
-        assert space == spaces[i]
-    for i, space in enumerate(reversed(space_tuple)):
-        assert space == spaces[len(spaces) - 1 - i]
-    assert space_tuple.index(Discrete(5)) == 0
-    assert space_tuple.index(Discrete(5), 1) == 2
-    with pytest.raises(ValueError):
-        space_tuple.index(Discrete(10), 0, 1)
-
-
-def test_multidiscrete_as_tuple():
-    # 1D multi-discrete
-    space = MultiDiscrete([3, 4, 5])
-
-    assert space.shape == (3,)
-    assert space[0] == Discrete(3)
-    assert space[0:1] == MultiDiscrete([3])
-    assert space[0:2] == MultiDiscrete([3, 4])
-    assert space[:] == space and space[:] is not space
-    assert len(space) == 3
-
-    # 2D multi-discrete
-    space = MultiDiscrete([[3, 4, 5], [6, 7, 8]])
-
-    assert space.shape == (2, 3)
-    assert space[0, 1] == Discrete(4)
-    assert space[0] == MultiDiscrete([3, 4, 5])
-    assert space[0:1] == MultiDiscrete([[3, 4, 5]])
-    assert space[0:2, :] == MultiDiscrete([[3, 4, 5], [6, 7, 8]])
-    assert space[:, 0:1] == MultiDiscrete([[3], [6]])
-    assert space[0:2, 0:2] == MultiDiscrete([[3, 4], [6, 7]])
-    assert space[:] == space and space[:] is not space
-    assert space[:, :] == space and space[:, :] is not space
-
-
-def test_multidiscrete_subspace_reproducibility():
-    # 1D multi-discrete
-    space = MultiDiscrete([100, 200, 300])
-    space.seed(None)
-
-    assert sample_equal(space[0].sample(), space[0].sample())
-    assert sample_equal(space[0:1].sample(), space[0:1].sample())
-    assert sample_equal(space[0:2].sample(), space[0:2].sample())
-    assert sample_equal(space[:].sample(), space[:].sample())
-    assert sample_equal(space[:].sample(), space.sample())
-
-    # 2D multi-discrete
-    space = MultiDiscrete([[300, 400, 500], [600, 700, 800]])
-    space.seed(None)
-
-    assert sample_equal(space[0, 1].sample(), space[0, 1].sample())
-    assert sample_equal(space[0].sample(), space[0].sample())
-    assert sample_equal(space[0:1].sample(), space[0:1].sample())
-    assert sample_equal(space[0:2, :].sample(), space[0:2, :].sample())
-    assert sample_equal(space[:, 0:1].sample(), space[:, 0:1].sample())
-    assert sample_equal(space[0:2, 0:2].sample(), space[0:2, 0:2].sample())
-    assert sample_equal(space[:].sample(), space[:].sample())
-    assert sample_equal(space[:, :].sample(), space[:, :].sample())
-    assert sample_equal(space[:, :].sample(), space.sample())
-
-
-def test_space_legacy_state_pickling():
-    legacy_state = {
-        "shape": (
-            1,
-            2,
-            3,
-        ),
-        "dtype": np.int64,
-        "np_random": np.random.default_rng(),
-        "n": 3,
-    }
-    space = Discrete(1)
-    space.__setstate__(legacy_state)
-
-    assert space.shape == legacy_state["shape"]
-    assert space._shape == legacy_state["shape"]  # pyright: reportPrivateUsage=false
-    assert space.np_random == legacy_state["np_random"]
-    assert (
-        space._np_random == legacy_state["np_random"]
-    )  # pyright: reportPrivateUsage=false
-    assert space.n == 3
-    assert space.dtype == legacy_state["dtype"]
-
-
-@pytest.mark.parametrize(
-    "space",
-    [
-        Box(low=0, high=np.inf, shape=(2,), dtype=np.int32),
-        Box(low=0, high=np.inf, shape=(2,), dtype=np.float32),
-        Box(low=0, high=np.inf, shape=(2,), dtype=np.int64),
-        Box(low=0, high=np.inf, shape=(2,), dtype=np.float64),
-        Box(low=-np.inf, high=0, shape=(2,), dtype=np.int32),
-        Box(low=-np.inf, high=0, shape=(2,), dtype=np.float32),
-        Box(low=-np.inf, high=0, shape=(2,), dtype=np.int64),
-        Box(low=-np.inf, high=0, shape=(2,), dtype=np.float64),
-        Box(low=-np.inf, high=np.inf, shape=(2,), dtype=np.int32),
-        Box(low=-np.inf, high=np.inf, shape=(2,), dtype=np.float32),
-        Box(low=-np.inf, high=np.inf, shape=(2,), dtype=np.int64),
-        Box(low=-np.inf, high=np.inf, shape=(2,), dtype=np.float64),
-        Box(low=0, high=np.inf, shape=(2, 3), dtype=np.int32),
-        Box(low=0, high=np.inf, shape=(2, 3), dtype=np.float32),
-        Box(low=0, high=np.inf, shape=(2, 3), dtype=np.int64),
-        Box(low=0, high=np.inf, shape=(2, 3), dtype=np.float64),
-        Box(low=-np.inf, high=0, shape=(2, 3), dtype=np.int32),
-        Box(low=-np.inf, high=0, shape=(2, 3), dtype=np.float32),
-        Box(low=-np.inf, high=0, shape=(2, 3), dtype=np.int64),
-        Box(low=-np.inf, high=0, shape=(2, 3), dtype=np.float64),
-        Box(low=-np.inf, high=np.inf, shape=(2, 3), dtype=np.int32),
-        Box(low=-np.inf, high=np.inf, shape=(2, 3), dtype=np.float32),
-        Box(low=-np.inf, high=np.inf, shape=(2, 3), dtype=np.int64),
-        Box(low=-np.inf, high=np.inf, shape=(2, 3), dtype=np.float64),
-        Box(low=np.array([-np.inf, 0]), high=np.array([0.0, np.inf]), dtype=np.int32),
-        Box(low=np.array([-np.inf, 0]), high=np.array([0.0, np.inf]), dtype=np.float32),
-        Box(low=np.array([-np.inf, 0]), high=np.array([0.0, np.inf]), dtype=np.int64),
-        Box(low=np.array([-np.inf, 0]), high=np.array([0.0, np.inf]), dtype=np.float64),
-    ],
-)
-def test_infinite_space(space):
-    # for this test, make sure that spaces that are passed in have only 0 or infinite bounds
-    # because space.high and space.low are both modified within the init
-    # so we check for infinite when we know it's not 0
-    space.seed(0)
-
-    assert np.all(space.high > space.low), "High bound not higher than low bound"
-
-    sample = space.sample()
-
-    # check if space contains sample
-    assert space.contains(
-        sample
-    ), "Sample {sample} not inside space according to `space.contains()`"
-
-    # manually check that the sign of the sample is within the bounds
-    assert np.all(
-        np.sign(space.high) >= np.sign(sample)
-    ), f"Sign of sample {sample} is less than space upper bound {space.high}"
-    assert np.all(
-        np.sign(space.low) <= np.sign(sample)
-    ), f"Sign of sample {sample} is more than space lower bound {space.low}"
-
-    # check that int bounds are bounded for everything
-    # but floats are unbounded for infinite
-    if np.any(space.high != 0):
-        assert (
-            space.is_bounded("above") is False
-        ), "inf upper bound supposed to be unbounded"
-    else:
-        assert (
-            space.is_bounded("above") is True
-        ), "non-inf upper bound supposed to be bounded"
-
-    if np.any(space.low != 0):
-        assert (
-            space.is_bounded("below") is False
-        ), "inf lower bound supposed to be unbounded"
-    else:
-        assert (
-            space.is_bounded("below") is True
-        ), "non-inf lower bound supposed to be bounded"
-
-    # check for dtype
-    assert (
-        space.high.dtype == space.dtype
-    ), "High's dtype {space.high.dtype} doesn't match `space.dtype`'"
-    assert (
-        space.low.dtype == space.dtype
-    ), "Low's dtype {space.high.dtype} doesn't match `space.dtype`'"
-
-
-def test_discrete_legacy_state_pickling():
-    legacy_state = {
-        "n": 3,
-    }
-
-    d = Discrete(1)
-    assert "start" in d.__dict__
-    del d.__dict__["start"]  # legacy did not include start param
-    assert "start" not in d.__dict__
-
-    d.__setstate__(legacy_state)
-
-    assert d.start == 0
-    assert d.n == 3
-
-
-def test_box_legacy_state_pickling():
-    legacy_state = {
-        "dtype": np.dtype("float32"),
-        "_shape": (5,),
-        "low": np.array([0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32),
-        "high": np.array([1.0, 1.0, 1.0, 1.0, 1.0], dtype=np.float32),
-        "bounded_below": np.array([True, True, True, True, True]),
-        "bounded_above": np.array([True, True, True, True, True]),
-        "_np_random": None,
-    }
-
-    b = Box(-1, 1, ())
-    assert "low_repr" in b.__dict__ and "high_repr" in b.__dict__
-    del b.__dict__["low_repr"]
-    del b.__dict__["high_repr"]
-    assert "low_repr" not in b.__dict__ and "high_repr" not in b.__dict__
-
-    b.__setstate__(legacy_state)
-    assert b.low_repr == "0.0"
-    assert b.high_repr == "1.0"
-
-
-@pytest.mark.parametrize(
-    "space",
-    [
-        Discrete(3),
-        Discrete(5, start=-2),
-        Box(low=0.0, high=np.inf, shape=(2, 2)),
-        Tuple([Discrete(5), Discrete(10)]),
-        Tuple(
-            [
-                Discrete(5),
-                Box(low=np.array([0.0, 0.0]), high=np.array([1, 5]), dtype=np.float64),
-            ]
-        ),
-        Tuple((Discrete(5), Discrete(2), Discrete(2))),
-        Tuple((Discrete(5), Discrete(2, start=6), Discrete(2, start=-4))),
-        MultiDiscrete([2, 2, 100]),
-        MultiBinary(10),
-        Dict(
-            {
-                "position": Discrete(5),
-                "velocity": Box(
-                    low=np.array([0.0, 0.0]), high=np.array([1, 5]), dtype=np.float64
-                ),
-            }
-        ),
-        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
-        Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
-        Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=None),
-        Graph(node_space=Discrete(5), edge_space=None),
-        Sequence(Discrete(4)),
-        Sequence(Dict({"a": Box(0, 1), "b": Discrete(3)})),
-        Text(5),
-        Text(min_length=1, max_length=10, charset=string.digits),
-    ],
-)
-def test_pickle(space):
-    space.sample()
 
     # Pickle and unpickle with a string
-    pickled = pickle.dumps(space)
-    space2 = pickle.loads(pickled)
+    pickled_space = pickle.dumps(space)
+    unpickled_space = pickle.loads(pickled_space)
+    assert space == unpickled_space
 
     # Pickle and unpickle with a file
     with tempfile.TemporaryFile() as f:
         pickle.dump(space, f)
         f.seek(0)
-        space3 = pickle.load(f)
+        file_unpickled_space = pickle.load(f)
 
-    sample = space.sample()
-    sample2 = space2.sample()
-    sample3 = space3.sample()
-    assert sample_equal(sample, sample2)
-    assert sample_equal(sample, sample3)
+    assert space == file_unpickled_space
+
+    # Check that space samples are the same
+    space_sample = space.sample()
+    unpickled_sample = unpickled_space.sample()
+    file_unpickled_sample = file_unpickled_space.sample()
+    assert data_equivalence(space_sample, unpickled_sample)
+    assert data_equivalence(space_sample, file_unpickled_sample)

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -207,7 +207,7 @@ SAMPLE_MASK_RNG, _ = seeding.np_random(1)
         [
             # Discrete
             np.array([1, 1, 0], dtype=np.int8),
-            np.array([0, 1, 0], dtype=np.int8),
+            np.array([0, 0, 0], dtype=np.int8),
             # Box
             None,
             None,

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -221,8 +221,8 @@ SAMPLE_MASK_RNG, _ = seeding.np_random(1)
                 (np.array([1, 1, 0], dtype=np.int8), np.array([0, 1], dtype=np.int8)),
             ),
             # Multi-binary
-            np.array([0, 1, 1, 1, 0, 0, 1, 1], dtype=np.int8),
-            np.array([[0, 1, 1], [0, 0, 1]], dtype=np.int8),
+            np.array([0, 1, 0, 1, 0, 2, 1, 1], dtype=np.int8),
+            np.array([[0, 1, 2], [0, 2, 1]], dtype=np.int8),
             # Text
             (None, SAMPLE_MASK_RNG.integers(low=0, high=2, size=62, dtype=np.int8)),
             (4, SAMPLE_MASK_RNG.integers(low=0, high=2, size=62, dtype=np.int8)),
@@ -265,7 +265,10 @@ def test_space_sample_mask(space: Space, mask, n_trials: int = 100):
         )
         assert variance < CHI_SQUARED[degrees_of_freedom]
     elif isinstance(space, MultiBinary):
-        expected_frequency = np.ones(space.shape) * mask * (n_trials / 2)
+        expected_frequency = (
+            np.ones(space.shape) * np.where(mask == 2, 0.5, mask) * n_trials
+        )
+        print(expected_frequency)
         observed_frequency = np.sum(samples, axis=0)
         assert space.shape == expected_frequency.shape == observed_frequency.shape
 

--- a/tests/spaces/test_text.py
+++ b/tests/spaces/test_text.py
@@ -18,11 +18,18 @@ def test_sample_mask():
     assert sample in space
     assert 1 <= len(sample) <= 5
 
-    with pytest.raises(ValueError, match=re.escape("Trying to sample with a minimum length > 0 (1) but the character mask is all zero meaning that no character could be sampled.")):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Trying to sample with a minimum length > 0 (1) but the character mask is all zero meaning that no character could be sampled."
+        ),
+    ):
         space.sample(mask=(3, np.zeros(len(space.character_set), dtype=np.int8)))
 
     space = Text(min_length=0, max_length=5)
-    sample = space.sample(mask=(None, np.zeros(len(space.character_set), dtype=np.int8)))
+    sample = space.sample(
+        mask=(None, np.zeros(len(space.character_set), dtype=np.int8))
+    )
     assert sample in space
     assert sample == ""
 

--- a/tests/spaces/test_text.py
+++ b/tests/spaces/test_text.py
@@ -1,0 +1,34 @@
+import re
+
+import numpy as np
+import pytest
+
+from gym.spaces import Text
+
+
+def test_sample_mask():
+    space = Text(min_length=1, max_length=5)
+
+    # Test the sample length
+    sample = space.sample(mask=(3, None))
+    assert sample in space
+    assert len(sample) == 3
+
+    sample = space.sample(mask=None)
+    assert sample in space
+    assert 1 <= len(sample) <= 5
+
+    with pytest.raises(ValueError, match=re.escape("Trying to sample with a minimum length > 0 (1) but the character mask is all zero meaning that no character could be sampled.")):
+        space.sample(mask=(3, np.zeros(len(space.character_set), dtype=np.int8)))
+
+    space = Text(min_length=0, max_length=5)
+    sample = space.sample(mask=(None, np.zeros(len(space.character_set), dtype=np.int8)))
+    assert sample in space
+    assert sample == ""
+
+    # Test the sample characters
+    space = Text(max_length=5, charset="abcd")
+
+    sample = space.sample(mask=(3, np.array([0, 1, 0, 0], dtype=np.int8)))
+    assert sample in space
+    assert sample == "bbb"

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -1,601 +1,135 @@
-import re
-from collections import OrderedDict
+from itertools import zip_longest
+from typing import Optional
 
 import numpy as np
 import pytest
 
-from gym.spaces import (
-    Box,
-    Dict,
-    Discrete,
-    Graph,
-    GraphInstance,
-    MultiBinary,
-    MultiDiscrete,
-    Sequence,
-    Tuple,
-    utils,
-)
+import gym
+from gym.spaces import Box, Graph, utils
+from gym.utils.env_checker import data_equivalence
+from tests.spaces.utils import TESTING_SPACES, TESTING_SPACES_IDS
 
-homogeneous_spaces = [
-    Discrete(3),
-    Box(low=0.0, high=np.inf, shape=(2, 2)),
-    Box(low=0.0, high=np.inf, shape=(2, 2), dtype=np.float16),
-    Tuple([Discrete(5), Discrete(10)]),
-    Tuple(
-        [
-            Discrete(5),
-            Box(low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64),
-        ]
-    ),
-    Tuple((Discrete(5), Discrete(2), Discrete(2))),
-    MultiDiscrete([2, 2, 10]),
-    MultiBinary(10),
-    Dict(
-        {
-            "position": Discrete(5),
-            "velocity": Box(
-                low=np.array([0.0, 0.0]), high=np.array([1.0, 5.0]), dtype=np.float64
-            ),
-        }
-    ),
-    Discrete(3, start=2),
-    Discrete(8, start=-5),
-]
-
-flatdims = [3, 4, 4, 15, 7, 9, 14, 10, 7, 3, 8]
-
-non_homogenous_spaces = [
-    Graph(node_space=Box(low=-100, high=100, shape=(2, 2)), edge_space=Discrete(5)),  #
-    Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(2, 2))),  #
-    Graph(node_space=Discrete(5), edge_space=None),  #
-    Sequence(Discrete(4)),  #
-    Sequence(Box(-10, 10, shape=(2, 2))),  #
-    Sequence(Tuple([Box(-10, 10, shape=(2,)), Box(-10, 10, shape=(2,))])),  #
-    Dict(a=Sequence(Discrete(4)), b=Box(-10, 10, shape=(2, 2))),  #
-    Dict(
-        a=Graph(node_space=Discrete(4), edge_space=Discrete(4)),
-        b=Box(-10, 10, shape=(2, 2)),
-    ),  #
-    Tuple([Sequence(Discrete(4)), Box(-10, 10, shape=(2, 2))]),  #
-    Tuple(
-        [
-            Graph(node_space=Discrete(4), edge_space=Discrete(4)),
-            Box(-10, 10, shape=(2, 2)),
-        ]
-    ),  #
-    Sequence(Graph(node_space=Box(-100, 100, shape=(2, 2)), edge_space=Discrete(4))),  #
-    Dict(
-        a=Dict(
-            a=Sequence(Box(-100, 100, shape=(2, 2))), b=Box(-100, 100, shape=(2, 2))
-        ),
-        b=Tuple([Box(-100, 100, shape=(2,)), Box(-100, 100, shape=(2,))]),
-    ),  #
-    Dict(
-        a=Dict(
-            a=Graph(node_space=Box(-100, 100, shape=(2, 2)), edge_space=None),
-            b=Box(-100, 100, shape=(2, 2)),
-        ),
-        b=Tuple([Box(-100, 100, shape=(2,)), Box(-100, 100, shape=(2,))]),
-    ),
-]
-
-
-@pytest.mark.parametrize("space", non_homogenous_spaces)
-def test_non_flattenable(space):
-    assert space.is_np_flattenable is False
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "cannot be flattened to a numpy array, probably because it contains a `Graph` or `Sequence` subspace"
-        ),
-    ):
-        utils.flatdim(space)
-
-
-@pytest.mark.parametrize(["space", "flatdim"], zip(homogeneous_spaces, flatdims))
-def test_flatdim(space, flatdim):
-    assert space.is_np_flattenable
-    dim = utils.flatdim(space)
-    assert dim == flatdim, f"Expected {dim} to equal {flatdim}"
-
-
-@pytest.mark.parametrize("space", homogeneous_spaces)
-def test_flatten_space_boxes(space):
-    flat_space = utils.flatten_space(space)
-    assert isinstance(flat_space, Box), f"Expected {type(flat_space)} to equal {Box}"
-    flatdim = utils.flatdim(space)
-    (single_dim,) = flat_space.shape
-    assert single_dim == flatdim, f"Expected {single_dim} to equal {flatdim}"
-
-
-@pytest.mark.parametrize("space", homogeneous_spaces + non_homogenous_spaces)
-def test_flat_space_contains_flat_points(space):
-    some_samples = [space.sample() for _ in range(10)]
-    flattened_samples = [utils.flatten(space, sample) for sample in some_samples]
-    flat_space = utils.flatten_space(space)
-    for i, flat_sample in enumerate(flattened_samples):
-        assert flat_space.contains(
-            flat_sample
-        ), f"Expected sample #{i} {flat_sample} to be in {flat_space}"
-
-
-@pytest.mark.parametrize("space", homogeneous_spaces)
-def test_flatten_dim(space):
-    sample = utils.flatten(space, space.sample())
-    (single_dim,) = sample.shape
-    flatdim = utils.flatdim(space)
-    assert single_dim == flatdim, f"Expected {single_dim} to equal {flatdim}"
-
-
-@pytest.mark.parametrize("space", homogeneous_spaces + non_homogenous_spaces)
-def test_flatten_roundtripping(space):
-    some_samples = [space.sample() for _ in range(10)]
-    flattened_samples = [utils.flatten(space, sample) for sample in some_samples]
-    roundtripped_samples = [
-        utils.unflatten(space, sample) for sample in flattened_samples
-    ]
-    for i, (original, roundtripped) in enumerate(
-        zip(some_samples, roundtripped_samples)
-    ):
-        assert compare_nested(
-            original, roundtripped
-        ), f"Expected sample #{i} {original} to equal {roundtripped}"
-        assert space.contains(roundtripped)
-
-
-def compare_nested(left, right):
-    if type(left) != type(right):
-        return False
-    elif isinstance(left, np.ndarray) and isinstance(right, np.ndarray):
-        return left.shape == right.shape and np.allclose(left, right)
-    elif isinstance(left, OrderedDict) and isinstance(right, OrderedDict):
-        res = len(left) == len(right)
-        for ((left_key, left_value), (right_key, right_value)) in zip(
-            left.items(), right.items()
-        ):
-            if not res:
-                return False
-            res = left_key == right_key and compare_nested(left_value, right_value)
-        return res
-    elif isinstance(left, (tuple, list)) and isinstance(right, (tuple, list)):
-        res = len(left) == len(right)
-        for (x, y) in zip(left, right):
-            if not res:
-                return False
-            res = compare_nested(x, y)
-        return res
-    else:
-        return left == right
-
-
-"""
-Expecteded flattened types are based off:
-1. The type that the space is hardcoded as(ie. multi_discrete=np.int64, discrete=np.int64, multi_binary=np.int8)
-2. The type that the space is instantiated with(ie. box=np.float32 by default unless instantiated with a different type)
-3. The smallest type that the composite space(tuple, dict) can be represented as. In flatten, this is determined
-   internally by numpy when np.concatenate is called.
-"""
-
-expected_flattened_dtypes = [
-    np.int64,
-    np.float32,
-    np.float16,
-    np.int64,
-    np.float64,
-    np.int64,
-    np.int64,
-    np.int8,
-    np.float64,
-    np.int64,
-    np.int64,
-]
-
-
-@pytest.mark.parametrize(
-    ["original_space", "expected_flattened_dtype"],
-    zip(homogeneous_spaces, expected_flattened_dtypes),
-)
-def test_dtypes(original_space, expected_flattened_dtype):
-    flattened_space = utils.flatten_space(original_space)
-
-    original_sample = original_space.sample()
-    flattened_sample = utils.flatten(original_space, original_sample)
-    unflattened_sample = utils.unflatten(original_space, flattened_sample)
-
-    assert flattened_space.contains(
-        flattened_sample
-    ), "Expected flattened_space to contain flattened_sample"
-    assert (
-        flattened_space.dtype == expected_flattened_dtype
-    ), f"Expected flattened_space's dtype to equal {expected_flattened_dtype}"
-
-    assert flattened_sample.dtype == flattened_space.dtype, (
-        "Expected flattened_space's dtype to equal " "flattened_sample's dtype "
-    )
-
-    compare_sample_types(original_space, original_sample, unflattened_sample)
-
-
-def compare_sample_types(original_space, original_sample, unflattened_sample):
-    if isinstance(original_space, Discrete):
-        assert isinstance(unflattened_sample, int), (
-            "Expected unflattened_sample to be an int. unflattened_sample: "
-            "{} original_sample: {}".format(unflattened_sample, original_sample)
-        )
-    elif isinstance(original_space, Tuple):
-        for index in range(len(original_space)):
-            compare_sample_types(
-                original_space.spaces[index],
-                original_sample[index],
-                unflattened_sample[index],
-            )
-    elif isinstance(original_space, Dict):
-        for key, space in original_space.spaces.items():
-            compare_sample_types(space, original_sample[key], unflattened_sample[key])
-    else:
-        assert unflattened_sample.dtype == original_sample.dtype, (
-            "Expected unflattened_sample's dtype to equal "
-            "original_sample's dtype. unflattened_sample: "
-            "{} original_sample: {}".format(unflattened_sample, original_sample)
-        )
-
-
-homogeneous_samples = [
-    2,
-    np.array([[1.0, 3.0], [5.0, 8.0]], dtype=np.float32),
-    np.array([[1.0, 3.0], [5.0, 8.0]], dtype=np.float16),
-    (3, 7),
-    (2, np.array([0.5, 3.5], dtype=np.float32)),
-    (3, 0, 1),
-    np.array([0, 1, 7], dtype=np.int64),
-    np.array([0, 1, 1, 0, 0, 0, 1, 1, 1, 1], dtype=np.int8),
-    OrderedDict(
-        [("position", 3), ("velocity", np.array([0.5, 3.5], dtype=np.float32))]
-    ),
+TESTING_SPACES_EXPECTED_FLATDIMS = [
+    # Discrete
     3,
-    -2,
-]
-
-
-expected_flattened_hom_samples = [
-    np.array([0, 0, 1], dtype=np.int64),
-    np.array([1.0, 3.0, 5.0, 8.0], dtype=np.float32),
-    np.array([1.0, 3.0, 5.0, 8.0], dtype=np.float16),
-    np.array([0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0], dtype=np.int64),
-    np.array([0, 0, 1, 0, 0, 0.5, 3.5], dtype=np.float64),
-    np.array([0, 0, 0, 1, 0, 1, 0, 0, 1], dtype=np.int64),
-    np.array([1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0], dtype=np.int64),
-    np.array([0, 1, 1, 0, 0, 0, 1, 1, 1, 1], dtype=np.int8),
-    np.array([0, 0, 0, 1, 0, 0.5, 3.5], dtype=np.float64),
-    np.array([0, 1, 0], dtype=np.int64),
-    np.array([0, 0, 0, 1, 0, 0, 0, 0], dtype=np.int64),
-]
-
-non_homogenous_samples = [
-    GraphInstance(
-        np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=np.float32),
-        np.array(
-            [
-                0,
-            ],
-            dtype=int,
-        ),
-        np.array([[0, 1]], dtype=int),
-    ),
-    GraphInstance(
-        np.array([0, 1], dtype=int),
-        np.array([[[1, 2], [3, 4]]], dtype=np.float32),
-        np.array([[0, 1]], dtype=int),
-    ),
-    GraphInstance(np.array([0, 1], dtype=int), None, np.array([[0, 1]], dtype=int)),
-    (0, 1, 2),
-    (
-        np.array([[0, 1], [2, 3]], dtype=np.float32),
-        np.array([[4, 5], [6, 7]], dtype=np.float32),
-    ),
-    (
-        (np.array([0, 1], dtype=np.float32), np.array([2, 3], dtype=np.float32)),
-        (np.array([4, 5], dtype=np.float32), np.array([6, 7], dtype=np.float32)),
-    ),
-    OrderedDict(
-        [("a", (0, 1, 2)), ("b", np.array([[0, 1], [2, 3]], dtype=np.float32))]
-    ),
-    OrderedDict(
-        [
-            (
-                "a",
-                GraphInstance(
-                    np.array([1, 2], dtype=np.int),
-                    np.array(
-                        [
-                            0,
-                        ],
-                        dtype=int,
-                    ),
-                    np.array([[0, 1]], dtype=int),
-                ),
-            ),
-            ("b", np.array([[0, 1], [2, 3]], dtype=np.float32)),
-        ]
-    ),
-    ((0, 1, 2), np.array([[0, 1], [2, 3]], dtype=np.float32)),
-    (
-        GraphInstance(
-            np.array([1, 2], dtype=np.int),
-            np.array(
-                [
-                    0,
-                ],
-                dtype=int,
-            ),
-            np.array([[0, 1]], dtype=int),
-        ),
-        np.array([[0, 1], [2, 3]], dtype=np.float32),
-    ),
-    (
-        GraphInstance(
-            nodes=np.array([[[0, 1], [2, 3]], [[4, 5], [6, 7]]], dtype=np.float32),
-            edges=np.array([0], dtype=int),
-            edge_links=np.array([[0, 1]]),
-        ),
-        GraphInstance(
-            nodes=np.array(
-                [[[8, 9], [10, 11]], [[12, 13], [14, 15]]], dtype=np.float32
-            ),
-            edges=np.array([1], dtype=int),
-            edge_links=np.array([[0, 1]]),
-        ),
-    ),
-    OrderedDict(
-        [
-            (
-                "a",
-                OrderedDict(
-                    [
-                        (
-                            "a",
-                            (
-                                np.array([[0, 1], [2, 3]], dtype=np.float32),
-                                np.array([[4, 5], [6, 7]], dtype=np.float32),
-                            ),
-                        ),
-                        ("b", np.array([[8, 9], [10, 11]], dtype=np.float32)),
-                    ]
-                ),
-            ),
-            (
-                "b",
-                (
-                    np.array([12, 13], dtype=np.float32),
-                    np.array([14, 15], dtype=np.float32),
-                ),
-            ),
-        ]
-    ),
-    OrderedDict(
-        [
-            (
-                "a",
-                OrderedDict(
-                    [
-                        (
-                            "a",
-                            GraphInstance(
-                                np.array(
-                                    [[[1, 2], [3, 4]], [[5, 6], [7, 8]]],
-                                    dtype=np.float32,
-                                ),
-                                None,
-                                np.array([[0, 1]], dtype=int),
-                            ),
-                        ),
-                        ("b", np.array([[8, 9], [10, 11]], dtype=np.float32)),
-                    ]
-                ),
-            ),
-            (
-                "b",
-                (
-                    np.array([12, 13], dtype=np.float32),
-                    np.array([14, 15], dtype=np.float32),
-                ),
-            ),
-        ]
-    ),
-]
-
-
-expected_flattened_non_hom_samples = [
-    GraphInstance(
-        np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=np.float32),
-        np.array([[1, 0, 0, 0, 0]], dtype=int),
-        np.array([[0, 1]], dtype=int),
-    ),
-    GraphInstance(
-        np.array([[1, 0, 0, 0, 0], [0, 1, 0, 0, 0]], dtype=int),
-        np.array([[1, 2, 3, 4]], dtype=np.float32),
-        np.array([[0, 1]], dtype=int),
-    ),
-    GraphInstance(
-        np.array([[1, 0, 0, 0, 0], [0, 1, 0, 0, 0]], dtype=int),
-        None,
-        np.array([[0, 1]], dtype=int),
-    ),
-    (
-        np.array([1, 0, 0, 0], dtype=int),
-        np.array([0, 1, 0, 0], dtype=int),
-        np.array([0, 0, 1, 0], dtype=int),
-    ),
-    (
-        np.array([0, 1, 2, 3], dtype=np.float32),
-        np.array([4, 5, 6, 7], dtype=np.float32),
-    ),
-    (
-        np.array([0, 1, 2, 3], dtype=np.float32),
-        np.array([4, 5, 6, 7], dtype=np.float32),
-    ),
-    OrderedDict(
-        [
-            (
-                "a",
-                (
-                    np.array([1, 0, 0, 0], dtype=int),
-                    np.array([0, 1, 0, 0], dtype=int),
-                    np.array([0, 0, 1, 0], dtype=int),
-                ),
-            ),
-            ("b", np.array([0, 1, 2, 3], dtype=np.float32)),
-        ]
-    ),
-    OrderedDict(
-        [
-            (
-                "a",
-                GraphInstance(
-                    np.array([[0, 1, 0, 0], [0, 0, 1, 0]], dtype=int),
-                    np.array([[1, 0, 0, 0]], dtype=int),
-                    np.array([[0, 1]], dtype=int),
-                ),
-            ),
-            ("b", np.array([0, 1, 2, 3], dtype=np.float32)),
-        ]
-    ),
-    (
-        (
-            np.array([1, 0, 0, 0], dtype=int),
-            np.array([0, 1, 0, 0], dtype=int),
-            np.array([0, 0, 1, 0], dtype=int),
-        ),
-        np.array([0, 1, 2, 3], dtype=np.float32),
-    ),
-    (
-        GraphInstance(
-            np.array([[0, 1, 0, 0], [0, 0, 1, 0]], dtype=np.float32),
-            np.array([[1, 0, 0, 0]], dtype=int),
-            np.array([[0, 1]], dtype=int),
-        ),
-        np.array([0, 1, 2, 3], dtype=np.float32),
-    ),
-    (
-        GraphInstance(
-            np.array([[0, 1, 2, 3], [4, 5, 6, 7]], dtype=np.float32),
-            np.array([[1, 0, 0, 0]]),
-            np.array([[0, 1]]),
-        ),
-        GraphInstance(
-            np.array([[8, 9, 10, 11], [12, 13, 14, 15]], dtype=np.float32),
-            np.array([[0, 1, 0, 0]]),
-            np.array([[0, 1]]),
-        ),
-    ),
-    OrderedDict(
-        [
-            (
-                "a",
-                OrderedDict(
-                    [
-                        (
-                            "a",
-                            (
-                                np.array([0, 1, 2, 3], dtype=np.float32),
-                                np.array([4, 5, 6, 7], dtype=np.float32),
-                            ),
-                        ),
-                        ("b", np.array([8, 9, 10, 11], dtype=np.float32)),
-                    ]
-                ),
-            ),
-            ("b", (np.array([12, 13, 14, 15], dtype=np.float32))),
-        ]
-    ),
-    OrderedDict(
-        [
-            (
-                "a",
-                OrderedDict(
-                    [
-                        (
-                            "a",
-                            GraphInstance(
-                                np.array(
-                                    [[1, 2, 3, 4], [5, 6, 7, 8]], dtype=np.float32
-                                ),
-                                None,
-                                np.array([[0, 1]], dtype=int),
-                            ),
-                        ),
-                        ("b", np.array([8, 9, 10, 11], dtype=np.float32)),
-                    ]
-                ),
-            ),
-            ("b", (np.array([12, 13, 14, 15], dtype=np.float32))),
-        ]
-    ),
+    3,
+    # Box
+    1,
+    4,
+    2,
+    2,
+    2,
+    # Multi-discrete
+    4,
+    10,
+    # Multi-binary
+    8,
+    6,
+    # Text
+    6,
+    6,
+    6,
+    # # Tuple
+    # 9,
+    # 7,
+    # 10,
+    # 6,
+    # None,
+    # # Dict
+    # 7,
+    # 8,
+    # 17,
+    # None,
+    # # Graph
+    # None,
+    # None,
+    # None,
+    # # Sequence
+    # None,
+    # None,
+    # None,
 ]
 
 
 @pytest.mark.parametrize(
-    ["space", "sample", "expected_flattened_sample"],
-    zip(
-        homogeneous_spaces + non_homogenous_spaces,
-        homogeneous_samples + non_homogenous_samples,
-        expected_flattened_hom_samples + expected_flattened_non_hom_samples,
-    ),
+    ["space", "flatdim"],
+    zip_longest(TESTING_SPACES, TESTING_SPACES_EXPECTED_FLATDIMS),
+    ids=TESTING_SPACES_IDS,
 )
-def test_flatten(space, sample, expected_flattened_sample):
-    flattened_sample = utils.flatten(space, sample)
+def test_flatdim(space: gym.spaces.Space, flatdim: Optional[int]):
+    """Checks that the flattened dims of the space is equal to an expected value."""
+    if space.is_np_flattenable:
+        dim = utils.flatdim(space)
+        assert dim == flatdim, f"Expected {dim} to equal {flatdim}"
+    else:
+        with pytest.raises(
+            ValueError,
+        ):
+            utils.flatdim(space)
+
+
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+def test_flatten_space(space):
+    """Test that the flattened spaces are a box and have the `flatdim` shape."""
     flat_space = utils.flatten_space(space)
 
-    assert sample in space
-    assert flattened_sample in flat_space
+    if space.is_np_flattenable:
+        assert isinstance(flat_space, Box)
+        (single_dim,) = flat_space.shape
+        flatdim = utils.flatdim(space)
+
+        assert single_dim == flatdim
+    elif isinstance(flat_space, Graph):
+        assert isinstance(space, Graph)
+
+        (node_single_dim,) = flat_space.node_space.shape
+        node_flatdim = utils.flatdim(space.node_space)
+        assert node_single_dim == node_flatdim
+
+        if flat_space.edge_space is not None:
+            (edge_single_dim,) = flat_space.edge_space.shape
+            edge_flatdim = utils.flatdim(space.edge_space)
+            assert edge_single_dim == edge_flatdim
+    else:
+        assert isinstance(
+            space, (gym.spaces.Tuple, gym.spaces.Dict, gym.spaces.Sequence)
+        )
+
+
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+def test_flatten(space):
+    """Test that a flattened sample have the `flatdim` shape."""
+    flattened_sample = utils.flatten(space, space.sample())
 
     if space.is_np_flattenable:
         assert isinstance(flattened_sample, np.ndarray)
-        assert flattened_sample.shape == expected_flattened_sample.shape
-        assert flattened_sample.dtype == expected_flattened_sample.dtype
-        assert np.all(flattened_sample == expected_flattened_sample)
+        (single_dim,) = flattened_sample.shape
+        flatdim = utils.flatdim(space)
+
+        assert single_dim == flatdim
     else:
-        assert not isinstance(flattened_sample, np.ndarray)
-        assert compare_nested(flattened_sample, expected_flattened_sample)
+        assert isinstance(flattened_sample, (tuple, dict, Graph))
 
 
-@pytest.mark.parametrize(
-    ["space", "flattened_sample", "expected_sample"],
-    zip(homogeneous_spaces, expected_flattened_hom_samples, homogeneous_samples),
-)
-def test_unflatten(space, flattened_sample, expected_sample):
-    sample = utils.unflatten(space, flattened_sample)
-    assert compare_nested(sample, expected_sample)
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+def test_flat_space_contains_flat_points(space):
+    """Test that the flattened samples are contained within the flattened space."""
+    flattened_samples = [utils.flatten(space, space.sample()) for _ in range(10)]
+    flat_space = utils.flatten_space(space)
+
+    for flat_sample in flattened_samples:
+        assert flat_sample in flat_space
 
 
-expected_flattened_spaces = [
-    Box(low=0, high=1, shape=(3,), dtype=np.int64),
-    Box(low=0.0, high=np.inf, shape=(4,), dtype=np.float32),
-    Box(low=0.0, high=np.inf, shape=(4,), dtype=np.float16),
-    Box(low=0, high=1, shape=(15,), dtype=np.int64),
-    Box(
-        low=np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64),
-        high=np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 5.0], dtype=np.float64),
-        dtype=np.float64,
-    ),
-    Box(low=0, high=1, shape=(9,), dtype=np.int64),
-    Box(low=0, high=1, shape=(14,), dtype=np.int64),
-    Box(low=0, high=1, shape=(10,), dtype=np.int8),
-    Box(
-        low=np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float64),
-        high=np.array([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 5.0], dtype=np.float64),
-        dtype=np.float64,
-    ),
-    Box(low=0, high=1, shape=(3,), dtype=np.int64),
-    Box(low=0, high=1, shape=(8,), dtype=np.int64),
-]
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+def test_flatten_roundtripping(space):
+    """Tests roundtripping with flattening and unflattening are equal to the original sample."""
+    samples = [space.sample() for _ in range(10)]
 
+    flattened_samples = [utils.flatten(space, sample) for sample in samples]
+    unflattened_samples = [
+        utils.unflatten(space, sample) for sample in flattened_samples
+    ]
 
-@pytest.mark.parametrize(
-    ["space", "expected_flattened_space"],
-    zip(homogeneous_spaces, expected_flattened_spaces),
-)
-def test_flatten_space(space, expected_flattened_space):
-    flattened_space = utils.flatten_space(space)
-    assert flattened_space == expected_flattened_space
+    for original, roundtripped in zip(samples, unflattened_samples):
+        assert data_equivalence(original, roundtripped)

--- a/tests/spaces/utils.py
+++ b/tests/spaces/utils.py
@@ -1,0 +1,27 @@
+from typing import List
+
+import numpy as np
+
+from gym.spaces import Box, Discrete, MultiBinary, MultiDiscrete, Space, Text
+
+TESTING_FUNDAMENTAL_SPACES = [
+    Discrete(3),
+    Discrete(3, start=-1),
+    Box(low=0.0, high=1.0),
+    Box(low=0.0, high=np.inf, shape=(2, 2)),
+    Box(low=np.array([-10.0, 0.0]), high=np.array([10.0, 10.0]), dtype=np.float64),
+    Box(low=-np.inf, high=0.0, shape=(2, 1)),
+    Box(low=0.0, high=np.inf, shape=(2, 1)),
+    MultiDiscrete([2, 2]),
+    MultiDiscrete([[2, 3], [3, 2]]),
+    MultiBinary(8),
+    MultiBinary([2, 3]),
+    Text(6),
+    Text(min_length=3, max_length=6),
+    Text(6, charset="abcdef"),
+]
+TESTING_FUNDAMENTAL_SPACES_IDS = [f"{space}" for space in TESTING_FUNDAMENTAL_SPACES]
+
+
+TESTING_SPACES: List[Space] = TESTING_FUNDAMENTAL_SPACES  # + TESTING_COMPOSITE_SPACES
+TESTING_SPACES_IDS = TESTING_FUNDAMENTAL_SPACES_IDS  # + TESTING_COMPOSITE_SPACES_IDS


### PR DESCRIPTION
Update all of the fundamental spaces (`Box`, `Discrete`, `MultiDiscrete`, `MultiBinary`, `Text`) with full coverage
This is the second part of https://github.com/openai/gym/pull/2977 split into two

These tests now provide 100% coverage for all of the fundamental spaces

1. Update `Discrete.contains` to use `np.issubdtype` instead of `np.typecodes ` as this assumes to be a undocumented feature in numpy
2. Fix `Discrete.__setstate__` such that the state is set once
3. Add feature (/ bug fix) to `MultiBinary.sample` to have both 0, 1 and 2 for necessary 0 or 1 with 2 representing random
4. Make `MultiBinary.contains` to be positive (not negative) checks
5. Bug fix `MultiBinary.from_jsonable` with use the correct dtype
6. Fix type hints in `MultiDiscrete`
7. Change `MultiDiscrete.sample` to assume that the `nvec` is correct over the users mask
8. Make `MultiDiscrete.contains` to use positive (not negative) checks
9. Correctly implement `Text.sample` with masks
10. Add `Text` property changes for private variables: `_char_set`, `_char_list`, `_char_index`
11. Add util support for `Text` with the flattened character being the index in the character set.
12. Remove space-specific tests from `test_space` in favour of individual testing files. 
13. Add `tests/spaces/utils.py` where all testing spaces can be added such that new spaces added to `TESTING_SPACES` can be automatically added to all tests. 