### PR TITLE
Correctly change color of visited road tiles in CarRacing

### DIFF
--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -81,7 +81,7 @@ class FrictionDetector(contactListener):
             return
 
         # inherit tile color from env
-        tile.color = self.env.road_color / 255
+        tile.color[:] = self.env.road_color
         if not obj or "tiles" not in obj.__dict__:
             return
         if begin:


### PR DESCRIPTION
# Description

One of previous commit erroneously changed to code to overwrite `tile.color` instead of updating it in-place.

Specifically, commit c6deb81ad3b6 changed the lines
https://github.com/openai/gym/blob/07fd227a4fc0ecbd4fdac5563c0f48deeb5688ed/gym/envs/box2d/car_racing.py#L66-L68
into
https://github.com/openai/gym/blob/c6deb81ad3b6da7adbbffd4a2df2002a53861d8f/gym/envs/box2d/car_racing.py#L64-L65

However, the `tile.color` is used via reference in
https://github.com/openai/gym/blob/f4d668f9687ae417ff041cb1735966633d8ba759/gym/envs/box2d/car_racing.py#L449

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)