### PR TITLE
ENH: add render warn for None

### DIFF
--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -608,8 +608,8 @@ class BipedalWalker(gym.Env, EzPickle):
     def render(self):
         if self.render_mode is None:
             gym.logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
                 f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
             return

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -606,6 +606,12 @@ class BipedalWalker(gym.Env, EzPickle):
         return np.array(state, dtype=np.float32), reward, terminated, False, {}
 
     def render(self):
+        if self.render_mode is None:
+            gym.logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+            return
+
         try:
             import pygame
             from pygame import gfxdraw

--- a/gym/envs/box2d/bipedal_walker.py
+++ b/gym/envs/box2d/bipedal_walker.py
@@ -607,8 +607,10 @@ class BipedalWalker(gym.Env, EzPickle):
 
     def render(self):
         if self.render_mode is None:
-            gym.logger.WARN(
-                "You are calling render method without specifying any render mode."
+            gym.logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
             return
 

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -565,13 +565,16 @@ class CarRacing(gym.Env, EzPickle):
         return self.state, step_reward, terminated, truncated, {}
 
     def render(self):
-        return self._render(self.render_mode)
+        if self.render_mode is None:
+            gym.logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+            return
 
-    def _render(self, mode: str):
-        assert mode in self.metadata["render_modes"]
+        assert self.render_mode in self.metadata["render_modes"]
 
         pygame.font.init()
-        if self.screen is None and mode == "human":
+        if self.screen is None and self.render_mode == "human":
             pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((WINDOW_W, WINDOW_H))
@@ -599,7 +602,7 @@ class CarRacing(gym.Env, EzPickle):
             zoom,
             trans,
             angle,
-            mode not in ["state_pixels_list", "state_pixels"],
+            self.render_mode not in ["state_pixels_list", "state_pixels"],
         )
 
         self.surf = pygame.transform.flip(self.surf, False, True)
@@ -613,7 +616,7 @@ class CarRacing(gym.Env, EzPickle):
         text_rect.center = (60, WINDOW_H - WINDOW_H * 2.5 / 40.0)
         self.surf.blit(text, text_rect)
 
-        if mode == "human":
+        if self.render_mode == "human":
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])
             assert self.screen is not None
@@ -621,9 +624,9 @@ class CarRacing(gym.Env, EzPickle):
             self.screen.blit(self.surf, (0, 0))
             pygame.display.flip()
 
-        if mode == "rgb_array":
+        if self.render_mode == "rgb_array":
             return self._create_image_array(self.surf, (VIDEO_W, VIDEO_H))
-        elif mode == "state_pixels":
+        elif self.render_mode == "state_pixels":
             return self._create_image_array(self.surf, (STATE_W, STATE_H))
         else:
             return self.isopen

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -567,8 +567,8 @@ class CarRacing(gym.Env, EzPickle):
     def render(self):
         if self.render_mode is None:
             gym.logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
                 f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
         else:

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -569,12 +569,14 @@ class CarRacing(gym.Env, EzPickle):
             gym.logger.WARN(
                 "You are calling render method without specifying any render mode."
             )
-            return
+        else:
+            return self._render(self.render_mode)
 
-        assert self.render_mode in self.metadata["render_modes"]
+    def _render(self, mode: str):
+        assert mode in self.metadata["render_modes"]
 
         pygame.font.init()
-        if self.screen is None and self.render_mode == "human":
+        if self.screen is None and mode == "human":
             pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((WINDOW_W, WINDOW_H))
@@ -602,7 +604,7 @@ class CarRacing(gym.Env, EzPickle):
             zoom,
             trans,
             angle,
-            self.render_mode not in ["state_pixels_list", "state_pixels"],
+            mode not in ["state_pixels_list", "state_pixels"],
         )
 
         self.surf = pygame.transform.flip(self.surf, False, True)
@@ -616,7 +618,7 @@ class CarRacing(gym.Env, EzPickle):
         text_rect.center = (60, WINDOW_H - WINDOW_H * 2.5 / 40.0)
         self.surf.blit(text, text_rect)
 
-        if self.render_mode == "human":
+        if mode == "human":
             pygame.event.pump()
             self.clock.tick(self.metadata["render_fps"])
             assert self.screen is not None
@@ -624,9 +626,9 @@ class CarRacing(gym.Env, EzPickle):
             self.screen.blit(self.surf, (0, 0))
             pygame.display.flip()
 
