### PR TITLE
Updating deprecated alias 'np.bool8' -> 'np.bool_'

### DIFF
--- a/gym/utils/passive_env_checker.py
+++ b/gym/utils/passive_env_checker.py
@@ -222,19 +222,19 @@ def env_step_passive_checker(env, action):
         )
         obs, reward, done, info = result
 
-        if not isinstance(done, (bool, np.bool8)):
+        if not isinstance(done, (bool, np.bool_)):
             logger.warn(
                 f"Expects `done` signal to be a boolean, actual type: {type(done)}"
             )
     elif len(result) == 5:
         obs, reward, terminated, truncated, info = result
 
-        # np.bool is actual python bool not np boolean type, therefore bool_ or bool8
-        if not isinstance(terminated, (bool, np.bool8)):
+        # np.bool is actual python bool not np boolean type, therefore bool_ or bool8 (deprecated alias)
+        if not isinstance(terminated, (bool, np.bool_)):
             logger.warn(
                 f"Expects `terminated` signal to be a boolean, actual type: {type(terminated)}"
             )
-        if not isinstance(truncated, (bool, np.bool8)):
+        if not isinstance(truncated, (bool, np.bool_)):
             logger.warn(
                 f"Expects `truncated` signal to be a boolean, actual type: {type(truncated)}"
             )


### PR DESCRIPTION
# Description

Part of code is outdated. I updated one small issue with old alias in numpy. Basically I changed "np.bool8" -> "np.bool_" in 3 places, because otherwise there is a warning when using gym repository. Warning information:

C:\Users\Administrator\AppData\Local\Programs\Python\Python311\Lib\site-packages\gym\utils\passive_env_checker.py:233: DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)

### Screenshots
My code:

![Zrzut ekranu 2024-02-23 050824](https://github.com/openai/gym/assets/66909222/ba7c6dae-40f8-40c1-9a6e-8876095a3547)

Warning:

![Zrzut ekranu 2024-02-23 050704](https://github.com/openai/gym/assets/66909222/fe127797-484d-4080-a216-5d3394b429ac)

### After changes
I took the following steps to check the results of the change:

1. Uninstalled gym
`pip uninstall gym`

2. Installed gym from my forked repo with new branch
`pip install git+https://github.com/sebastianbrzustowicz/gym.git@np.bool_`

There is no longer any redundant warning.

Hope I helped a little bit.