### PR TITLE
Correct the module scope of DeprecationWarning warning filter

### DIFF
--- a/gym/logger.py
+++ b/gym/logger.py
@@ -14,7 +14,8 @@ DISABLED = 50
 min_level = 30
 
 
-warnings.simplefilter("once", DeprecationWarning)
+# Ensure DeprecationWarning to be displayed (#2685, #3059)
+warnings.filterwarnings("once", "", DeprecationWarning, module=r"^gym\.")
 
 
 def set_level(level: int):


### PR DESCRIPTION
# Description

This line mistakenly voids and nullifies all the previous warning filters for DeprecationWarning, registered by other packages or user programs via `warnings.simplefilter("ignore", DeprecationWarning, ...)` call which has an explicit intention of suppress some DeprecationWarning.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

N/A


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