-        if self.render_mode == "rgb_array":
+        if mode == "rgb_array":
             return self._create_image_array(self.surf, (VIDEO_W, VIDEO_H))
-        elif self.render_mode == "state_pixels":
+        elif mode == "state_pixels":
             return self._create_image_array(self.surf, (STATE_W, STATE_H))
         else:
             return self.isopen

--- a/gym/envs/box2d/car_racing.py
+++ b/gym/envs/box2d/car_racing.py
@@ -566,8 +566,10 @@ class CarRacing(gym.Env, EzPickle):
 
     def render(self):
         if self.render_mode is None:
-            gym.logger.WARN(
-                "You are calling render method without specifying any render mode."
+            gym.logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
         else:
             return self._render(self.render_mode)

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -600,6 +600,12 @@ class LunarLander(gym.Env, EzPickle):
         return np.array(state, dtype=np.float32), reward, terminated, False, {}
 
     def render(self):
+        if self.render_mode is None:
+            gym.logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+            return
+
         try:
             import pygame
             from pygame import gfxdraw

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -601,8 +601,10 @@ class LunarLander(gym.Env, EzPickle):
 
     def render(self):
         if self.render_mode is None:
-            gym.logger.WARN(
-                "You are calling render method without specifying any render mode."
+            gym.logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
             return
 

--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -602,8 +602,8 @@ class LunarLander(gym.Env, EzPickle):
     def render(self):
         if self.render_mode is None:
             gym.logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
                 f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
             return

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -279,8 +279,8 @@ class AcrobotEnv(core.Env):
     def render(self):
         if self.render_mode is None:
             logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
                 f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
             return

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -278,8 +278,10 @@ class AcrobotEnv(core.Env):
 
     def render(self):
         if self.render_mode is None:
-            logger.WARN(
-                "You are calling render method without specifying any render mode."
+            logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
             return
 

--- a/gym/envs/classic_control/acrobot.py
+++ b/gym/envs/classic_control/acrobot.py
@@ -4,7 +4,7 @@ from typing import Optional
 import numpy as np
 from numpy import cos, pi, sin
 
-from gym import core, spaces
+from gym import core, logger, spaces
 from gym.error import DependencyNotInstalled
 
 __copyright__ = "Copyright 2013, RLPy http://acl.mit.edu/RLPy"
@@ -277,6 +277,12 @@ class AcrobotEnv(core.Env):
         return dtheta1, dtheta2, ddtheta1, ddtheta2, 0.0
 
     def render(self):
+        if self.render_mode is None:
+            logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+            return
+
         try:
             import pygame
             from pygame import gfxdraw

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -207,6 +207,12 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         return np.array(self.state, dtype=np.float32), {}
 
     def render(self):
+        if self.render_mode is None:
+            gym.logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+            return
+
         try:
             import pygame
             from pygame import gfxdraw

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -208,9 +208,10 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
 
     def render(self):
         if self.render_mode is None:
-            gym.logger.WARN(
-                "You are calling render method without specifying any render mode."
-            )
+            gym.logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'            )
             return
 
         try:

--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -209,9 +209,10 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
     def render(self):
         if self.render_mode is None:
             gym.logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
-                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'            )
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
+            )
             return
 
         try:

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -189,6 +189,12 @@ class Continuous_MountainCarEnv(gym.Env):
         return np.sin(3 * xs) * 0.45 + 0.55
 
     def render(self):
+        if self.render_mode is None:
+            gym.logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+            return
+
         try:
             import pygame
             from pygame import gfxdraw

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -190,9 +190,10 @@ class Continuous_MountainCarEnv(gym.Env):
 
     def render(self):
         if self.render_mode is None:
-            gym.logger.WARN(
-                "You are calling render method without specifying any render mode."
-            )
+            gym.logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'            )
             return
 
         try:

--- a/gym/envs/classic_control/continuous_mountain_car.py
+++ b/gym/envs/classic_control/continuous_mountain_car.py
@@ -191,9 +191,10 @@ class Continuous_MountainCarEnv(gym.Env):
     def render(self):
         if self.render_mode is None:
             gym.logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
-                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'            )
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
+            )
             return
 
         try:

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -169,9 +169,10 @@ class MountainCarEnv(gym.Env):
     def render(self):
         if self.render_mode is None:
             gym.logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
-                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'            )
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
+            )
             return
 
         try:

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -168,9 +168,10 @@ class MountainCarEnv(gym.Env):
 
     def render(self):
         if self.render_mode is None:
