### PR TITLE
Add a complete compatibility wrapper

### DIFF
--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -490,7 +490,7 @@ def register(
         order_enforce=order_enforce,
         autoreset=autoreset,
         disable_env_checker=disable_env_checker,
-        apply_step_compatibility=apply_api_compatibility,
+        apply_api_compatibility=apply_api_compatibility,
         **kwargs,
     )
     _check_spec_register(new_spec)
@@ -517,8 +517,8 @@ def make(
         autoreset: Whether to automatically reset the environment after each episode (AutoResetWrapper).
         apply_api_compatibility: Whether to wrap the environment with the `StepAPICompatibility` wrapper that
             converts the environment step from a done bool to return termination and truncation bools.
-            By default, the argument is None to which the environment specification `apply_step_compatibility` is used
-            which defaults to False. Otherwise, the value of `apply_step_compatibility` is used.
+            By default, the argument is None to which the environment specification `apply_api_compatibility` is used
+            which defaults to False. Otherwise, the value of `apply_api_compatibility` is used.
             If `True`, the wrapper is applied otherwise, the wrapper is not applied.
         disable_env_checker: If to run the env checker, None will default to the environment specification `disable_env_checker`
             (which is by default False, running the environment checker),

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -26,9 +26,9 @@ from gym.wrappers import (
     HumanRendering,
     OrderEnforcing,
     RenderCollection,
-    StepAPICompatibility,
     TimeLimit,
 )
+from gym.wrappers.compatibility import EnvCompatibility
 from gym.wrappers.env_checker import PassiveEnvChecker
 
 if sys.version_info < (3, 10):
@@ -658,7 +658,7 @@ def make(
     if apply_step_compatibility is True or (
         apply_step_compatibility is None and spec_.apply_step_compatibility is True
     ):
-        env = StepAPICompatibility(env, output_truncation_bool=True)
+        env = EnvCompatibility(env)
 
     # Add the order enforcing wrapper
     if spec_.order_enforce:

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -628,6 +628,14 @@ def make(
                 f"The environment creator metadata doesn't include `render_modes`, contains: {list(env_creator.metadata.keys())}"
             )
 
+    if apply_api_compatibility is True or (
+        apply_api_compatibility is None and spec_.apply_api_compatibility is True
+    ):
+        # If we use the compatibility layer, we treat the render mode explicitly and don't pass it to the env creator
+        render_mode = _kwargs.pop("render_mode", None)
+    else:
+        render_mode = None
+
     try:
         env = env_creator(**_kwargs)
     except TypeError as e:
@@ -652,7 +660,7 @@ def make(
     if apply_api_compatibility is True or (
         apply_api_compatibility is None and spec_.apply_api_compatibility is True
     ):
-        env = EnvCompatibility(env)
+        env = EnvCompatibility(env, render_mode)
 
     # Run the environment checker as the lowest level wrapper
     if disable_env_checker is False or (

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -141,7 +141,7 @@ class EnvSpec:
     order_enforce: bool = field(default=True)
     autoreset: bool = field(default=False)
     disable_env_checker: bool = field(default=False)
-    apply_step_compatibility: bool = field(default=False)
+    apply_api_compatibility: bool = field(default=False)
 
     # Environment arguments
     kwargs: dict = field(default_factory=dict)
@@ -440,7 +440,7 @@ def register(
     order_enforce: bool = True,
     autoreset: bool = False,
     disable_env_checker: bool = False,
-    apply_step_compatibility: bool = False,
+    apply_api_compatibility: bool = False,
     **kwargs,
 ):
     """Register an environment with gym.
@@ -459,7 +459,7 @@ def register(
         order_enforce: If to enable the order enforcer wrapper to ensure users run functions in the correct order
         autoreset: If to add the autoreset wrapper such that reset does not need to be called.
         disable_env_checker: If to disable the environment checker for the environment. Recommended to False.
-        apply_step_compatibility: If to apply the `StepAPICompatibility` wrapper.
+        apply_api_compatibility: If to apply the `StepAPICompatibility` wrapper.
         **kwargs: arbitrary keyword arguments which are passed to the environment constructor
     """
     global registry, current_namespace
@@ -490,7 +490,7 @@ def register(
         order_enforce=order_enforce,
         autoreset=autoreset,
         disable_env_checker=disable_env_checker,
-        apply_step_compatibility=apply_step_compatibility,
+        apply_step_compatibility=apply_api_compatibility,
         **kwargs,
     )
     _check_spec_register(new_spec)
@@ -656,7 +656,7 @@ def make(
 
     # Add step API wrapper
     if apply_api_compatibility is True or (
-        apply_api_compatibility is None and spec_.apply_step_compatibility is True
+        apply_api_compatibility is None and spec_.apply_api_compatibility is True
     ):
         env = EnvCompatibility(env)
 

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -648,17 +648,17 @@ def make(
     spec_.kwargs = _kwargs
     env.unwrapped.spec = spec_
 
-    # Run the environment checker as the lowest level wrapper
-    if disable_env_checker is False or (
-        disable_env_checker is None and spec_.disable_env_checker is False
-    ):
-        env = PassiveEnvChecker(env)
-
     # Add step API wrapper
     if apply_api_compatibility is True or (
         apply_api_compatibility is None and spec_.apply_api_compatibility is True
     ):
         env = EnvCompatibility(env)
+
+    # Run the environment checker as the lowest level wrapper
+    if disable_env_checker is False or (
+        disable_env_checker is None and spec_.disable_env_checker is False
+    ):
+        env = PassiveEnvChecker(env)
 
     # Add the order enforcing wrapper
     if spec_.order_enforce:

--- a/gym/envs/registration.py
+++ b/gym/envs/registration.py
@@ -503,7 +503,7 @@ def make(
     id: Union[str, EnvSpec],
     max_episode_steps: Optional[int] = None,
     autoreset: bool = False,
-    apply_step_compatibility: Optional[bool] = None,
+    apply_api_compatibility: Optional[bool] = None,
     disable_env_checker: Optional[bool] = None,
     **kwargs,
 ) -> Env:
@@ -515,7 +515,7 @@ def make(
         id: Name of the environment. Optionally, a module to import can be included, eg. 'module:Env-v0'
         max_episode_steps: Maximum length of an episode (TimeLimit wrapper).
         autoreset: Whether to automatically reset the environment after each episode (AutoResetWrapper).
-        apply_step_compatibility: Whether to wrap the environment with the `StepAPICompatibility` wrapper that
+        apply_api_compatibility: Whether to wrap the environment with the `StepAPICompatibility` wrapper that
             converts the environment step from a done bool to return termination and truncation bools.
             By default, the argument is None to which the environment specification `apply_step_compatibility` is used
             which defaults to False. Otherwise, the value of `apply_step_compatibility` is used.
@@ -655,8 +655,8 @@ def make(
         env = PassiveEnvChecker(env)
 
     # Add step API wrapper
-    if apply_step_compatibility is True or (
-        apply_step_compatibility is None and spec_.apply_step_compatibility is True
+    if apply_api_compatibility is True or (
+        apply_api_compatibility is None and spec_.apply_step_compatibility is True
     ):
         env = EnvCompatibility(env)
 

--- a/gym/wrappers/compatibility.py
+++ b/gym/wrappers/compatibility.py
@@ -101,6 +101,9 @@ class EnvCompatibility(gym.Env):
         """
         obs, reward, done, info = self.env.step(action)
 
+        if self.render_mode == "human":
+            self.render()
+
         return convert_to_terminated_truncated_step_api((obs, reward, done, info))
 
     def render(self) -> Any:

--- a/gym/wrappers/compatibility.py
+++ b/gym/wrappers/compatibility.py
@@ -52,7 +52,6 @@ class EnvCompatibility(gym.Env):
 
     Known limitations:
     - Environments that use `self.np_random` might not work as expected.
-    - `env.render_mode` cannot be set in `make` if the environment doesn't accept it as a parameter (e.g. via kwargs).
     """
 
     def __init__(self, old_env: LegacyEnv, render_mode: Optional[str] = None):

--- a/gym/wrappers/compatibility.py
+++ b/gym/wrappers/compatibility.py
@@ -114,3 +114,11 @@ class EnvCompatibility(gym.Env):
     def close(self):
         """Closes the environment."""
         self.env.close()
+
+    def __str__(self):
+        """Returns the wrapper name and the unwrapped environment string."""
+        return f"<{type(self).__name__}{self.env}>"
+
+    def __repr__(self):
+        """Returns the string representation of the wrapper."""
+        return str(self)

--- a/gym/wrappers/compatibility.py
+++ b/gym/wrappers/compatibility.py
@@ -88,6 +88,10 @@ class EnvCompatibility(gym.Env):
         if seed is not None:
             self.env.seed(seed)
         # Options are ignored
+
+        if self.render_mode == "human":
+            self.render()
+
         return self.env.reset(), {}
 
     def step(self, action: Any) -> Tuple[Any, float, bool, bool, Dict]:

--- a/gym/wrappers/compatibility.py
+++ b/gym/wrappers/compatibility.py
@@ -52,6 +52,7 @@ class EnvCompatibility(gym.Env):
 
     Known limitations:
     - Environments that use `self.np_random` might not work as expected.
+    - `env.render_mode` cannot be set in `make` if the environment doesn't accept it as a parameter (e.g. via kwargs).
 
     Args:
         old_env (gym.Env): the env to wrap. Can be in old or new API

--- a/gym/wrappers/compatibility.py
+++ b/gym/wrappers/compatibility.py
@@ -44,19 +44,15 @@ class LegacyEnv(Protocol):
 
 
 class EnvCompatibility(gym.Env):
-    r"""A wrapper which can transform an environment from new step API to old and vice-versa.
+    r"""A wrapper which can transform an environment from the old API to the new API.
 
-    Old step API refers to step() method returning (observation, reward, done, info)
-    New step API refers to step() method returning (observation, reward, terminated, truncated, info)
+    Old step API refers to step() method returning (observation, reward, done, info), and reset() only retuning the observation.
+    New step API refers to step() method returning (observation, reward, terminated, truncated, info) and reset() returning (observation, info).
     (Refer to docs for details on the API change)
 
     Known limitations:
     - Environments that use `self.np_random` might not work as expected.
     - `env.render_mode` cannot be set in `make` if the environment doesn't accept it as a parameter (e.g. via kwargs).
-
-    Args:
-        old_env (gym.Env): the env to wrap. Can be in old or new API
-
     """
 
     def __init__(self, old_env: LegacyEnv, render_mode: Optional[str] = None):
@@ -95,13 +91,13 @@ class EnvCompatibility(gym.Env):
         return self.env.reset(), {}
 
     def step(self, action: Any) -> Tuple[Any, float, bool, bool, Dict]:
-        """Steps through the environment, returning 5 or 4 items depending on `apply_step_compatibility`.
+        """Steps through the environment.
 
         Args:
             action: action to step through the environment with
 
         Returns:
-            (observation, reward, terminated, truncated, info) or (observation, reward, done, info)
+            (observation, reward, terminated, truncated, info)
         """
         obs, reward, done, info = self.env.step(action)
 

--- a/gym/wrappers/compatibility.py
+++ b/gym/wrappers/compatibility.py
@@ -1,0 +1,119 @@
+"""A compatibility wrapper converting an old-style environment into a valid environment."""
+import sys
+from typing import Any, Dict, Optional, Tuple
+
+import gym
+from gym.core import ObsType
+from gym.utils.step_api_compatibility import convert_to_terminated_truncated_step_api
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol, runtime_checkable
+elif sys.version_info >= (3, 7):
+    from typing_extensions import Protocol, runtime_checkable
+else:
+    Protocol = object
+    runtime_checkable = lambda x: x  # noqa: E731
+
+
+@runtime_checkable
+class LegacyEnv(Protocol):
+    """A protocol for environments using the old step API."""
+
+    observation_space: gym.Space
+    action_space: gym.Space
+
+    def reset(self) -> Any:
+        """Reset the environment and return the initial observation."""
+        ...
+
+    def step(self, action: Any) -> Tuple[Any, float, bool, Dict]:
+        """Run one timestep of the environment's dynamics."""
+        ...
+
+    def render(self, mode: Optional[str] = "human") -> Any:
+        """Render the environment."""
+        ...
+
+    def close(self):
+        """Close the environment."""
+        ...
+
+    def seed(self, seed: Optional[int] = None):
+        """Set the seed for this env's random number generator(s)."""
+        ...
+
+
+class EnvCompatibility(gym.Env):
+    r"""A wrapper which can transform an environment from new step API to old and vice-versa.
+
+    Old step API refers to step() method returning (observation, reward, done, info)
+    New step API refers to step() method returning (observation, reward, terminated, truncated, info)
+    (Refer to docs for details on the API change)
+
+    Known limitations:
+    - Environments that use `self.np_random` might not work as expected.
+
+    Args:
+        old_env (gym.Env): the env to wrap. Can be in old or new API
+
+    """
+
+    def __init__(self, old_env: LegacyEnv, render_mode: Optional[str] = None):
+        """A wrapper which converts old-style envs to valid modern envs.
+
+        Some information may be lost in the conversion, so we recommend updating your environment.
+
+        Args:
+            old_env (LegacyEnv): the env to wrap, implemented with the old API
+            render_mode (str): the render mode to use when rendering the environment, passed automatically to env.render
+        """
+        self.metadata = getattr(old_env, "metadata", {"render_modes": []})
+        self.render_mode = render_mode
+        self.reward_range = getattr(old_env, "reward_range", None)
+        self.spec = getattr(old_env, "spec", None)
+        self.env = old_env
+
+        self.observation_space = old_env.observation_space
+        self.action_space = old_env.action_space
+
+    def reset(
+        self, seed: Optional[int] = None, options: Optional[dict] = None
+    ) -> Tuple[ObsType, dict]:
+        """Resets the environment.
+
+        Args:
+            seed: the seed to reset the environment with
+            options: the options to reset the environment with
+
+        Returns:
+            (observation, info)
+        """
+        if seed is not None:
+            self.env.seed(seed)
+        # Options are ignored
+        return self.env.reset(), {}
+
+    def step(self, action: Any) -> Tuple[Any, float, bool, bool, Dict]:
+        """Steps through the environment, returning 5 or 4 items depending on `apply_step_compatibility`.
+
+        Args:
+            action: action to step through the environment with
+
+        Returns:
+            (observation, reward, terminated, truncated, info) or (observation, reward, done, info)
+        """
+        obs, reward, done, info = self.env.step(action)
+
+        return convert_to_terminated_truncated_step_api((obs, reward, done, info))
+
+    def render(self) -> Any:
+        """Renders the environment.
+
+        Returns:
+            The rendering of the environment, depending on the render mode
+        """
+        return self.env.render(mode=self.render_mode)
+
+    def close(self):
+        """Closes the environment."""
+        self.env.close()

--- a/gym/wrappers/step_api_compatibility.py
+++ b/gym/wrappers/step_api_compatibility.py
@@ -22,7 +22,7 @@ class StepAPICompatibility(gym.Wrapper):
         >>> env = gym.make("CartPole-v1")
         >>> env # wrapper not applied by default, set to new API
         <TimeLimit<OrderEnforcing<PassiveEnvChecker<CartPoleEnv<CartPole-v1>>>>>
-        >>> env = gym.make("CartPole-v1", apply_step_compatibility=True) # set to old API
+        >>> env = gym.make("CartPole-v1", apply_api_compatibility=True) # set to old API
         <StepAPICompatibility<TimeLimit<OrderEnforcing<PassiveEnvChecker<CartPoleEnv<CartPole-v1>>>>>>
         >>> env = StepAPICompatibility(CustomEnv(), apply_step_compatibility=False) # manually using wrapper on unregistered envs
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cloudpickle>=1.2.0
 importlib_metadata>=4.8.0; python_version < '3.10'
 gym_notices>=0.0.4
 dataclasses==0.8; python_version == '3.6'
+typing_extensions==4.3.0; python_version == '3.7'
 opencv-python>=3.0
 lz4>=3.1.0
 matplotlib>=3.0

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -100,8 +100,7 @@ def test_make_compatibility_in_spec():
         entry_point=LegacyEnvExplicit,
         apply_api_compatibility=True,
     )
-    env = gym.make("LegacyTestEnv-v0")
-    env.unwrapped.render_mode = "rgb_array"
+    env = gym.make("LegacyTestEnv-v0", render_mode="rgb_array")
     assert env.observation_space == Discrete(1)
     assert env.action_space == Discrete(1)
     assert env.reset() == (0, {})
@@ -116,8 +115,9 @@ def test_make_compatibility_in_spec():
 
 def test_make_compatibility_in_make():
     gym.register(id="LegacyTestEnv-v0", entry_point=LegacyEnvExplicit)
-    env = gym.make("LegacyTestEnv-v0", apply_api_compatibility=True)
-    env.unwrapped.render_mode = "rgb_array"
+    env = gym.make(
+        "LegacyTestEnv-v0", apply_api_compatibility=True, render_mode="rgb_array"
+    )
     assert env.observation_space == Discrete(1)
     assert env.action_space == Discrete(1)
     assert env.reset() == (0, {})

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
@@ -77,7 +78,9 @@ def test_explicit():
 
 def test_implicit():
     old_env = LegacyEnvImplicit()
-    assert isinstance(old_env, LegacyEnv)
+    if sys.version_info > (3, 6):
+        # We need to give up on typing in Python 3.6
+        assert isinstance(old_env, LegacyEnv)
     env = EnvCompatibility(old_env, render_mode="rgb_array")
     assert env.observation_space == Discrete(1)
     assert env.action_space == Discrete(1)

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -109,6 +109,7 @@ def test_make_compatibility_in_spec():
     assert isinstance(img, np.ndarray)
     assert img.shape == (1, 1, 3)  # type: ignore
     env.close()
+    del gym.envs.registration.registry["LegacyTestEnv-v0"]
 
 
 def test_make_compatibility_in_make():
@@ -124,3 +125,4 @@ def test_make_compatibility_in_make():
     assert isinstance(img, np.ndarray)
     assert img.shape == (1, 1, 3)  # type: ignore
     env.close()
+    del gym.envs.registration.registry["LegacyTestEnv-v0"]

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -78,7 +78,7 @@ def test_explicit():
 
 def test_implicit():
     old_env = LegacyEnvImplicit()
-    if sys.version_info > (3, 6):
+    if sys.version_info >= (3, 7):
         # We need to give up on typing in Python 3.6
         assert isinstance(old_env, LegacyEnv)
     env = EnvCompatibility(old_env, render_mode="rgb_array")

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -113,7 +113,7 @@ def test_make_compatibility_in_spec():
 
 def test_make_compatibility_in_make():
     gym.register(id="LegacyTestEnv-v0", entry_point=LegacyEnvExplicit)
-    env = gym.make("LegacyTestEnv-v0", apply_step_compatibility=True)
+    env = gym.make("LegacyTestEnv-v0", apply_api_compatibility=True)
     env.unwrapped.render_mode = "rgb_array"
     assert env.observation_space == Discrete(1)
     assert env.action_space == Discrete(1)

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -96,7 +96,7 @@ def test_make_compatibility_in_spec():
     gym.register(
         id="LegacyTestEnv-v0",
         entry_point=LegacyEnvExplicit,
-        apply_step_compatibility=True,
+        apply_api_compatibility=True,
     )
     env = gym.make("LegacyTestEnv-v0")
     env.unwrapped.render_mode = "rgb_array"

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -1,0 +1,88 @@
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+
+from gym.spaces import Discrete
+from gym.wrappers.compatibility import EnvCompatibility, LegacyEnv
+
+
+class LegacyEnvExplicit(LegacyEnv):
+    """Legacy env that explicitly implements the old API."""
+
+    observation_space = Discrete(1)
+    action_space = Discrete(1)
+
+    def __init__(self):
+        pass
+
+    def reset(self):
+        return 0
+
+    def step(self, action):
+        return 0, 0, False, {}
+
+    def render(self, mode="human"):
+        if mode == "human":
+            return
+        elif mode == "rgb_array":
+            return np.zeros((1, 1, 3), dtype=np.uint8)
+
+    def close(self):
+        pass
+
+    def seed(self, seed=None):
+        pass
+
+
+class LegacyEnvImplicit:
+    """Legacy env that implicitly implements the old API as a protocol."""
+
+    observation_space = Discrete(1)
+    action_space = Discrete(1)
+
+    def __init__(self):
+        pass
+
+    def reset(self):
+        return 0
+
+    def step(self, action: Any) -> Tuple[int, float, bool, Dict]:
+        return 0, 0.0, False, {}
+
+    def render(self, mode: Optional[str] = "human") -> Any:
+        if mode == "human":
+            return
+        elif mode == "rgb_array":
+            return np.zeros((1, 1, 3), dtype=np.uint8)
+
+    def close(self):
+        pass
+
+    def seed(self, seed: Optional[int] = None):
+        pass
+
+
+def test_explicit():
+    old_env = LegacyEnvExplicit()
+    assert isinstance(old_env, LegacyEnv)
+    env = EnvCompatibility(old_env, render_mode="rgb_array")
+    assert env.observation_space == Discrete(1)
+    assert env.action_space == Discrete(1)
+    assert env.reset() == (0, {})
+    assert env.reset(seed=0, options={"some": "option"}) == (0, {})
+    assert env.step(0) == (0, 0, False, False, {})
+    assert env.render().shape == (1, 1, 3)
+    env.close()
+
+
+def test_implicit():
+    old_env = LegacyEnvImplicit()
+    assert isinstance(old_env, LegacyEnv)
+    env = EnvCompatibility(old_env, render_mode="rgb_array")
+    assert env.observation_space == Discrete(1)
+    assert env.action_space == Discrete(1)
+    assert env.reset() == (0, {})
+    assert env.reset(seed=0, options={"some": "option"}) == (0, {})
+    assert env.step(0) == (0, 0, False, False, {})
+    assert env.render().shape == (1, 1, 3)
+    env.close()

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -107,7 +107,7 @@ def test_make_compatibility_in_spec():
     assert env.step(0) == (0, 0, False, False, {})
     img = env.render()
     assert isinstance(img, np.ndarray)
-    assert img.shape == (1, 1, 3)
+    assert img.shape == (1, 1, 3)  # type: ignore
     env.close()
 
 
@@ -122,5 +122,5 @@ def test_make_compatibility_in_make():
     assert env.step(0) == (0, 0, False, False, {})
     img = env.render()
     assert isinstance(img, np.ndarray)
-    assert img.shape == (1, 1, 3)
+    assert img.shape == (1, 1, 3)  # type: ignore
     env.close()

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -13,6 +13,7 @@ class LegacyEnvExplicit(LegacyEnv, gym.Env):
 
     observation_space = Discrete(1)
     action_space = Discrete(1)
+    metadata = {"render.modes": ["human", "rgb_array"]}
 
     def __init__(self):
         pass
@@ -41,6 +42,7 @@ class LegacyEnvImplicit(gym.Env):
 
     observation_space = Discrete(1)
     action_space = Discrete(1)
+    metadata = {"render.modes": ["human", "rgb_array"]}
 
     def __init__(self):
         pass

--- a/tests/envs/test_make.py
+++ b/tests/envs/test_make.py
@@ -136,7 +136,7 @@ def test_apply_step_compatibility():
     gym.register(
         "testing-old-env",
         lambda: GenericTestEnv(step_fn=old_step_fn),
-        apply_step_compatibility=True,
+        apply_api_compatibility=True,
         max_episode_steps=3,
     )
     env = gym.make("testing-old-env")
@@ -147,7 +147,7 @@ def test_apply_step_compatibility():
     _, _, termination, truncation, _ = env.step(env.action_space.sample())
     assert termination is False and truncation is True
 
-    gym.spec("testing-old-env").apply_step_compatibility = False
+    gym.spec("testing-old-env").apply_api_compatibility = False
     env = gym.make("testing-old-env")
     # Cannot run reset and step as will not work
 

--- a/tests/envs/test_make.py
+++ b/tests/envs/test_make.py
@@ -151,7 +151,7 @@ def test_apply_step_compatibility():
     env = gym.make("testing-old-env")
     # Cannot run reset and step as will not work
 
-    env = gym.make("testing-old-env", apply_step_compatibility=True)
+    env = gym.make("testing-old-env", apply_api_compatibility=True)
 
     env.reset()
     assert len(env.step(env.action_space.sample())) == 5

--- a/tests/envs/test_make.py
+++ b/tests/envs/test_make.py
@@ -132,7 +132,7 @@ def test_make_disable_env_checker():
     env.close()
 
 
-def test_apply_step_compatibility():
+def test_apply_api_compatibility():
     gym.register(
         "testing-old-env",
         lambda: GenericTestEnv(step_fn=old_step_fn),

--- a/tests/envs/test_make.py
+++ b/tests/envs/test_make.py
@@ -9,13 +9,7 @@ import pytest
 
 import gym
 from gym.envs.classic_control import cartpole
-from gym.wrappers import (
-    AutoResetWrapper,
-    HumanRendering,
-    OrderEnforcing,
-    StepAPICompatibility,
-    TimeLimit,
-)
+from gym.wrappers import AutoResetWrapper, HumanRendering, OrderEnforcing, TimeLimit
 from gym.wrappers.env_checker import PassiveEnvChecker
 from tests.envs.test_envs import PASSIVE_CHECK_IGNORE_WARNING
 from tests.envs.utils import all_testing_env_specs
@@ -146,7 +140,6 @@ def test_apply_step_compatibility():
         max_episode_steps=3,
     )
     env = gym.make("testing-old-env")
-    assert has_wrapper(env, StepAPICompatibility)
 
     env.reset()
     assert len(env.step(env.action_space.sample())) == 5
@@ -156,11 +149,9 @@ def test_apply_step_compatibility():
 
     gym.spec("testing-old-env").apply_step_compatibility = False
     env = gym.make("testing-old-env")
-    assert has_wrapper(env, StepAPICompatibility) is False
     # Cannot run reset and step as will not work
 
     env = gym.make("testing-old-env", apply_step_compatibility=True)
-    assert has_wrapper(env, StepAPICompatibility)
 
     env.reset()
     assert len(env.step(env.action_space.sample())) == 5

--- a/tests/spaces/test_graph.py
+++ b/tests/spaces/test_graph.py
@@ -8,6 +8,7 @@ from gym.spaces import Discrete, Graph, GraphInstance
 
 def test_node_space_sample():
     space = Graph(node_space=Discrete(3), edge_space=None)
+    space.seed(0)
 
     sample = space.sample(
         mask=(tuple(np.array([0, 1, 0], dtype=np.int8) for _ in range(5)), None),
@@ -47,12 +48,13 @@ def test_node_space_sample():
 
 def test_edge_space_sample():
     space = Graph(node_space=Discrete(3), edge_space=Discrete(3))
+    space.seed(0)
     # When num_nodes>1 then num_edges is set to 0
     assert space.sample(num_nodes=1).edges is None
     assert 0 <= len(space.sample(num_edges=3).edges) < 6
 
     sample = space.sample(mask=(None, np.array([0, 1, 0], dtype=np.int8)))
-    assert np.all(sample.edges == 1)
+    assert np.all(sample.edges == 1) or sample.edges is None
 
     sample = space.sample(
         mask=(

--- a/tests/wrappers/test_step_compatibility.py
+++ b/tests/wrappers/test_step_compatibility.py
@@ -61,7 +61,7 @@ def test_step_compatibility_in_make(apply_step_compatibility):
     if apply_step_compatibility is not None:
         env = gym.make(
             "OldStepEnv-v0",
-            apply_step_compatibility=apply_step_compatibility,
+            apply_api_compatibility=apply_step_compatibility,
             disable_env_checker=True,
         )
     else:

--- a/tests/wrappers/test_step_compatibility.py
+++ b/tests/wrappers/test_step_compatibility.py
@@ -64,7 +64,7 @@ def test_step_compatibility_in_make(apply_step_compatibility):
             apply_step_compatibility=apply_step_compatibility,
             disable_env_checker=True,
         )
-    elif apply_step_compatibility is None:
+    else:
         env = gym.make("OldStepEnv-v0", disable_env_checker=True)
 
     env.reset()

--- a/tests/wrappers/test_step_compatibility.py
+++ b/tests/wrappers/test_step_compatibility.py
@@ -54,14 +54,14 @@ def test_step_compatibility_to_old_api(env):
     assert isinstance(done, bool)
 
 
-@pytest.mark.parametrize("apply_step_compatibility", [None, True, False])
-def test_step_compatibility_in_make(apply_step_compatibility):
+@pytest.mark.parametrize("apply_api_compatibility", [None, True, False])
+def test_step_compatibility_in_make(apply_api_compatibility):
     gym.register("OldStepEnv-v0", entry_point=OldStepEnv)
 
-    if apply_step_compatibility is not None:
+    if apply_api_compatibility is not None:
         env = gym.make(
             "OldStepEnv-v0",
-            apply_api_compatibility=apply_step_compatibility,
+            apply_api_compatibility=apply_api_compatibility,
             disable_env_checker=True,
         )
     else:
@@ -69,7 +69,7 @@ def test_step_compatibility_in_make(apply_step_compatibility):
 
     env.reset()
     step_returns = env.step(0)
-    if apply_step_compatibility:
+    if apply_api_compatibility:
         assert len(step_returns) == 5
         _, _, terminated, truncated, _ = step_returns
         assert isinstance(terminated, bool)


### PR DESCRIPTION
This should in principle make it so that any* legacy environment can be created and then converted into a valid modern environment.

WIP, I want to see if tests work for 3.6 (ugh) since I had to do a hack around protocols. I also still need to automatically integrate it into the `make` pipeline.

Brief explanation of the methodology: I implemented a [protocol](https://peps.python.org/pep-0544/) which will type check if something is a valid legacy env according to a minimal "mandatory" set of methods and fields. In python >= 3.8, this is available by default in `typing`. In 3.7, we need to use `typing_extensions`, which in turn does not support 3.6, for which the protocol check will be de facto disabled.

*Restrictions apply. Old environments expected to inherit the old `gym.Env` and will instead inherit from the new `gym.Env`, so there may be issues in some cases. 