### PR TITLE
[BugFix] Raise exception in PixelObservationWrapper if env.render_mode is not specified

### DIFF
--- a/gym/wrappers/pixel_observation.py
+++ b/gym/wrappers/pixel_observation.py
@@ -97,7 +97,7 @@ class PixelObservationWrapper(gym.ObservationWrapper):
         if not env.render_mode:
             raise AttributeError(
                 "env.render_mode must be specified to use PixelObservationWrapper:"
-                "`gym.make(env_name, render_mode='single_rgb_array')`."
+                "`gym.make(env_name, render_mode='rgb_array')`."
             )
 
         for key in pixel_keys:

--- a/gym/wrappers/pixel_observation.py
+++ b/gym/wrappers/pixel_observation.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 
 import gym
-from gym import logger, spaces
+from gym import spaces
 
 STATE_KEY = "state"
 
@@ -95,10 +95,9 @@ class PixelObservationWrapper(gym.ObservationWrapper):
 
         default_render_kwargs = {}
         if not env.render_mode:
-            default_render_kwargs = {"mode": "rgb_array_list"}
-            logger.warn(
+            raise AttributeError(
                 "env.render_mode must be specified to use PixelObservationWrapper:"
-                "`gym.make(env_name, render_mode='rgb_array')`."
+                "`gym.make(env_name, render_mode='single_rgb_array')`."
             )
 
         for key in pixel_keys:


### PR DESCRIPTION
# Description

In 8e812e1de501ae359f16ce5bcd9a6f40048b342f we added a warning when render_mode was not specified, but in 0.26 this will not work anymore.
Hence we require that env.render_mode is not None for `PixelObservationWrapper` to be used.

## Behaviour _ante_

```python
from gym.wrappers.pixel_observation import PixelObservationWrapper
import gym
base_env = gym. Make("Pendulum-v1") # no error
env = PixelObservationWrapper(env) # no error
env.reset() # error
```

With the error
```
~/venv/rl/lib/python3.8/site-packages/gym/utils/passive_env_checker.py in env_render_passive_checker(env, *args, **kwargs)
    314             )
    315 
--> 316     result = env.render(*args, **kwargs)
    317 
    318     # TODO: Check that the result is correct

TypeError: render() got an unexpected keyword argument 'mode'
```

## Behaviour _post_

An error is raised as soon as PixelObservationWrapper is instantiated
```python
from gym.wrappers.pixel_observation import PixelObservationWrapper
import gym
base_env = gym.make("Pendulum-v1") # no error
env = PixelObservationWrapper(env) # error
```

Solution
```python
from gym.wrappers.pixel_observation import PixelObservationWrapper
import gym
base_env = gym. Make("Pendulum-v1", render_mode="human") # no error
env = PixelObservationWrapper(env) # no error
env.reset() # no error
```
