### PR TITLE
Update passive_env_checker.py to fix "bool8 error"

### DIFF
--- a/gym/utils/passive_env_checker.py
+++ b/gym/utils/passive_env_checker.py
@@ -222,19 +222,19 @@ def env_step_passive_checker(env, action):
         )
         obs, reward, done, info = result
 
-        if not isinstance(done, (bool, np.bool8)):
+        if not isinstance(done, (bool, np.bool)):
             logger.warn(
                 f"Expects `done` signal to be a boolean, actual type: {type(done)}"
             )
     elif len(result) == 5:
         obs, reward, terminated, truncated, info = result
 
-        # np.bool is actual python bool not np boolean type, therefore bool_ or bool8
-        if not isinstance(terminated, (bool, np.bool8)):
+        # np.bool is actual python bool not np boolean type, therefore bool_ or bool
+        if not isinstance(terminated, (bool, np.bool)):
             logger.warn(
                 f"Expects `terminated` signal to be a boolean, actual type: {type(terminated)}"
             )
-        if not isinstance(truncated, (bool, np.bool8)):
+        if not isinstance(truncated, (bool, np.bool)):
             logger.warn(
                 f"Expects `truncated` signal to be a boolean, actual type: {type(truncated)}"
             )


### PR DESCRIPTION
fix the bool8 error
bool8 -> bool

**I have tested the change and made sure it runs well**

# Description
Running the demo code in [DemoCode](https://www.gymlibrary.dev/content/basic_usage/) export an error

**Code example**
```python
import gym
env = gym.make("LunarLander-v2", render_mode="human")
env.action_space.seed(42)

observation, info = env.reset(seed=42)

for _ in range(1000):
    observation, reward, terminated, truncated, info = env.step(env.action_space.sample())

    if terminated or truncated:
        observation, info = env.reset()

env.close()
```

**System Info**

>  File "E:\learn\.venv\Lib\site-packages\gym\utils\passive_env_checker.py", line 233, in env_step_passive_checker
    if not isinstance(terminated, (bool, np.bool8)):
                                         ^^^^^^^^
  File "E:\learn\.venv\Lib\site-packages\numpy\__init__.py", line 427, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'bool8'. Did you mean: 'bool'?
libpng warning: iCCP: cHRM chunk does not match sRGB

**Additional context**
I edited the source code to ensure that the code can be run.Maybe there is a version problem here.

### Checklist

- [x] I have checked that there is no similar [issue](https://github.com/openai/gym/issues) in the repo (**required**)
_In fact, there is a similar PR, but it seems to have expired_

Fixes #3258 #3294 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots
Please attach before and after screenshots of the change if applicable.

| Before ❌| After ✔|
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/37355e99-a7f1-4d4d-9df2-eacafaadb51b) | ![image](https://github.com/user-attachments/assets/552600e3-93c2-43eb-8b0c-73be4628da0b) |

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [] I have not done this task
-->