-            gym.logger.WARN(
-                "You are calling render method without specifying any render mode."
-            )
+            gym.logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'            )
             return
 
         try:

--- a/gym/envs/classic_control/mountain_car.py
+++ b/gym/envs/classic_control/mountain_car.py
@@ -167,6 +167,12 @@ class MountainCarEnv(gym.Env):
         return np.sin(3 * xs) * 0.45 + 0.55
 
     def render(self):
+        if self.render_mode is None:
+            gym.logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+            return
+
         try:
             import pygame
             from pygame import gfxdraw

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -165,9 +165,10 @@ class PendulumEnv(gym.Env):
     def render(self):
         if self.render_mode is None:
             gym.logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
-                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'            )
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
+            )
             return
 
         try:

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -164,9 +164,10 @@ class PendulumEnv(gym.Env):
 
     def render(self):
         if self.render_mode is None:
-            gym.logger.WARN(
-                "You are calling render method without specifying any render mode."
-            )
+            gym.logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'            )
             return
 
         try:

--- a/gym/envs/classic_control/pendulum.py
+++ b/gym/envs/classic_control/pendulum.py
@@ -163,6 +163,12 @@ class PendulumEnv(gym.Env):
         return np.array([np.cos(theta), np.sin(theta), thetadot], dtype=np.float32)
 
     def render(self):
+        if self.render_mode is None:
+            gym.logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+            return
+
         try:
             import pygame
             from pygame import gfxdraw

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -228,6 +228,12 @@ class MuJocoPyEnv(BaseMujocoEnv):
             self.sim.step()
 
     def render(self):
+        if self.render_mode is None:
+            gym.logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+            return
+
         width, height = self.width, self.height
         camera_name, camera_id = self.camera_name, self.camera_id
         if self.render_mode in {"rgb_array", "depth_array"}:
@@ -348,6 +354,12 @@ class MujocoEnv(BaseMujocoEnv):
         mujoco.mj_rnePostConstraint(self.model, self.data)
 
     def render(self):
