### PR TITLE
Add default parameters for self.masscart and self.masspole to the constructor in CartPoleEnv

### DIFF
--- a/gym/envs/classic_control/cartpole.py
+++ b/gym/envs/classic_control/cartpole.py
@@ -86,10 +86,10 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         "render_fps": 50,
     }
 
-    def __init__(self, render_mode: Optional[str] = None):
+    def __init__(self, render_mode: Optional[str] = None, masscart = 1.0, masspole = 0.1):
         self.gravity = 9.8
-        self.masscart = 1.0
-        self.masspole = 0.1
+        self.masscart = masscart
+        self.masspole = masspole
         self.total_mass = self.masspole + self.masscart
         self.length = 0.5  # actually half the pole's length
         self.polemass_length = self.masspole * self.length


### PR DESCRIPTION
Add default parameters for self.masscart and self.masspole to the constructor in CartPoleEnv. The parameters are for the mass of the cart and mass in the pole, so people can change them if they want. 

## Type of change


- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

### Screenshots
![image](https://github.com/user-attachments/assets/165d464c-535b-4a0e-8ed8-7d09fd130771)
![image](https://github.com/user-attachments/assets/3df46c08-99d7-418d-80b6-b94bb442de35)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
