### PR TITLE
Feature/faster episode recorder

### DIFF
--- a/gym/wrappers/record_episode_statistics.py
+++ b/gym/wrappers/record_episode_statistics.py
@@ -92,7 +92,7 @@ class RecordEpisodeStatistics(gym.Wrapper):
                 "episode": {
                     "r": np.where(dones, self.episode_returns, 0),
                     "l": np.where(dones, self.episode_lengths, 0),
-                    "t": round(time.perf_counter() - self.t0, 6)
+                    "t": round(time.perf_counter() - self.t0, 6),
                 },
             }
             if self.is_vector_env:

--- a/tests/wrappers/test_record_episode_statistics.py
+++ b/tests/wrappers/test_record_episode_statistics.py
@@ -3,7 +3,6 @@ import pytest
 
 import gym
 from gym.wrappers import RecordEpisodeStatistics, VectorListInfo
-from gym.wrappers.record_episode_statistics import add_vector_episode_statistics
 
 
 @pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v1"])
@@ -74,29 +73,3 @@ def test_wrong_wrapping_order():
 
     with pytest.raises(AssertionError):
         wrapped_env.step(wrapped_env.action_space.sample())
-
-
-def test_add_vector_episode_statistics():
-    NUM_ENVS = 5
-
-    info = {}
-    for i in range(NUM_ENVS):
-        episode_info = {
-            "episode": {
-                "r": i,
-                "l": i,
-                "t": i,
-            }
-        }
-        info = add_vector_episode_statistics(info, episode_info["episode"], NUM_ENVS, i)
-        assert np.alltrue(info["_episode"][: i + 1])
-
-        for j in range(NUM_ENVS):
-            if j <= i:
-                assert info["episode"]["r"][j] == j
-                assert info["episode"]["l"][j] == j
-                assert info["episode"]["t"][j] == j
-            else:
-                assert info["episode"]["r"][j] == 0
-                assert info["episode"]["l"][j] == 0
-                assert info["episode"]["t"][j] == 0


### PR DESCRIPTION
# Description

This addresses two issues I've run into with RecordEpisodeStatistics

1) Silent list conversion in vectorized environments. Currently, RecordEpisodeStatistics converts terminated and truncated into lists, but obs and reward may still be arrays, and the new vectorized `info` interface uses arrays. I particularly run into this in my code if I do something like `dones.any()`. This PR leaves the underlying details of terminated/truncated alone by using NumPy array functionality.

2) Speed. Instead of looping through a potentially large batch of environments, this PR uses NumPy functions with their underlying vectorization to achieve the same task.

I considered building this with Jumpy, but I'm not sure on its status in the project, and it would also eat the cost of creating new arrays wherever I'm doing in-place modifications. 

I tested to make sure that this replicates the exact functionality of the original wrapper. To prove my speedup, I need to come up with some decent micro benchmarks; a couple attempts on Colab were fairly noisy.

## Type of change

- [x] Existing feature enhancement (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
