### PR TITLE
Fix `render_modes` Assertion to be compatible with new mujoco

### DIFF
--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -58,11 +58,16 @@ class BaseMujocoEnv(gym.Env):
 
         self.viewer = None
 
-        assert all([mode in self.metadata["render_modes"] for mode in [
-            "human",
-            "rgb_array",
-            "depth_array",
-        ]]), self.metadata["render_modes"]
+        assert all(
+            [
+                mode in self.metadata["render_modes"]
+                for mode in [
+                    "human",
+                    "rgb_array",
+                    "depth_array",
+                ]
+            ]
+        ), self.metadata["render_modes"]
         assert (
             int(np.round(1.0 / self.dt)) == self.metadata["render_fps"]
         ), f'Expected value: {int(np.round(1.0 / self.dt))}, Actual value: {self.metadata["render_fps"]}'

--- a/gym/envs/mujoco/mujoco_env.py
+++ b/gym/envs/mujoco/mujoco_env.py
@@ -58,11 +58,11 @@ class BaseMujocoEnv(gym.Env):
 
         self.viewer = None
 
-        assert self.metadata["render_modes"] == [
+        assert all([mode in self.metadata["render_modes"] for mode in [
             "human",
             "rgb_array",
             "depth_array",
-        ], self.metadata["render_modes"]
+        ]]), self.metadata["render_modes"]
         assert (
             int(np.round(1.0 / self.dt)) == self.metadata["render_fps"]
         ), f'Expected value: {int(np.round(1.0 / self.dt))}, Actual value: {self.metadata["render_fps"]}'


### PR DESCRIPTION
# Description

new version of Mujoco supports more render modes: ['human', 'rgb_array', 'depth_array', 'single_rgb_array', 'single_depth_array'] we want to test if the modes are in this list, instead of comparing the two modes directly


Fixes #3113 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
