### PR TITLE
Bump ale to 0.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ lz4>=3.1.0
 matplotlib>=3.0
 box2d-py==2.3.5
 pygame==2.1.0
-ale-py~=0.7.5
+ale-py~=0.8.0
 mujoco==2.2.0
 mujoco_py<2.2,>=2.1
 imageio>=2.14.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("gym/version.py") as file:
 
 # Environment-specific dependencies.
 extras = {
-    "atari": ["ale-py~=0.7.5"],
+    "atari": ["ale-py~=0.8.0"],
     "accept-rom-license": ["autorom[accept-rom-license]~=0.4.2"],
     "box2d": ["box2d-py==2.3.5", "pygame==2.1.0", "swig==4.*"],
     "classic_control": ["pygame==2.1.0"],


### PR DESCRIPTION
Bumps ALE version to 0.8.0 which is compatible with gym v0.26.0