### PR TITLE
Fix for the collision problem in the pusher environment

### DIFF
--- a/gym/envs/mujoco/assets/pusher.xml
+++ b/gym/envs/mujoco/assets/pusher.xml
@@ -1,12 +1,12 @@
 <mujoco model="arm3d">
   <compiler inertiafromgeom="true" angle="radian" coordinate="local"/>
   <option timestep="0.01" gravity="0 0 0" iterations="20" integrator="Euler" />
-  
+
   <default>
     <joint armature='0.04' damping="1" limited="true"/>
     <geom friction=".8 .1 .1" density="300" margin="0.002" condim="1" contype="0" conaffinity="0"/>
   </default>
-  
+
   <worldbody>
     <light diffuse=".5 .5 .5" pos="0 0 3" dir="0 0 -1"/>
     <geom name="table" type="plane" pos="0 0.5 -0.325" size="1 1 0.1" contype="1" conaffinity="1"/>
@@ -64,8 +64,8 @@
       </body>
     </body>
 
-    <!--<body name="object" pos="0.55 -0.3 -0.275" >-->
-    <body name="object" pos="0.45 -0.05 -0.275" >
+    <!--<body name="object" pos="0.55 -0.3 -0.275">-->
+    <body name="object" pos="0.45 -0.05 -0.275">
       <geom rgba="1 1 1 0" type="sphere" size="0.05 0.05 0.05" density="0.00001" conaffinity="0"/>
       <geom rgba="1 1 1 1" type="cylinder" size="0.05 0.05 0.05" density="0.00001" contype="1" conaffinity="0"/>
       <joint name="obj_slidey" type="slide" pos="0 0 0" axis="0 1 0" range="-10.3213 10.3" damping="0.5"/>
@@ -73,9 +73,9 @@
     </body>
 
     <body name="goal" pos="0.45 -0.05 -0.3230">
-      <geom rgba="1 0 0 1" type="cylinder" size="0.08 0.001 0.1" density='0.00001' contype="0" conaffinity="0"/>
+      <geom rgba="1 0 0 1" type="cylinder" size="1 0.001 0.1" density='0.00001' contype="0" conaffinity="0"/>
       <joint name="goal_slidey" type="slide" pos="0 0 0" axis="0 1 0" range="-10.3213 10.3" damping="0.5"/>
-      <joint name="goal_slidex" type="slide" pos="0 0 0" axis="1 0 0" range="-10.3213 10.3" damping="0.5"/> 
+      <joint name="goal_slidex" type="slide" pos="0 0 0" axis="1 0 0" range="-10.3213 10.3" damping="0.5"/>
     </body>
   </worldbody>
 


### PR DESCRIPTION
# Description
The issue involves inaccurate collision calculations in a robotic manipulation experiment due to an error in the file pusher.xml. This error prevents the robot gripper from successfully grasping the cup. To rectify this issue, line 69 within the pusher.xml file needs modification.

Fixes # (issue)
Change:
<geom rgba="1 1 1 0" type="sphere" size=“0.05 0.05 0.05" density="0.00001" conaffinity="0"/>
To:
<geom rgba="1 1 1 0" type="sphere" size="1 0.05 0.05" density="0.00001" conaffinity="0"/>

## Type of change
- [x ] Bug fix (non-breaking change which fixes an issue)

### Video 
Before: https://github.com/openai/gym/assets/83762186/6f6f6e4e-e524-459a-8022-7574eea85abf
After: https://github.com/openai/gym/assets/83762186/2be15619-3787-4b34-b6ef-9df9876ff8ce