+        if self.render_mode is None:
+            gym.logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+            return
+
         if self.render_mode in {
             "rgb_array",
             "depth_array",

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -229,9 +229,10 @@ class MuJocoPyEnv(BaseMujocoEnv):
 
     def render(self):
         if self.render_mode is None:
-            gym.logger.WARN(
-                "You are calling render method without specifying any render mode."
-            )
+            gym.logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'            )
             return
 
         width, height = self.width, self.height
@@ -355,8 +356,10 @@ class MujocoEnv(BaseMujocoEnv):
 
     def render(self):
         if self.render_mode is None:
-            gym.logger.WARN(
-                "You are calling render method without specifying any render mode."
+            gym.logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
             return
 

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -230,9 +230,10 @@ class MuJocoPyEnv(BaseMujocoEnv):
     def render(self):
         if self.render_mode is None:
             gym.logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
-                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'            )
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
+            )
             return
 
         width, height = self.width, self.height
@@ -357,8 +358,8 @@ class MujocoEnv(BaseMujocoEnv):
     def render(self):
         if self.render_mode is None:
             gym.logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
                 f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
             return

--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -192,8 +192,8 @@ class BlackjackEnv(gym.Env):
     def render(self):
         if self.render_mode is None:
             gym.logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
                 f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
             return

--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -191,8 +191,10 @@ class BlackjackEnv(gym.Env):
 
     def render(self):
         if self.render_mode is None:
-            gym.logger.WARN(
-                "You are calling render method without specifying any render mode."
+            gym.logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
             return
 

--- a/gym/envs/toy_text/blackjack.py
+++ b/gym/envs/toy_text/blackjack.py
@@ -190,6 +190,12 @@ class BlackjackEnv(gym.Env):
         return self._get_obs(), {}
 
     def render(self):
+        if self.render_mode is None:
+            gym.logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+            return
+
         try:
             import pygame
         except ImportError:

--- a/gym/envs/toy_text/cliffwalking.py
+++ b/gym/envs/toy_text/cliffwalking.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import numpy as np
 
-from gym import Env, spaces
+from gym import Env, logger, spaces
 from gym.envs.toy_text.utils import categorical_sample
 from gym.error import DependencyNotInstalled
 
@@ -163,7 +163,11 @@ class CliffWalkingEnv(Env):
         return int(self.s), {"prob": 1}
 
     def render(self):
-        if self.render_mode == "ansi":
+        if self.render_mode is None:
+            logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+        elif self.render_mode == "ansi":
             return self._render_text()
         else:
             return self._render_gui(self.render_mode)

--- a/gym/envs/toy_text/cliffwalking.py
+++ b/gym/envs/toy_text/cliffwalking.py
@@ -164,8 +164,10 @@ class CliffWalkingEnv(Env):
 
     def render(self):
         if self.render_mode is None:
-            logger.WARN(
-                "You are calling render method without specifying any render mode."
+            logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
         elif self.render_mode == "ansi":
             return self._render_text()

--- a/gym/envs/toy_text/cliffwalking.py
+++ b/gym/envs/toy_text/cliffwalking.py
@@ -165,8 +165,8 @@ class CliffWalkingEnv(Env):
     def render(self):
         if self.render_mode is None:
             logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
                 f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
         elif self.render_mode == "ansi":

--- a/gym/envs/toy_text/frozen_lake.py
+++ b/gym/envs/toy_text/frozen_lake.py
@@ -268,8 +268,10 @@ class FrozenLakeEnv(Env):
 
     def render(self):
         if self.render_mode is None:
-            logger.WARN(
-                "You are calling render method without specifying any render mode."
+            logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
         elif self.render_mode == "ansi":
             return self._render_text()

--- a/gym/envs/toy_text/frozen_lake.py
+++ b/gym/envs/toy_text/frozen_lake.py
@@ -269,8 +269,8 @@ class FrozenLakeEnv(Env):
     def render(self):
         if self.render_mode is None:
             logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
                 f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
         elif self.render_mode == "ansi":

--- a/gym/envs/toy_text/frozen_lake.py
+++ b/gym/envs/toy_text/frozen_lake.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 import numpy as np
 
-from gym import Env, spaces, utils
+from gym import Env, logger, spaces, utils
 from gym.envs.toy_text.utils import categorical_sample
 from gym.error import DependencyNotInstalled
 
@@ -267,7 +267,11 @@ class FrozenLakeEnv(Env):
         return int(self.s), {"prob": 1}
 
     def render(self):
-        if self.render_mode == "ansi":
+        if self.render_mode is None:
+            logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
+        elif self.render_mode == "ansi":
             return self._render_text()
         else:  # self.render_mode in {"human", "rgb_array"}:
             return self._render_gui(self.render_mode)

--- a/gym/envs/toy_text/taxi.py
+++ b/gym/envs/toy_text/taxi.py
@@ -280,8 +280,8 @@ class TaxiEnv(Env):
     def render(self):
         if self.render_mode is None:
             logger.warn(
-                'You are calling render method without specifying any render mode. '
-                'You can specify the render_mode at initialization, '
+                "You are calling render method without specifying any render mode. "
+                "You can specify the render_mode at initialization, "
                 f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
         if self.render_mode == "ansi":

--- a/gym/envs/toy_text/taxi.py
+++ b/gym/envs/toy_text/taxi.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import numpy as np
 
-from gym import Env, spaces, utils
+from gym import Env, logger, spaces, utils
 from gym.envs.toy_text.utils import categorical_sample
 from gym.error import DependencyNotInstalled
 
@@ -278,6 +278,10 @@ class TaxiEnv(Env):
         return int(self.s), {"prob": 1.0, "action_mask": self.action_mask(self.s)}
 
     def render(self):
+        if self.render_mode is None:
+            logger.WARN(
+                "You are calling render method without specifying any render mode."
+            )
         if self.render_mode == "ansi":
             return self._render_text()
         else:  # self.render_mode in {"human", "rgb_array"}:

--- a/gym/envs/toy_text/taxi.py
+++ b/gym/envs/toy_text/taxi.py
@@ -279,8 +279,10 @@ class TaxiEnv(Env):
 
     def render(self):
         if self.render_mode is None:
-            logger.WARN(
-                "You are calling render method without specifying any render mode."
+            logger.warn(
+                'You are calling render method without specifying any render mode. '
+                'You can specify the render_mode at initialization, '
+                f'e.g. gym("{self.spec.id}", render_mode="rgb_array")'
             )
         if self.render_mode == "ansi":
             return self._render_text()


### PR DESCRIPTION
Add a warning when `render` is called without specifying `render_mode`, see https://github.com/openai/gym/issues/3108