### PR TITLE
Correct spelling core.py L90

### DIFF
--- a/gym/core.py
+++ b/gym/core.py
@@ -87,7 +87,7 @@ class Env(Generic[ObsType, ActType]):
         """Run one timestep of the environment's dynamics.
 
         When end of episode is reached, you are responsible for calling :meth:`reset` to reset this environment's state.
-        Accepts an action and returns either a tuple `(observation, reward, terminated, truncated, info)`.
+        Accepts an action and returns a tuple `(observation, reward, terminated, truncated, info)`.
 
         Args:
             action (ActType): an action provided by the agent


### PR DESCRIPTION
Removed "either" -- typo or grammatical error

# Description

There is a typo in line 90 stating -- "either a tuple" instead of tuple.

Fixes #3301

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Please attach before and after screenshots of the change if applicable.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
