### PR TITLE
Replace all references to gymlibrary.ml domain with new .dev address

### DIFF
--- a/gym/utils/env_checker.py
+++ b/gym/utils/env_checker.py
@@ -256,7 +256,7 @@ def check_env(env: gym.Env, warn: bool = None, skip_render_check: bool = False):
     This is an invasive function that calls the environment's reset and step.
 
     This is particularly useful when using a custom environment.
-    Please take a look at https://www.gymlibrary.ml/content/environment_creation/
+    Please take a look at https://www.gymlibrary.dev/content/environment_creation/
     for more information about the API.
 
     Args:
@@ -269,7 +269,7 @@ def check_env(env: gym.Env, warn: bool = None, skip_render_check: bool = False):
 
     assert isinstance(
         env, gym.Env
-    ), "The environment must inherit from the gym.Env class. See https://www.gymlibrary.ml/content/environment_creation/ for more info."
+    ), "The environment must inherit from the gym.Env class. See https://www.gymlibrary.dev/content/environment_creation/ for more info."
 
     if env.unwrapped is not env:
         logger.warn(
@@ -279,13 +279,13 @@ def check_env(env: gym.Env, warn: bool = None, skip_render_check: bool = False):
     # ============= Check the spaces (observation and action) ================
     assert hasattr(
         env, "action_space"
-    ), "The environment must specify an action space. See https://www.gymlibrary.ml/content/environment_creation/ for more info."
+    ), "The environment must specify an action space. See https://www.gymlibrary.dev/content/environment_creation/ for more info."
     check_action_space(env.action_space)
     check_space_limit(env.action_space, "action")
 
     assert hasattr(
         env, "observation_space"
-    ), "The environment must specify an observation space. See https://www.gymlibrary.ml/content/environment_creation/ for more info."
+    ), "The environment must specify an observation space. See https://www.gymlibrary.dev/content/environment_creation/ for more info."
     check_observation_space(env.observation_space)
     check_space_limit(env.observation_space, "observation")
 

--- a/gym/wrappers/env_checker.py
+++ b/gym/wrappers/env_checker.py
@@ -19,11 +19,11 @@ class PassiveEnvChecker(gym.Wrapper):
 
         assert hasattr(
             env, "action_space"
-        ), "The environment must specify an action space. https://www.gymlibrary.ml/content/environment_creation/"
+        ), "The environment must specify an action space. https://www.gymlibrary.dev/content/environment_creation/"
         check_action_space(env.action_space)
         assert hasattr(
             env, "observation_space"
-        ), "The environment must specify an observation space. https://www.gymlibrary.ml/content/environment_creation/"
+        ), "The environment must specify an observation space. https://www.gymlibrary.dev/content/environment_creation/"
         check_observation_space(env.observation_space)
 
         self.checked_reset = False

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     },
     python_requires=">=3.6",
     tests_require=extras["testing"],
-    url="https://www.gymlibrary.ml/",
+    url="https://www.gymlibrary.dev/",
     version=VERSION,
     zip_safe=False,
 )

--- a/tests/utils/test_env_checker.py
+++ b/tests/utils/test_env_checker.py
@@ -244,15 +244,15 @@ def test_check_reset_options():
     [
         [
             "Error",
-            "The environment must inherit from the gym.Env class. See https://www.gymlibrary.ml/content/environment_creation/ for more info.",
+            "The environment must inherit from the gym.Env class. See https://www.gymlibrary.dev/content/environment_creation/ for more info.",
         ],
         [
             GenericTestEnv(action_space=None),
-            "The environment must specify an action space. See https://www.gymlibrary.ml/content/environment_creation/ for more info.",
+            "The environment must specify an action space. See https://www.gymlibrary.dev/content/environment_creation/ for more info.",
         ],
         [
             GenericTestEnv(observation_space=None),
-            "The environment must specify an observation space. See https://www.gymlibrary.ml/content/environment_creation/ for more info.",
+            "The environment must specify an observation space. See https://www.gymlibrary.dev/content/environment_creation/ for more info.",
         ],
     ],
 )

--- a/tests/wrappers/test_passive_env_checker.py
+++ b/tests/wrappers/test_passive_env_checker.py
@@ -35,7 +35,7 @@ def test_passive_checker_wrapper_warnings(env):
     [
         (
             GenericTestEnv(action_space=None),
-            "The environment must specify an action space. https://www.gymlibrary.ml/content/environment_creation/",
+            "The environment must specify an action space. https://www.gymlibrary.dev/content/environment_creation/",
         ),
         (
             GenericTestEnv(action_space="error"),
@@ -43,7 +43,7 @@ def test_passive_checker_wrapper_warnings(env):
         ),
         (
             GenericTestEnv(observation_space=None),
-            "The environment must specify an observation space. https://www.gymlibrary.ml/content/environment_creation/",
+            "The environment must specify an observation space. https://www.gymlibrary.dev/content/environment_creation/",
         ),
         (
             GenericTestEnv(observation_space="error"),


### PR DESCRIPTION
# Description
As you write on your README, the `gymlibrary.ml` domain is no longer available, however there are still references in the code. This is one example:
``` bash
/home/vscode/.local/lib/python3.10/site-packages/gym/core.py:43: DeprecationWarning: WARN: The argument mode in render method is deprecated; use render_mode during environment initialization instead.
See here for more information: https://www.gymlibrary.ml/content/api/
  deprecation(
```
## Type of change

Please delete options that are not relevant.
- [x ] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
