### PR TITLE
fix truncarted typo in readme API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ observation, info = env.reset(seed=42)
 
 for _ in range(1000):
     action = env.action_space.sample()
-    observation, reward, terminated, truncarted, info = env.step(action)
+    observation, reward, terminated, truncated, info = env.step(action)
 
     if terminated or truncated:
         observation, info = env.reset()


### PR DESCRIPTION
# Description

This tiny PR removes one character from the readme in order to fix a typo in the API example. The typo is that `truncarted` was written instead of `truncated`. Without this fix the example does not work (in Gym v0.26) as it throws a `NameError: name 'truncated' is not defined`. Also, thanks for all the awesome work!

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
