### PR TITLE
fix: bipedal rgb_array shape

### DIFF
--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -621,7 +621,9 @@ class BipedalWalker(gym.Env, EzPickle):
         if self.clock is None:
             self.clock = pygame.time.Clock()
 
-        self.surf = pygame.Surface((VIEWPORT_W + self.scroll * SCALE, VIEWPORT_H))
+        self.surf = pygame.Surface(
+            (VIEWPORT_W + max(0.0, self.scroll) * SCALE, VIEWPORT_H)
+        )
 
         pygame.transform.scale(self.surf, (SCALE, SCALE))
 


### PR DESCRIPTION
Fix the problem reported in this issue: https://github.com/openai/gym/issues/3049

This issue happens when the agent moves backward, thus the scroll becomes negative.

To reproduce the issue:
```python
import gym
import numpy as np

env = gym.make("BipedalWalker-v3", render_mode="rgb_array")
action_list = [np.array([0.643685, -0.62666583, -0.1335137, -0.13038172]), np.array([-0.19339366, -0.9087967,  0.00145424, -0.4682705]), np.array([0.179367,  0.6020662,  0.42777744, -0.39004773]), np.array([ 0.02049271,  0.04724116, -0.8624853 ,  0.03024031]), np.array([-0.6154519 ,  0.52910167, -0.33587497,  0.7485084 ]), np.array([-0.6128346,  0.4765728,  0.2591065, -0.3021512]), np.array([-0.235959  , -0.30048248,  0.87556076,  0.7753413 ]), np.array([-0.9614248 , -0.13825607,  0.99294996, -0.11442958]), np.array([-0.18276785,  0.26463097,  0.44796792, -0.8739907 ]), np.array([0.85195774, 0.5286732 , 0.496335  , 0.36988902]), np.array([-0.0840409 ,  0.16184323, -0.634224  ,  0.86797273]), np.array([-0.97534806,  0.31701997, -0.8507178 ,  0.4120439 ]), np.array([-0.39506558,  0.9434654 , -0.96054906,  0.00880588]), np.array([-0.6835781 ,  0.8211686 , -0.05593331,  0.05781673]), np.array([-0.58589566, -0.6381957 , -0.632999  , -0.30774575]), np.array([ 0.47192395, -0.92304075,  0.6425233 , -0.92087024]), np.array([ 0.1875863,  0.5420707, -0.9274609,  0.6606024]), np.array([-0.72258395, -0.7478248 , -0.5655383 , -0.2581901 ]), np.array([ 0.2705225 ,  0.47199565, -0.11255373, -0.86911774]), np.array([-0.13884565, -0.37597236,  0.07308514,  0.45713252]), np.array([ 0.92100114, -0.35050565,  0.6811875 ,  0.47295535]), np.array([-0.09725217, -0.20325504, -0.7870783 ,  0.07472079]), np.array([ 0.09136666, -0.93310696, -0.82850933,  0.14684333]), np.array([0.4453324, 0.9152248, 0.8322004, 0.8049548]), np.array([ 0.56018   , -0.01450923,  0.16680394,  0.47482583]), np.array([-0.41383448, -0.20085047,  0.42868853,  0.5110155 ]), np.array([-0.4279947 ,  0.35662994,  0.8183462 ,  0.21517053]), np.array([ 0.5898978 , -0.9781276 ,  0.18979469, -0.1614459 ]), np.array([-0.31077167,  0.60447997,  0.82021326,  0.82657313]), np.array([ 0.8207786 ,  0.65222967, -0.66079664, -0.02506254]), np.array([-0.51066256,  0.27079412, -0.92657954,  0.8742213 ]), np.array([ 0.46347475, -0.15175875, -0.53603065, -0.21098745]), np.array([ 0.39295816, -0.01637655, -0.721596  , -0.57422465]), np.array([-0.60221064, -0.15010175, -0.39234048, -0.5266877 ]), np.array([-0.05991038, -0.53504926, -0.32401964,  0.38576806]), np.array([-0.6268798 , -0.06704492,  0.69337595, -0.6427842 ]), np.array([ 0.7093774 , -0.43126252, -0.99616826, -0.6455295 ]), np.array([-0.14166228,  0.8667675 ,  0.1795836 ,  0.6241876 ]), np.array([ 0.9157805 ,  0.84588903,  0.76045954, -0.8032939 ]), np.array([-0.14809695, -0.17869028, -0.87412864, -0.1591354 ]), np.array([-0.51737565, -0.9989355 ,  0.40166578, -0.5023515 ]), np.array([ 0.9502871 , -0.9040277 ,  0.21352765,  0.57944405]), np.array([ 0.56125003,  0.20018181, -0.95034605, -0.15287359]), np.array([-0.3154254 , -0.07446004, -0.9690393 ,  0.9622016 ]), np.array([ 0.21771437,  0.8887881 , -0.9863894 , -0.8724034 ]), np.array([ 0.39352176, -0.7001385 , -0.16980354,  0.07000761]), np.array([-0.979767  , -0.45758107,  0.8911563 , -0.08953675]), np.array([ 0.49918324,  0.9228076 , -0.2646765 , -0.3097803 ]), np.array([ 0.6620012 , -0.96974695, -0.15020505,  0.30313143]), np.array([-0.18247065,  0.43751952,  0.01933471,  0.33363464]), np.array([-0.61877394, -0.9476306 , -0.8349054 , -0.25190774]), np.array([-0.92225266, -0.8115883 ,  0.15599026, -0.59566766]), np.array([ 0.00533226, -0.34414297,  0.14059748,  0.16085744]), np.array([-0.17177185,  0.56855583, -0.52641034,  0.62500757]), np.array([-0.40493345, -0.3076859 , -0.7160312 , -0.65174174]), np.array([ 0.6850576 , -0.9612596 , -0.02091006,  0.32623777]), np.array([-0.9160383,  0.8617576, -0.465756 , -0.9227743]), np.array([-0.18535642, -0.75398093, -0.8249806 ,  0.13734086]), np.array([ 0.14831062,  0.7711198 ,  0.6504944 , -0.78548276]), np.array([-0.5524805 , -0.69469136,  0.2031052 ,  0.9546891 ]), np.array([ 0.16769259,  0.79624283, -0.02346617, -0.7695191 ]), np.array([ 0.12755956,  0.52089745,  0.07243016, -0.34585223]), np.array([-0.3771856 , -0.17726257,  0.5565605 ,  0.3665386 ]), np.array([ 0.20121232, -0.8475649 ,  0.41901204,  0.3628199 ]), np.array([ 0.71005636,  0.7055862 , -0.76494634,  0.05509782]), np.array([ 0.41927156,  0.8637003 ,  0.9983261 , -0.8352386 ]), np.array([ 0.31284067,  0.03769052,  0.70507765, -0.08994306]), np.array([ 0.09184641,  0.8967327 ,  0.26557937, -0.29661146]), np.array([-0.7726936 , -0.52805257, -0.0618767 , -0.35944775]), np.array([-0.46993572,  0.9251816 , -0.95027226,  0.31960052]), np.array([ 0.85452825,  0.18880677, -0.71394354, -0.70524025]), np.array([-0.8985728 , -0.10281813, -0.48221368, -0.04487926]), np.array([-0.15196428,  0.8618916 ,  0.4890748 ,  0.41005248]), np.array([-0.5974676 , -0.93549937, -0.4677144 , -0.63049424]), np.array([-0.3779468 ,  0.9106576 ,  0.6289624 ,  0.95054334]), np.array([-0.97507274, -0.02020846, -0.1372993 , -0.50736964]), np.array([ 0.50563085,  0.38596255,  0.25653768, -0.9416368 ]), np.array([ 0.6106515 , -0.136857  ,  0.01290369,  0.0478943 ]), np.array([-0.04328071, -0.94382745, -0.363252  , -0.21479565]), np.array([ 0.30206698,  0.08327765, -0.9129897 ,  0.9103231 ]), np.array([-0.8882193 ,  0.6252409 ,  0.50017494, -0.6119237 ]), np.array([-0.13433145, -0.24199042,  0.49307704,  0.3015699 ]), np.array([ 0.25055128,  0.9157094 , -0.4901475 ,  0.8099683 ]), np.array([0.52348274, 0.27641577, 0.85683835, 0.7544451 ]), np.array([0.38568947, 0.30092776, 0.29074007, 0.787334  ]), np.array([-0.93295896,  0.13218422, -0.29519245, -0.324167  ]), np.array([ 0.5638857 ,  0.3410942 , -0.37738988, -0.03427474]), np.array([ 0.5623664 ,  0.32109112,  0.9927296 , -0.01804948]), np.array([-0.6755795 ,  0.30867776,  0.71335405,  0.7087948 ]), np.array([0.2989208 , 0.34821448, 0.8940771 , 0.81655675]), np.array([ 0.67319655, -0.68893814, -0.25520962, -0.6391557 ]), np.array([-0.07174755, -0.8299711 ,  0.21328507,  0.9296278 ]), np.array([-0.97989726, -0.865415  , -0.5236168 ,  0.1891743 ]), np.array([ 0.10780847, -0.5415337 , -0.96623516,  0.43275303]), np.array([-0.20953982, -0.97188723, -0.3014299 ,  0.7011993 ]), np.array([ 0.02814789, -0.89827526, -0.24117279,  0.42374986]), np.array([ 0.42804134,  0.3521514 , -0.39498943, -0.884818  ]), np.array([ 0.16669601, -0.31610003,  0.8251603 ,  0.982135  ]), np.array([-0.11691312,  0.56624407, -0.39886016,  0.662622  ]), np.array([ 0.95325524,  0.31067362, -0.41781706, -0.43493238])]


env.reset()
for action in action_list:
    print(env.render().shape)
    env.step(action)
```