### PR TITLE
Update passive_env_checker.py with np.bool_ instead of np.bool8

### DIFF
--- a/gym/utils/passive_env_checker.py
+++ b/gym/utils/passive_env_checker.py
@@ -222,7 +222,7 @@ def env_step_passive_checker(env, action):
         )
         obs, reward, done, info = result
 
-        if not isinstance(done, (bool, np.bool8)):
+        if not isinstance(done, (bool, np.bool_)):
             logger.warn(
                 f"Expects `done` signal to be a boolean, actual type: {type(done)}"
             )
@@ -230,11 +230,11 @@ def env_step_passive_checker(env, action):
         obs, reward, terminated, truncated, info = result
 
         # np.bool is actual python bool not np boolean type, therefore bool_ or bool8
-        if not isinstance(terminated, (bool, np.bool8)):
+        if not isinstance(terminated, (bool, np.bool_)):
             logger.warn(
                 f"Expects `terminated` signal to be a boolean, actual type: {type(terminated)}"
             )
-        if not isinstance(truncated, (bool, np.bool8)):
+        if not isinstance(truncated, (bool, np.bool_)):
             logger.warn(
                 f"Expects `truncated` signal to be a boolean, actual type: {type(truncated)}"
             )


### PR DESCRIPTION
passive_env_checker.py:233: DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24)

# Description

passive_env_checker.py:233: DeprecationWarning: `np.bool8` is a deprecated alias for `np.bool_`.  (Deprecated NumPy 1.24). I replaced all occurences of np.bool8 with np.bool_ inside passive_env_checker.py.


Fixes # (Deprecated Package)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
