### PR TITLE
specified render_mode for standalone running

### DIFF
--- a/gym/envs/box2d/lunar_lander.py
+++ b/gym/envs/box2d/lunar_lander.py
@@ -814,4 +814,4 @@ class LunarLanderContinuous:
 
 
 if __name__ == "__main__":
-    demo_heuristic_lander(LunarLander(), render=True)
+    demo_heuristic_lander(LunarLander(render_mode='human'), render=True)


### PR DESCRIPTION
# Description
unspecified render_mode was causing an error when running to see a demo of heuristic landing.

Fixes # (issue)
-UNKNOWN-

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
|  
! [Screenshot 2023-02-14 at 22 26 44](https://user-images.githubusercontent.com/26012911/218945382-e830fe13-d36d-4b89-b963-c1cd474a52ce.png) | ![Screenshot 2023-02-14 at 23 58 35](https://user-images.githubusercontent.com/26012911/218945436-b1f386a6-10d1-49d1-b75e-0ccc8b479d3d.png)
|

-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Notes
This is a minor bug fix. I could not run pre-commit because it required access to a gitlab repo. Unit tests give warnings, but none generated by my change.