### PR TITLE
modified:   setup.py in v0.21.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras = {
     "mujoco": ["mujoco_py>=1.50, <2.0"],
     "robotics": ["mujoco_py>=1.50, <2.0"],
     "toy_text": ["scipy>=1.4.1"],
-    "other": ["lz4>=3.1.0", "opencv-python>=3."],
+    "other": ["lz4>=3.1.0", "opencv-python>=3.0"],
 }
 
 # Meta dependency groups.


### PR DESCRIPTION
# Description

Changed line 20 in setup.py from "opencv-python>=3." to "opencv-python>=3.0". 
This issue caused an error when installing the **gym v0.21.0** on Linux/WSL through `pip install -e .`
Note: this bug is not shown when install on macOS and Windows. 

## Type of change

- [x] Bug fix 

### Screenshots

| Before | After |
| ------ | ----- |
| ![](https://github.com/openai/gym/assets/35953120/4760dc5f-b2ce-4bdf-bb97-0e92f380def9) | ![](https://github-production-user-asset-6210df.s3.amazonaws.com/35953120/257565397-9170a787-b35b-4ec5-9d25-dca2a9c9239d.png)  |
