### PR TITLE
Fixed forward discounted return estimation.

### DIFF
--- a/gym/wrappers/normalize.py
+++ b/gym/wrappers/normalize.py
@@ -130,10 +130,9 @@ class NormalizeReward(gym.core.Wrapper):
         obs, rews, terminateds, truncateds, infos = self.env.step(action)
         if not self.is_vector_env:
             rews = np.array([rews])
-        self.returns = self.returns * self.gamma + rews
-        rews = self.normalize(rews)
-        dones = np.logical_or(terminateds, truncateds)
-        self.returns[dones] = 0.0
+        dones = np.logical_or(terminateds, truncateds)            
+        self.returns = self.returns * self.gamma * (1-dones) + rews
+        rews = self.normalize(rews)                
         if not self.is_vector_env:
             rews = rews[0]
         return obs, rews, terminateds, truncateds, infos

--- a/gym/wrappers/normalize.py
+++ b/gym/wrappers/normalize.py
@@ -129,12 +129,12 @@ class NormalizeReward(gym.core.Wrapper):
         """Steps through the environment, normalizing the rewards returned."""
         obs, rews, terminateds, truncateds, infos = self.env.step(action)
         if not self.is_vector_env:
-            rews = np.array([rews])
-        dones = np.logical_or(terminateds, truncateds)            
-        self.returns = self.returns * self.gamma * (1-dones) + rews
+            rews = np.array([rews])        
+        self.returns = self.returns * self.gamma * (1-terminateds) + rews
         rews = self.normalize(rews)                
         if not self.is_vector_env:
             rews = rews[0]
+        dones = np.logical_or(terminateds, truncateds)            
         return obs, rews, terminateds, truncateds, infos
 
     def normalize(self, rews):


### PR DESCRIPTION
# Description

Forward discounted return estimation was incorrectly estimated in the normalised rewards wrapper. Having the variance of returns deviate significantly from 1.0 can cause performance problems when using reward normalization.

Fixes # (issue)

## Type of change

- [*] Bug fix (non-breaking change which fixes an issue)

### Screenshots

I will include a notebook as a reference.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

