### PR TITLE
adding specific syntax for 'pip install' in README to work more gener…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Gym also has a discord server for development purposes that you can join here: h
 
 To install the base Gym library, use `pip install gym`.
 
-This does not include dependencies for all families of environments (there's a massive number, and some can be problematic to install on certain systems). You can install these dependencies for one family like `pip install gym[atari]` or use `pip install gym[all]` to install all dependencies.
+This does not include dependencies for all families of environments (there's a massive number, and some can be problematic to install on certain systems). You can install these dependencies for one family like `pip install 'gym[atari]'` or use `pip install 'gym[all]'` to install all dependencies.
 
 We support Python 3.7, 3.8, 3.9 and 3.10 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
 
@@ -54,7 +54,7 @@ Gym keeps strict versioning for reproducibility reasons. All environments end in
 ## MuJoCo Environments
 
 The latest "\_v4" and future versions of the MuJoCo environments will no longer depend on `mujoco-py`. Instead `mujoco` will be the required dependency for future gym MuJoCo environment versions. Old gym MuJoCo environment versions that depend on `mujoco-py` will still be kept but unmaintained.
-To install the dependencies for the latest gym MuJoCo environments use `pip install gym[mujoco]`. Dependencies for old MuJoCo environments can still be installed by `pip install gym[mujoco_py]`. 
+To install the dependencies for the latest gym MuJoCo environments use `pip install 'gym[mujoco]'`. Dependencies for old MuJoCo environments can still be installed by `pip install 'gym[mujoco_py]'`. 
 
 ## Citation
 


### PR DESCRIPTION
# Description

Documentation improvement: adding general syntax for `pip install` such that it works across various python environments.

- [x] This change requires a documentation update

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

